### PR TITLE
[DataGrid] Use same React version as core

### DIFF
--- a/packages/grid/data-grid/README.md
+++ b/packages/grid/data-grid/README.md
@@ -21,7 +21,7 @@ This component has 3 peer dependencies that you will need to install as well.
 ```json
 "peerDependencies": {
   "@material-ui/core": "^4.9.12",
-  "react": "^16.13.1",
+  "react": "^16.8.0",
   "styled-components": "^5.1.0"
 },
 ```

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -29,7 +29,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.9.12",
-    "react": "^16.13.1",
+    "react": "^16.8.0",
     "styled-components": "^5.1.0"
   },
   "scripts": {

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -41,7 +41,7 @@
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
     "@material-ui/x-grid": "^0.1.35",
-    "react": "^16.13.1",
+    "react": "^16.8.0",
     "styled-components": "^5.1.0"
   },
   "scripts": {

--- a/packages/grid/x-grid-modules/package.json
+++ b/packages/grid/x-grid-modules/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.9.12",
-    "react": "^16.13.1",
+    "react": "^16.8.0",
     "styled-components": "^5.1.0"
   },
   "scripts": {

--- a/packages/grid/x-grid/README.md
+++ b/packages/grid/x-grid/README.md
@@ -21,7 +21,7 @@ This component has 3 peer dependencies that you will need to install as well.
 ```json
 "peerDependencies": {
   "@material-ui/core": "^4.9.12",
-  "react": "^16.13.1",
+  "react": "^16.8.0",
   "styled-components": "^5.1.0"
 },
 ```

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -31,7 +31,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.9.12",
-    "react": "^16.13.1",
+    "react": "^16.8.0",
     "styled-components": "^5.1.0"
   },
   "scripts": {

--- a/packages/storybook/src/documentation/pages/quick-start.stories.mdx
+++ b/packages/storybook/src/documentation/pages/quick-start.stories.mdx
@@ -29,7 +29,7 @@ To summarise, X-Grid has the following peer dependencies.
 ```json
 "peerDependencies": {
   "@material-ui/core": "^4.9.12",
-  "react": "^16.13.1",
+  "react": "^16.8.0",
   "styled-components": "^5.1.0"
 }
 ```


### PR DESCRIPTION
While it won't make any significant difference, it signals that we aim for maximum compatibility between MIT and X.

Closes #21