### PR TITLE
[docs] Move the pagination page

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -24,6 +24,7 @@ if (process.env.BABEL_ENV === 'es') {
 
 const defaultAlias = {
   '@material-ui/data-grid': './packages/grid/data-grid/src',
+  '@material-ui/x-grid-data-generator': './packages/grid/x-grid-data-generator/src',
   '@material-ui/x-grid-modules': './packages/grid/x-grid-modules/src',
   '@material-ui/x-grid': './packages/grid/x-grid/src',
   '@material-ui/x-license': './packages/x-license/src',

--- a/docs/babel.config.js
+++ b/docs/babel.config.js
@@ -15,6 +15,7 @@ function resolvePath(sourcePath, currentFile, opts) {
 
 const alias = {
   '@material-ui/data-grid': '../packages/grid/data-grid/src',
+  '@material-ui/x-grid-data-generator': '../packages/grid/x-grid-data-generator/src',
   '@material-ui/x-grid-modules': '../packages/grid/x-grid-modules/src',
   '@material-ui/x-grid': '../packages/grid/x-grid/src',
   '@material-ui/x-license': '../packages/x-license/src',

--- a/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.js
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function AutoPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        autoPageSize
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function AutoPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        autoPageSize
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function BasisPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 1000,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid pagination rows={data.rows} columns={data.columns} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function BasisPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 1000,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid pagination rows={data.rows} columns={data.columns} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
@@ -1,0 +1,28 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function ControlledPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  const [page, setPage] = React.useState(1);
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        page={page}
+        onPageChange={(params) => {
+          setPage(params.page);
+        }}
+        pageSize={5}
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
@@ -1,0 +1,27 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function ControlledPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+  const [page, setPage] = React.useState(1);
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        page={page}
+        onPageChange={(params) => {
+          setPage(params.page);
+        }}
+        pageSize={5}
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.js
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function SizePaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        pageSize={5}
+        rowsPerPageOptions={[5, 10, 20]}
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function SizePaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  return (
+    <div style={{ height: 450, width: '100%' }}>
+      <DataGrid
+        pageSize={5}
+        rowsPerPageOptions={[5, 10, 20]}
+        pagination
+        rows={data.rows}
+        columns={data.columns}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -7,6 +7,33 @@ components: DataGrid, XGrid
 
 <p class="description">Through paging, a segment of data can be viewed from the assigned data source.</p>
 
+By default, the Grid displays all the rows with infinite scrolling (and virtualization).
+Set the `pagination` prop to enable the pagination feature.
+
+## Basic example
+
+{{"demo": "pages/components/data-grid/pagination/BasicPaginationGrid.js"}}
+
+## Page size
+
+- The default page size is `100`, you can change this value with the `pageSize` prop.
+- You can configure the possible page size the end-users can choose from with the `rowsPerPageOptions` prop.
+
+{{"demo": "pages/components/data-grid/pagination/SizePaginationGrid.js"}}
+
+## Controlled pagination
+
+While the previous demos show how the pagination can be uncontrolled, the active page can be controlled with the `page`/`onPageChange` props.
+
+{{"demo": "pages/components/data-grid/pagination/ControlledPaginationGrid.js"}}
+
+## Auto size
+
+The `autoPageSize` prop allows to auto-scale the `pageSize` to match the container height and the max number of rows that can be displayed without a vertical scroll bar.
+By default, this feature is off.
+
+{{"demo": "pages/components/data-grid/pagination/AutoPaginationGrid.js"}}
+
 - https://ej2.syncfusion.com/react/demos/#/material/grid/paging
 - https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/paging/
 - https://www.telerik.com/kendo-react-ui/components/grid/paging/

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -17,11 +17,11 @@
     "datagen": "./bin/data-gen-script.js"
   },
   "dependencies": {
-    "@types/faker": "^4.1.0",
+    "@types/chance": "^1.1.0",
+    "chance": "^1.1.6",
     "clsx": "^1.0.4",
     "commander": "^5.1.0",
-    "esm": "^3.2.25",
-    "faker": "^4.1.0"
+    "esm": "^3.2.25"
   },
   "devDependencies": {
     "@types/node": "^14.0.13",

--- a/packages/grid/x-grid-data-generator/src/commodities.columns.tsx
+++ b/packages/grid/x-grid-data-generator/src/commodities.columns.tsx
@@ -1,4 +1,4 @@
-import './style/real-data-stories.css';
+// import './style/real-data-stories.css';
 import {
   generateTotalPrice,
   randomCommodity,

--- a/packages/grid/x-grid-data-generator/src/employees.columns.tsx
+++ b/packages/grid/x-grid-data-generator/src/employees.columns.tsx
@@ -1,4 +1,4 @@
-import './style/real-data-stories.css';
+// import './style/real-data-stories.css';
 import {
   generateName,
   randomAvatar,

--- a/packages/grid/x-grid-data-generator/src/services/random-generator.ts
+++ b/packages/grid/x-grid-data-generator/src/services/random-generator.ts
@@ -1,4 +1,4 @@
-import faker from 'faker';
+import globalChance from 'chance';
 import {
   COLORS,
   COMMODITY_OPTIONS,
@@ -11,6 +11,62 @@ import {
   TAXCODE_OPTIONS,
 } from './static-data';
 
+const chance = globalChance();
+
+function dateFuture(years?: number, refDate?: string) {
+  let date = new Date();
+  if (typeof refDate !== 'undefined') {
+    date = new Date(Date.parse(refDate));
+  }
+
+  const range = {
+    min: 1000,
+    max: (years || 1) * 365 * 24 * 3600 * 1000,
+  };
+
+  // some time from now to N years later, in milliseconds
+  const past = date.getTime() + chance.integer(range);
+  date.setTime(past);
+
+  return date;
+}
+
+function dateRecent(days?: number, refDate?: string) {
+  let date = new Date();
+  if (typeof refDate !== 'undefined') {
+    date = new Date(Date.parse(refDate));
+  }
+
+  const range = {
+    min: 1000,
+    max: (days || 1) * 24 * 3600 * 1000,
+  };
+
+  // some time from now to N days ago, in milliseconds
+  const past = date.getTime() - chance.integer(range);
+  date.setTime(past);
+
+  return date;
+}
+
+function datePast(years?: number, refDate?: string) {
+  let date = new Date();
+  if (typeof refDate !== 'undefined') {
+    date = new Date(Date.parse(refDate));
+  }
+
+  const range = {
+    min: 1000,
+    max: (years || 1) * 365 * 24 * 3600 * 1000,
+  };
+
+  // some time from now to N years ago, in milliseconds
+  const past = date.getTime() - chance.integer(range);
+  date.setTime(past);
+
+  return date;
+}
+
 export const random = (min: number, max: number): number => Math.random() * (max - min) + min;
 export const randomInt = (min: number, max: number): number => Number(random(min, max).toFixed());
 export const randomPrice = (min = 0, max = 100000): number => random(min, max);
@@ -21,15 +77,15 @@ export const getDate = () => randomDate(new Date(2012, 0, 1), new Date());
 export const randomArrayItem = (arr: any[]) => arr[random(0, arr.length - 1).toFixed()];
 
 export const randomColor = () => randomArrayItem(COLORS);
-export const randomId = () => faker.random.uuid();
-export const randomDesk = () => `D-${faker.random.number()}`;
+export const randomId = () => chance.guid();
+export const randomDesk = () => `D-${chance.integer({ min: 0, max: 10000 })}`;
 export const randomCommodity = () => randomArrayItem(COMMODITY_OPTIONS);
-export const randomTraderId = () => faker.random.number();
-export const randomTraderName = () => faker.name.findName();
-export const randomUserName = () => faker.internet.userName();
-export const randomEmail = () => faker.internet.email();
-export const randomUrl = () => faker.internet.url();
-export const randomPhoneNumber = () => faker.phone.phoneNumber();
+export const randomTraderId = () => chance.integer({ min: 0, max: 10000 });
+export const randomTraderName = () => chance.name();
+export const randomUserName = () => chance.twitter();
+export const randomEmail = () => chance.email();
+export const randomUrl = () => chance.url();
+export const randomPhoneNumber = () => chance.phone();
 export const randomUnitPrice = () => randomPrice(1, 100);
 export const randomUnitPriceCurrency = () => randomArrayItem(CURRENCY_OPTIONS);
 export const randomQuantity = () => randomInt(1000, 100000);
@@ -37,21 +93,21 @@ export const randomFeeRate = () => random(0.1, 0.4);
 export const randomIncoterm = () => randomArrayItem(INCOTERM_OPTIONS);
 export const randomStatusOptions = () => randomArrayItem(STATUS_OPTIONS);
 export const randomPnL = () => random(-100000000, 100000000);
-export const randomMaturityDate = () => faker.date.future();
-export const randomTradeDate = () => faker.date.recent();
-export const randomBrokerId = () => faker.random.uuid();
-export const randomCompanyName = () => faker.company.companyName();
+export const randomMaturityDate = () => dateFuture();
+export const randomTradeDate = () => dateRecent();
+export const randomBrokerId = () => chance.guid();
+export const randomCompanyName = () => chance.company();
 export const randomCountry = () => randomArrayItem(COUNTRY_ISO_OPTIONS);
 export const randomCurrency = () => randomArrayItem(CURRENCY_OPTIONS);
-export const randomAddress = () => faker.address.streetAddress();
-export const randomCity = () => faker.address.city();
+export const randomAddress = () => chance.address();
+export const randomCity = () => chance.city();
 export const randomTaxCode = () => randomArrayItem(TAXCODE_OPTIONS);
 export const randomContractType = () => randomArrayItem(CONTRACT_TYPE_OPTIONS);
 export const randomRateType = () => randomArrayItem(RATE_TYPE_OPTIONS);
-export const randomCreatedDate = () => faker.date.past();
-export const randomUpdatedDate = () => faker.date.recent();
-export const randomAvatar = () => ({ name: faker.name.findName(), color: randomColor() });
-export const randomJobTitle = () => faker.name.jobTitle();
+export const randomCreatedDate = () => datePast();
+export const randomUpdatedDate = () => dateRecent();
+export const randomAvatar = () => ({ name: chance.name(), color: randomColor() });
+export const randomJobTitle = () => chance.profession();
 export const randomRating = () => random(0, 5);
 
 export const generateName = (data) => data.avatar.name;

--- a/packages/grid/x-grid-data-generator/src/services/real-data-service.ts
+++ b/packages/grid/x-grid-data-generator/src/services/real-data-service.ts
@@ -23,7 +23,6 @@ export function getRealData(rowLength: number, columns: any[]): Promise<GridData
 
       data.push(model);
     }
-
     resolve({ columns, rows: data });
   });
 }

--- a/packages/grid/x-grid-data-generator/src/useDemoData.ts
+++ b/packages/grid/x-grid-data-generator/src/useDemoData.ts
@@ -1,51 +1,53 @@
 import * as React from 'react';
-import { ColDef, Columns, RowData } from '@material-ui/x-grid';
-import { getRealData } from './services/real-data-service';
+import { GridData, getRealData } from './services/real-data-service';
 import { commodityColumns } from './commodities.columns';
 import { employeeColumns } from './employees.columns';
 
 export type DemoDataReturnType = {
-  data: { rows: RowData[]; columns: ColDef[] };
-  setSize: (count: number) => void;
-  setDataset: (dataset: string) => void;
+  data: GridData;
+  setRowLength: (count: number) => void;
   loadNewData: () => void;
 };
 export type DataSet = 'Commodity' | 'Employee';
 
-export const useDemoData = (dataSetProp: DataSet, nbRows: number): DemoDataReturnType => {
-  const [rows, setRows] = React.useState<RowData[]>([]);
-  const [cols, setCols] = React.useState<Columns>([]);
-  const [size, setSize] = React.useState(nbRows);
+interface DemoDataOptions {
+  dataSet: DataSet;
+  rowLength: number;
+  maxColumns?: number;
+}
+
+export const useDemoData = (options: DemoDataOptions): DemoDataReturnType => {
+  const [data, setData] = React.useState<GridData>({ columns: [], rows: [] });
+  const [rowLength, setRowLength] = React.useState(options.rowLength);
   const [index, setIndex] = React.useState(0);
-  const [dataset, setDataset] = React.useState(dataSetProp.toString());
 
   React.useEffect(() => {
     let active = true;
 
     (async () => {
-      const data = await getRealData(
-        size,
-        dataset === 'Commodity' ? commodityColumns : employeeColumns,
-      );
+      let columns = options.dataSet === 'Commodity' ? commodityColumns : employeeColumns;
+
+      if (options.maxColumns) {
+        columns = columns.slice(0, options.maxColumns);
+      }
+
+      const newData = await getRealData(rowLength, columns);
 
       if (!active) {
         return;
       }
 
-      setRows([]);
-      setCols(data.columns);
-      setRows(data.rows);
+      setData(newData);
     })();
 
     return () => {
       active = false;
     };
-  }, [size, dataset, index]);
+  }, [rowLength, options.dataSet, index, options.maxColumns]);
 
   return {
-    data: { rows, columns: cols },
-    setSize,
-    setDataset,
+    data,
+    setRowLength,
     loadNewData: () => {
       setIndex((oldIndex) => oldIndex + 1);
     },

--- a/packages/storybook/src/stories/playground/real-data-demo.stories.tsx
+++ b/packages/storybook/src/stories/playground/real-data-demo.stories.tsx
@@ -57,7 +57,7 @@ const getGridOptions: () => GridOptionsProp = () => {
 };
 
 export function Commodity() {
-  const { data, setSize, loadNewData } = useDemoData('Commodity', 100);
+  const { data, setRowLength, loadNewData } = useDemoData({ dataSet: 'Commodity', rowLength: 100 });
 
   return (
     <React.Fragment>
@@ -65,7 +65,7 @@ export function Commodity() {
         <Button color="primary" onClick={loadNewData}>
           Load New Rows
         </Button>
-        <Button color="primary" onClick={() => setSize(randomInt(100, 500))}>
+        <Button color="primary" onClick={() => setRowLength(randomInt(100, 500))}>
           Load New Rows with new length
         </Button>
       </div>
@@ -77,7 +77,7 @@ export function Commodity() {
 }
 
 export function Commodity500() {
-  const { data } = useDemoData('Commodity', 500);
+  const { data } = useDemoData({ dataSet: 'Commodity', rowLength: 500 });
 
   return (
     <div className="grid-container">
@@ -87,7 +87,7 @@ export function Commodity500() {
 }
 
 export function Commodity1000() {
-  const { data } = useDemoData('Commodity', 1000);
+  const { data } = useDemoData({ dataSet: 'Commodity', rowLength: 1000 });
 
   return (
     <div className="grid-container">
@@ -97,7 +97,7 @@ export function Commodity1000() {
 }
 
 export function Commodity10000() {
-  const { data } = useDemoData('Commodity', 10000);
+  const { data } = useDemoData({ dataSet: 'Commodity', rowLength: 10000 });
 
   return (
     <div className="grid-container">
@@ -107,7 +107,7 @@ export function Commodity10000() {
 }
 
 export function Employee100() {
-  const { data } = useDemoData('Employee', 100);
+  const { data } = useDemoData({ dataSet: 'Employee', rowLength: 100 });
 
   return (
     <div className="grid-container">
@@ -117,7 +117,7 @@ export function Employee100() {
 }
 
 export function Employee1000() {
-  const { data } = useDemoData('Employee', 1000);
+  const { data } = useDemoData({ dataSet: 'Employee', rowLength: 1000 });
 
   return (
     <div className="grid-container">
@@ -127,7 +127,7 @@ export function Employee1000() {
 }
 
 export function Employee10000() {
-  const { data } = useDemoData('Employee', 10000);
+  const { data } = useDemoData({ dataSet: 'Employee', rowLength: 10000 });
 
   return (
     <div className="grid-container">

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,14 +18,16 @@
     "types": ["jest", "node"],
     "baseUrl": "./",
     "paths": {
-      "@material-ui/x-grid": ["./packages/grid/x-grid/src"],
-      "@material-ui/x-grid/*": ["./packages/grid/x-grid/src/*"],
+      "@material-ui/data-grid": ["./packages/grid/data-grid/src"],
+      "@material-ui/data-grid/*": ["./packages/grid/data-grid/src/*"],
+      "@material-ui/x-grid-data-generator": ["./packages/grid/x-grid-data-generator/src/"],
+      "@material-ui/x-grid-data-generator/*": ["./packages/grid/x-grid-data-generator/src/*"],
       "@material-ui/x-grid-modules": ["./packages/grid/x-grid-modules/src"],
       "@material-ui/x-grid-modules/*": ["./packages/grid/x-grid-modules/src/*"],
+      "@material-ui/x-grid": ["./packages/grid/x-grid/src"],
+      "@material-ui/x-grid/*": ["./packages/grid/x-grid/src/*"],
       "@material-ui/x-license": ["./packages/x-license/src"],
-      "@material-ui/x-license/*": ["./packages/x-license/src/¨"],
-      "@material-ui/data-grid": ["./packages/grid/data-grid/src"],
-      "@material-ui/data-grid/*": ["./packages/grid/data-grid/src/*"]
+      "@material-ui/x-license/*": ["./packages/x-license/src/¨"]
     }
   }
 }

--- a/webpackBaseConfig.js
+++ b/webpackBaseConfig.js
@@ -7,10 +7,14 @@ module.exports = {
   resolve: {
     modules: [__dirname, 'node_modules'],
     alias: {
-      '@material-ui/x-grid': path.resolve(__dirname, './packages/grid/x-grid/src'),
-      '@material-ui/x-grid-modules': path.resolve(__dirname, './packages/grid/x-grid-modules/src'),
-      '@material-ui/x-license': path.resolve(__dirname, './packages/x-license/src'),
       '@material-ui/data-grid': path.resolve(__dirname, './packages/grid/data-grid/src'),
+      '@material-ui/x-grid-data-generator': path.resolve(
+        __dirname,
+        './packages/grid/x-grid-data-generator/src',
+      ),
+      '@material-ui/x-grid-modules': path.resolve(__dirname, './packages/grid/x-grid-modules/src'),
+      '@material-ui/x-grid': path.resolve(__dirname, './packages/grid/x-grid/src'),
+      '@material-ui/x-license': path.resolve(__dirname, './packages/x-license/src'),
       docs: path.resolve(__dirname, './docs/node_modules/@material-ui/monorepo/docs'),
       docsx: path.resolve(__dirname, './docs'),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -4568,6 +4568,11 @@
   resolved "https://registry.yarnpkg.com/@types/braces/-/braces-3.0.0.tgz#7da1c0d44ff1c7eb660a36ec078ea61ba7eb42cb"
   integrity sha512-TbH79tcyi9FHwbyboOKeRachRq63mSuWYXOflsNO9ZyE5ClQ/JaozNKl+aWUq87qPNsXasXxi2AbgfwIJ+8GQw==
 
+"@types/chance@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@types/chance/-/chance-1.1.0.tgz#7d8e6bd0506344d94c042f692d59d20f8eb7d66d"
+  integrity sha512-j/9aaLU6JaaN2iFiSZgvD+G0nju1Fi2/f2WM+WwS+8+cpTdzFhXFH3+SHZgfjgum6wNW80sfcawUx+Rx7tH26w==
+
 "@types/cheerio@*":
   version "0.22.18"
   resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.18.tgz#19018dceae691509901e339d63edf1e935978fe6"
@@ -4622,11 +4627,6 @@
   version "0.0.39"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-0.0.39.tgz#e177e699ee1b8c22d23174caaa7422644389509f"
   integrity sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
-
-"@types/faker@^4.1.0":
-  version "4.1.12"
-  resolved "https://registry.yarnpkg.com/@types/faker/-/faker-4.1.12.tgz#065d37343677df1aa757c622650bd14666c42602"
-  integrity sha512-0MEyzJrLLs1WaOCx9ULK6FzdCSj2EuxdSP9kvuxxdBEGujZYUOZ4vkPXdgu3dhyg/pOdn7VCatelYX7k0YShlA==
 
 "@types/glob-base@^0.3.0":
   version "0.3.0"
@@ -7335,6 +7335,11 @@ chalk@^4.0.0, chalk@^4.1.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chance@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/chance/-/chance-1.1.6.tgz#967a0a129e0f342f7c65cd5d20f5ae870a26b8af"
+  integrity sha512-DXLzaGjasDWbvlFAJyQBIwlzdQZuPdz4of9TTTxmHTjja88ZU/vBwUwxxjalSt43zWTPrhiJT0z0N4bZqfZS9w==
 
 char-regex@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
I had to solve an issue with the generation of fake data. The page was toooo slow to load. I wanted to keep the demo as simple as possible while retaining acceptable performance. I ended-up switching [faker](https://github.com/Marak/faker.js) to [chance](https://github.com/chancejs/chancejs). This lead to an x20 improvement of runtime to generate the fake data (from 800ms to 40ms) and x5 reduction of bundle size (from 358 to [63 kB](https://bundlephobia.com/result?p=chance) gzipped).

We might have more opportunities to improve the performance in the future, I suspect that once we display 10 grid on the same page of the documentation, we will be able to gain by caching the generated fake rows.