### PR TITLE
[DataGrid] Add footer border top

### DIFF
--- a/packages/grid/x-grid-modules/src/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/x-grid-modules/src/components/styled-wrappers/GridRootStyles.ts
@@ -188,6 +188,7 @@ export const useStyles = makeStyles(
           textAlign: 'center',
         },
         '& .MuiDataGrid-footer': {
+          borderTop: `1px solid ${borderColor}`,
           display: 'flex',
           justifyContent: 'space-between',
         },


### PR DESCRIPTION
I'm not entirely sure about this change. We are moving one case from KO to OK and two OK to OK-ish.

- **before** vertical scrollbar: KO
<img width="785" alt="before-vertical scrollbar" src="https://user-images.githubusercontent.com/3165635/93003446-0a228280-f53f-11ea-929d-f6c6311edc6e.png">

- **before** no scrollbar: OK
<img width="786" alt="before-no scrollbar" src="https://user-images.githubusercontent.com/3165635/93003448-0b53af80-f53f-11ea-90de-471233577b69.png">

- **before** horizontal scrollbar: OK
<img width="780" alt="before-horizontal scrollbar" src="https://user-images.githubusercontent.com/3165635/93003450-0bec4600-f53f-11ea-98ef-9c5aebb97f1f.png">

- **after** vertical scrollbar: OK
<img width="784" alt="after-vertical scrollbar" src="https://user-images.githubusercontent.com/3165635/93003452-0c84dc80-f53f-11ea-942a-35f510c040f6.png">

- **after** no scrollbar: OK-ish
<img width="783" alt="after-no scrollbar" src="https://user-images.githubusercontent.com/3165635/93003453-0d1d7300-f53f-11ea-807f-093551856d35.png">

- **after** horizontal scrollbar: OK-ish
<img width="776" alt="after-horizontal scrollbar" src="https://user-images.githubusercontent.com/3165635/93003454-0db60980-f53f-11ea-8c12-aaeff267c1c5.png">

Maybe we should add a new class name that is only applied when there is a vertical scrollbar and no horizontal one?