### PR TITLE
[DataGrid] Avoid logger noise

### DIFF
--- a/packages/grid/x-grid-modules/src/hooks/features/useApiRef.ts
+++ b/packages/grid/x-grid-modules/src/hooks/features/useApiRef.ts
@@ -10,7 +10,7 @@ const EventEmitter = require('events').EventEmitter;
  */
 export const useApiRef = (): ApiRef => {
   const logger = useLogger('useApiRef');
-  logger.debug('Initialising grid api with EventEmitter.');
+  logger.debug('Initializing grid api with EventEmitter.');
 
   return React.useRef<GridApi>(new EventEmitter());
 };

--- a/packages/grid/x-grid-modules/src/hooks/root/useApi.ts
+++ b/packages/grid/x-grid-modules/src/hooks/root/useApi.ts
@@ -40,7 +40,7 @@ export function useApi(
   );
 
   React.useEffect(() => {
-    logger.debug('Initialising grid api.');
+    logger.debug('Initializing grid api.');
     apiRef.current.isInitialised = true;
     apiRef.current.rootElementRef = gridRootRef;
 

--- a/packages/grid/x-grid-modules/src/hooks/root/useEvents.ts
+++ b/packages/grid/x-grid-modules/src/hooks/root/useEvents.ts
@@ -213,7 +213,7 @@ export function useEvents(
       const api = apiRef.current;
 
       return () => {
-        logger.warn('Clearing all events listeners');
+        logger.debug('Clearing all events listeners');
         api.publishEvent(UNMOUNT);
         gridRootElem.removeEventListener(CLICK, onClickHandler, { capture: true });
         gridRootElem.removeEventListener(MOUSE_HOVER, onHoverHandler, { capture: true });


### PR DESCRIPTION
Same as #146

This time, spot in the CI

<img width="540" alt="Capture d’écran 2020-08-05 à 00 29 25" src="https://user-images.githubusercontent.com/3165635/89351664-c1abb580-d6b2-11ea-959c-70cb7f89a7b1.png">
