### PR TITLE
[DataGrid] Remove .MuiDataGrid-overlayContent node

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -67,7 +67,6 @@ The `ref` is forwarded to the root element.
 | <span class="prop-name">root</span> | <span class="prop-name">.MuiDataGrid-root</span> | Styles applied to the root element. |
 |  | <span class="prop-name">.MuiDataGrid-mainGridContainer</span> | Styles applied to the main container element.|
 |  | <span class="prop-name">.MuiDataGrid-overlay</span> | Styles applied to the outer overlay element.|
-|  | <span class="prop-name">.MuiDataGrid-overlayContent</span> | Styles applied to the overlay content element.|
 |  | <span class="prop-name">.MuiDataGrid-columnsContainer</span> | Styles applied to the outer columns container element.|
 |  | <span class="prop-name">.MuiDataGrid-colCellWrapper</span> | Styles applied to the outer columns header cells container element.|
 |  | <span class="prop-name">.MuiDataGrid-colCell</span> | Styles applied to the header cell element.|

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -72,7 +72,6 @@ The `ref` is forwarded to the root element.
 | <span class="prop-name">root</span> | <span class="prop-name">.MuiDataGrid-root</span> | Styles applied to the root element. |
 |  | <span class="prop-name">.MuiDataGrid-mainGridContainer</span> | Styles applied to the main container element.|
 |  | <span class="prop-name">.MuiDataGrid-overlay</span> | Styles applied to the outer overlay element.|
-|  | <span class="prop-name">.MuiDataGrid-overlayContent</span> | Styles applied to the overlay content element.|
 |  | <span class="prop-name">.MuiDataGrid-columnsContainer</span> | Styles applied to the outer columns container element.|
 |  | <span class="prop-name">.MuiDataGrid-colCellWrapper</span> | Styles applied to the outer columns header cells container element.|
 |  | <span class="prop-name">.MuiDataGrid-colCell</span> | Styles applied to the header cell element.|

--- a/docs/src/pages/components/data-grid/rendering/CustomEmptyOverlayGrid.js
+++ b/docs/src/pages/components/data-grid/rendering/CustomEmptyOverlayGrid.js
@@ -5,10 +5,7 @@ import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    '& .MuiDataGrid-overlayContent': {
-      flexDirection: 'column',
-      alignItems: 'center',
-    },
+    flexDirection: 'column',
     '& .ant-empty-img-1': {
       fill: theme.palette.type === 'light' ? '#aeb8c2' : '#262626',
     },

--- a/docs/src/pages/components/data-grid/rendering/CustomEmptyOverlayGrid.tsx
+++ b/docs/src/pages/components/data-grid/rendering/CustomEmptyOverlayGrid.tsx
@@ -6,10 +6,7 @@ import { createStyles, Theme, makeStyles } from '@material-ui/core/styles';
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
-      '& .MuiDataGrid-overlayContent': {
-        flexDirection: 'column',
-        alignItems: 'center',
-      },
+      flexDirection: 'column',
       '& .ant-empty-img-1': {
         fill: theme.palette.type === 'light' ? '#aeb8c2' : '#262626',
       },

--- a/packages/grid/x-grid-modules/src/components/styled-wrappers/GridOverlay.tsx
+++ b/packages/grid/x-grid-modules/src/components/styled-wrappers/GridOverlay.tsx
@@ -5,15 +5,13 @@ import { OptionsContext } from '../options-context';
 type GridOverlayProps = React.HTMLAttributes<HTMLDivElement>;
 
 export function GridOverlay(props: GridOverlayProps) {
-  const { className, children, ...other } = props;
+  const { className, style, ...other } = props;
   const options = React.useContext(OptionsContext);
   return (
     <div
       className={classnames('MuiDataGrid-overlay', className)}
+      style={{ top: options?.headerHeight, ...style }}
       {...other}
-      style={{ top: options?.headerHeight }}
-    >
-      <div className="MuiDataGrid-overlayContent">{children}</div>
-    </div>
+    />
   );
 }

--- a/packages/grid/x-grid-modules/src/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/x-grid-modules/src/components/styled-wrappers/GridRootStyles.ts
@@ -37,16 +37,12 @@ export const useStyles = makeStyles(
           bottom: 0,
           alignSelf: 'center',
           alignItems: 'center',
+          justifyContent: 'center',
           zIndex: 10,
           backgroundColor: fade(
             theme.palette.background.default,
             theme.palette.action.disabledOpacity,
           ),
-        },
-        '& .MuiDataGrid-overlayContent': {
-          flex: 1,
-          display: 'flex',
-          justifyContent: 'center',
         },
         '& .MuiDataGrid-columnsContainer': {
           position: 'absolute',


### PR DESCRIPTION
A continuation on https://github.com/mui-org/material-ui-x/pull/268/files#r487562268. I couldn't spot any visual regression. A lighter DOM = faster rendering & easier customizations.