### PR TITLE
[docs] Fix layout jump issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,29 +2,6 @@
 
 The Material-UI X mono-repo gathers Material-UI advanced components.
 
-## XGrid
+## Components
 
-The Data Grid component is designed to display and analyze tabular data. It leverages the power of React and TypeScript, to provide the best UX, while manipulating an unlimited set of data.
-As one of our X advanced component series, it comes with an intuitive API for real-time updates, accessibility, as well as theming and custom templates, all with blazing fast performance.
-
-Check out our demo **[here](https://muix-preview.netlify.app/#/grid)**.
-
-### Features
-
-- **Virtualization** is used to display an unlimited set of elements, without cluttering the DOM. Therefore you can set 1000s of rows or columns.
-- **Sorting** can be applied on a single or multiple columns.
-- **Selection** brings user interaction in play and lets you manipulate a small set of data.
-- **Templating** will let you render rich components for better data analysis.
-- **Pagination** let you split your dataset or API request to avoid overloading your backend.
-- **API** for the advanced users that needs to manipulate the component, outside the react component props. Great for real-time updates and streaming applications.
-- **Theming** to make it your own.
-
-## Licenses
-
-- DataGrid. **MIT** license as part of our core package
-- XGrid. **Commercial** License as part of our X package. More here
-
-## Support
-
-- We provide **Enterprise Support** for all our X component series. Please contact us for more info
-- We keep supporting our core components through all our dedicated channel. Github, twitter...
+- [DataGrid](https://material-ui.com/components/data-grid/)

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -119,7 +119,7 @@ Grouping columns allows you to have multiple levels of columns in your header an
 
 Column reordering enables reordering the columns by dragging the header cells.
 
-## 🚧 Sticky columns [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
+## 🚧 Column pinning [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
 > ⚠️ This feature isn't implemented yet. It's coming.
 >

--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -134,7 +134,7 @@ The following table summarizes the features available in the community `DataGrid
 | [Column resizing](/components/data-grid/columns/#column-resizing)                       | ❌        | ✅             |
 | [Column groups](/components/data-grid/columns/#column-groups)                           | 🚧        | 🚧             |
 | [Column reorder](/components/data-grid/columns/#column-reorder)                         | ❌        | 🚧             |
-| [Column sticky](/components/data-grid/columns/#column-sticky)                           | ❌        | 🚧             |
+| [Column pinning](/components/data-grid/columns/#column-pinning)                         | ❌        | 🚧             |
 | [Column spanning](/components/data-grid/columns/#column-spanning)                       | 🚧        | 🚧             |
 | **Rows**                                                                                |           |                |
 | [Rows sorting](/components/data-grid/rows/#row-sorting)                                 | ✅        | ✅             |

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -73,7 +73,7 @@ You can find more details on, the [feature comparison](/components/data-grid/get
 
 Here are some resources you might be interested in to learn more about the grid:
 
-- A [fullscreen demo](https://material-ui.com/components/data-grid/full-screen-demo/#/grid)
+- A [fullscreen demo](https://material-ui.com/components/data-grid/demo/#/grid)
 - The storybook used for [internal development](https://material-ui-x.netlify.app/storybook/)
 - The [source on GitHub](https://github.com/mui-org/material-ui-x/tree/master/packages/grid)
 - The [Material Design specification](https://material.io/design/components/data-tables.html) specification

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -73,7 +73,7 @@ You can find more details on, the [feature comparison](/components/data-grid/get
 
 Here are some resources you might be interested in to learn more about the grid:
 
-- A [fullscreen demo](https://muix-preview.netlify.app/#/grid)
+- A [fullscreen demo](https://material-ui.com/components/data-grid/full-screen-demo/#/grid)
 - The storybook used for [internal development](https://material-ui-x.netlify.app/storybook/)
 - The [source on GitHub](https://github.com/mui-org/material-ui-x/tree/master/packages/grid)
 - The [Material Design specification](https://material.io/design/components/data-tables.html) specification

--- a/docs/src/pages/components/data-grid/rows/ServerSortingGrid.js
+++ b/docs/src/pages/components/data-grid/rows/ServerSortingGrid.js
@@ -69,20 +69,18 @@ export default function ServerSortingGrid() {
     };
   }, [sortModel, data]);
 
-  if (data.columns.length === 0) {
-    return null;
-  }
-
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={rows}
-        columns={data.columns}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        loading={loading}
-      />
+      {data.columns.length === 0 ? null : (
+        <DataGrid
+          rows={rows}
+          columns={data.columns}
+          sortingMode="server"
+          sortModel={sortModel}
+          onSortModelChange={handleSortModelChange}
+          loading={loading}
+        />
+      )}
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/rows/ServerSortingGrid.js
+++ b/docs/src/pages/components/data-grid/rows/ServerSortingGrid.js
@@ -71,16 +71,14 @@ export default function ServerSortingGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      {data.columns.length === 0 ? null : (
-        <DataGrid
-          rows={rows}
-          columns={data.columns}
-          sortingMode="server"
-          sortModel={sortModel}
-          onSortModelChange={handleSortModelChange}
-          loading={loading}
-        />
-      )}
+      <DataGrid
+        rows={rows}
+        columns={data.columns}
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={handleSortModelChange}
+        loading={loading}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/rows/ServerSortingGrid.tsx
+++ b/docs/src/pages/components/data-grid/rows/ServerSortingGrid.tsx
@@ -67,20 +67,18 @@ export default function ServerSortingGrid() {
     };
   }, [sortModel, data]);
 
-  if (data.columns.length === 0) {
-    return null;
-  }
-
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={rows}
-        columns={data.columns}
-        sortingMode="server"
-        sortModel={sortModel}
-        onSortModelChange={handleSortModelChange}
-        loading={loading}
-      />
+      {data.columns.length === 0 ? null : (
+        <DataGrid
+          rows={rows}
+          columns={data.columns}
+          sortingMode="server"
+          sortModel={sortModel}
+          onSortModelChange={handleSortModelChange}
+          loading={loading}
+        />
+      )}
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/rows/ServerSortingGrid.tsx
+++ b/docs/src/pages/components/data-grid/rows/ServerSortingGrid.tsx
@@ -69,16 +69,14 @@ export default function ServerSortingGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      {data.columns.length === 0 ? null : (
-        <DataGrid
-          rows={rows}
-          columns={data.columns}
-          sortingMode="server"
-          sortModel={sortModel}
-          onSortModelChange={handleSortModelChange}
-          loading={loading}
-        />
-      )}
+      <DataGrid
+        rows={rows}
+        columns={data.columns}
+        sortingMode="server"
+        sortModel={sortModel}
+        onSortModelChange={handleSortModelChange}
+        loading={loading}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Also rename `Sticky columns` into `Column pinning`.