### PR TITLE
[docs] Add more context on the ⚡️ icons

### DIFF
--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -49,7 +49,7 @@ To change the width of a column, use the `width` property available in `ColDef`.
 
 {{"demo": "pages/components/data-grid/columns/ColumnWidthGrid.js"}}
 
-## Column resizing ⚡️
+## Column resizing <span role="img" title="Enterprise">⚡️</span>
 
 By default, `XGrid` allows all columns to be resized by dragging the right portion of the column separator.
 
@@ -111,7 +111,7 @@ const usdPrice: ColTypeDef = {
 
 Grouping columns allows you to have multiple levels of columns in your header and the ability, if needed, to 'open and close' column groups to show and hide additional columns.
 
-## 🚧 Column reorder ⚡️
+## 🚧 Column reorder <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -119,7 +119,7 @@ Grouping columns allows you to have multiple levels of columns in your header an
 
 Column reordering enables reordering the columns by dragging the header cells.
 
-## 🚧 Sticky columns ⚡️
+## 🚧 Sticky columns <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >

--- a/docs/src/pages/components/data-grid/export/export.md
+++ b/docs/src/pages/components/data-grid/export/export.md
@@ -23,7 +23,7 @@ You will be able to export the displayed data to CSV with an API call, or using 
 
 Optimization of the layout of the grid for print mode. It can also be used to export to PDF.
 
-## 🚧 Excel export ⚡️
+## 🚧 Excel export <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -31,7 +31,7 @@ Optimization of the layout of the grid for print mode. It can also be used to ex
 
 You will be able to export the displayed data to Excel with an API call, or using the grid UI.
 
-## 🚧 Clipboard ⚡️
+## 🚧 Clipboard <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >

--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -99,14 +99,14 @@ export default function App() {
 
 {{"demo": "pages/components/data-grid/getting-started/Codesandbox.js", "hideToolbar": true, "bg": true}}
 
-## Enterprise
+## Enterprise ⚡️
 
 The data grid comes in 2 versions:
 
 - `DataGrid` **MIT licensed** as part of the community edition. It's an extension of `@material-ui/core`.
 - `XGrid` **Commercially licensed** as part of the X product line offering.
 
-The features only available in the commercial version are suffixed with a <span style="font-size: 26px">⚡️</span> icon.
+The features only available in the commercial version are suffixed with a <span style="font-size: 26px" role="img" title="Enterprise">⚡️</span> icon.
 
 <img src="/static/x/header-icon.png" width="454" height="239" alt="">
 

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -7,7 +7,7 @@ components: DataGrid, XGrid
 
 <p class="description">Explore and analyse in depth the grid data.</p>
 
-## 🚧 Tree data ⚡️
+## 🚧 Tree data <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -15,7 +15,7 @@ components: DataGrid, XGrid
 
 Tree data allows to visualize self-referential hierarchical (tree-like structure) data.
 
-## 🚧 Master detail ⚡️
+## 🚧 Master detail <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -23,7 +23,7 @@ Tree data allows to visualize self-referential hierarchical (tree-like structure
 
 The feature allows to display row details on an expandable pane.
 
-## 🚧 Grouping ⚡️
+## 🚧 Grouping <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -31,7 +31,7 @@ The feature allows to display row details on an expandable pane.
 
 Group rows together that share a column value, this creates a visible header for each group and allows the end-user to collapse groups that they don't want to see.
 
-## 🚧 Aggregation ⚡️
+## 🚧 Aggregation <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
@@ -39,7 +39,7 @@ Group rows together that share a column value, this creates a visible header for
 
 When grouping, you will be able to apply an aggregation function to populate the group row with values.
 
-## 🚧 Pivoting ⚡️
+## 🚧 Pivoting <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -18,7 +18,7 @@ The data grid comes in 2 versions:
 - `DataGrid` **MIT licensed** as part of the community edition. It's an extension of `@material-ui/core`.
 - `XGrid` **Commercially licensed** as part of the X product line offering.
 
-The features only available in the commercial version are suffixed with a <span style="font-size: 26px">⚡️</span> icon.
+The features only available in the commercial version are suffixed with a <span style="font-size: 26px" role="img" title="Enterprise">⚡️</span> icon.
 
 ### MIT version
 
@@ -31,7 +31,7 @@ import { DataGrid } from '@material-ui/data-grid';
 
 {{"demo": "pages/components/data-grid/overview/DataGridDemo.js", "defaultCodeOpen": false}}
 
-### Commercial version ⚡️
+### Commercial version <span role="img" title="Enterprise">⚡️</span>
 
 The following grid displays 31 columns and 100,000 rows - over 3 million cells in total.
 

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -63,7 +63,7 @@ Below is an example of how you can reset the page using the imperative `setPage`
 
 {{"demo": "pages/components/data-grid/pagination/ApiRefPaginationGrid.js"}}
 
-## Paginate > 100 rows ⚡️
+## Paginate > 100 rows <span role="img" title="Enterprise">⚡️</span>
 
 The `DataGrid` component can display up to 100 rows per page.
 The `XGrid` component removes this limitation.

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -118,7 +118,7 @@ The grid exposes a set of methods that enables all of these features using the i
 - `setSortModel`: Set the sort model and trigger the sorting of rows.
 - `onSortModelChange`: Callback fired when the column sorting changed before the grid has sorted its rows.
 
-### Multi-column sorting ⚡️
+### Multi-column sorting <span role="img" title="Enterprise">⚡️</span>
 
 You can sort by multiple columns at the same time using `XGrid`.
 Hold the <kbd>CTRL</kbd> key down while clicking the column header.
@@ -158,7 +158,7 @@ Row spanning allows to change this default behavior.
 It allows cells to span multiple rows.
 This is very close to the "row spanning" in an HTML `<table>`.
 
-## 🚧 Row reorder ⚡️
+## 🚧 Row reorder <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -32,7 +32,7 @@ For the `XGrid`, you need to disable multiple row selection with `disableMultipl
 
 {{"demo": "pages/components/data-grid/selection/SingleRowSelectionGrid.js"}}
 
-### Multiple row selection ⚡️
+### Multiple row selection <span role="img" title="Enterprise">⚡️</span>
 
 To activate multiple selection, put focus the `XGrid` component and hold the <kbd>CTRL</kbd> key while selecting rows.
 
@@ -62,7 +62,7 @@ The grid exposes a set of methods that enables all of these features using the i
 
 - `onSelectionChange`: Callback fired when the selection state of one or multiple rows changes.
 
-## 🚧 Range selection ⚡️
+## 🚧 Range selection <span role="img" title="Enterprise">⚡️</span>
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >


### PR DESCRIPTION
More accessible and give a bit more context:

<img width="303" alt="Capture d’écran 2020-09-12 à 17 46 10" src="https://user-images.githubusercontent.com/3165635/92999269-dd12a780-f51f-11ea-9c44-2596268aaad0.png">
