### PR TITLE
[DataGrid] Fix SSR support

### DIFF
--- a/packages/grid/x-grid-modules/src/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/x-grid-modules/src/hooks/virtualization/useVirtualRows.ts
@@ -27,6 +27,11 @@ import { useApiEventHandler } from '../root/useApiEventHandler';
 
 type UseVirtualRowsReturnType = Partial<RenderContextProps> | null;
 
+const useEnhancedEffect =
+  typeof window !== 'undefined' && process.env.NODE_ENV !== 'test'
+    ? React.useLayoutEffect
+    : React.useEffect;
+
 export const useVirtualRows = (
   colRef: React.MutableRefObject<HTMLDivElement | null>,
   windowRef: React.MutableRefObject<HTMLDivElement | null>,
@@ -152,7 +157,7 @@ export const useVirtualRows = (
     }
   }, [apiRef, logger, reRender, windowRef, updateRenderedCols, scrollTo]);
 
-  React.useLayoutEffect(() => {
+  useEnhancedEffect(() => {
     if (renderingZoneRef && renderingZoneRef.current) {
       logger.debug('applying scrollTop ', rzScrollRef.current);
       scrollTo(rzScrollRef.current);


### PR DESCRIPTION
#187 unlocks an interesting new constraint: we now server-side render the grid. This surface this problem:

<img width="1333" alt="Capture d’écran 2020-08-17 à 01 25 56" src="https://user-images.githubusercontent.com/3165635/90346395-dbd98200-e028-11ea-87a7-4a0b63e7d6e6.png">

I have used the same approach as in the core and created a note to abstract this module so we can do:

```jsx
import { useEnhancedEffect } from '@material-ui/core/utils';
```