### PR TITLE
[DataGrid] Fix set state leak

### DIFF
--- a/packages/grid/x-grid-modules/src/hooks/utils/useRafUpdate.ts
+++ b/packages/grid/x-grid-modules/src/hooks/utils/useRafUpdate.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { useLogger } from './useLogger';
 
 type UseRafUpdateReturnType = [(...args: any[]) => void, (fn: (args: any) => void) => void];
+
 export function useRafUpdate(initialFn?: (...args: any) => void): UseRafUpdateReturnType {
   const logger = useLogger('useRafUpdate');
   const rafRef = React.useRef(0);
@@ -13,7 +14,7 @@ export function useRafUpdate(initialFn?: (...args: any) => void): UseRafUpdateRe
 
   const runUpdate = React.useCallback(
     (...args: any[]) => {
-      if (!fn) {
+      if (!fn.current) {
         return;
       }
       if (rafRef.current > 0) {
@@ -28,6 +29,12 @@ export function useRafUpdate(initialFn?: (...args: any) => void): UseRafUpdateRe
     },
     [logger],
   );
+
+  React.useEffect(() => {
+    return () => {
+      cancelAnimationFrame(rafRef.current);
+    };
+  }, []);
 
   return [runUpdate, setUpdate];
 }


### PR DESCRIPTION
> Warning: Can't perform a React state update on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in %s.%s', 'a useEffect cleanup function'

Fix #150