### PR TITLE
[docs] Avoid double borders

### DIFF
--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -25,7 +25,7 @@ interface ColDef {
 }
 ```
 
-{{"demo": "pages/components/data-grid/columns/BasicColumnsGrid.js"}}
+{{"demo": "pages/components/data-grid/columns/BasicColumnsGrid.js", "bg": "inline"}}
 
 By default, columns are ordered according to the order they are included in the `columns` array.
 
@@ -37,7 +37,7 @@ You can configure the headers with:
 - `description`: The description of the column rendered as tooltip if the column header name is not fully displayed.
 - `hide`: Hide the column.
 
-{{"demo": "pages/components/data-grid/columns/HeaderColumnsGrid.js"}}
+{{"demo": "pages/components/data-grid/columns/HeaderColumnsGrid.js", "bg": "inline"}}
 
 For more advanced header configuration, go to the [rendering section](/components/data-grid/rendering/#header-cell).
 
@@ -47,7 +47,7 @@ By default, the columns have a width of 100 pixels.
 This is an arbitrary, easy to remember value.
 To change the width of a column, use the `width` property available in `ColDef`.
 
-{{"demo": "pages/components/data-grid/columns/ColumnWidthGrid.js"}}
+{{"demo": "pages/components/data-grid/columns/ColumnWidthGrid.js", "bg": "inline"}}
 
 ## Column resizing [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
@@ -56,7 +56,7 @@ By default, `XGrid` allows all columns to be resized by dragging the right porti
 To prevent the resizing of a column, set `resizable: false` in the `ColDef`.
 Alternatively, to disable all columns resize, set the prop `disableColumnResize={true}`.
 
-{{"demo": "pages/components/data-grid/columns/ColumnSizingGrid.js", "disableAd": true}}
+{{"demo": "pages/components/data-grid/columns/ColumnSizingGrid.js", "disableAd": true, "bg": "inline"}}
 
 <!--
 - https://ag-grid.com/javascript-grid-resizing/
@@ -84,7 +84,7 @@ The following are the native column types:
 
 To apply a column type, you need to define the type property in your column definition.
 
-{{"demo": "pages/components/data-grid/columns/ColumnTypesGrid.js"}}
+{{"demo": "pages/components/data-grid/columns/ColumnTypesGrid.js", "bg": "inline"}}
 
 ## Custom column types
 
@@ -101,7 +101,7 @@ const usdPrice: ColTypeDef = {
 };
 ```
 
-{{"demo": "pages/components/data-grid/columns/CustomColumnTypesGrid.js"}}
+{{"demo": "pages/components/data-grid/columns/CustomColumnTypesGrid.js", "bg": "inline"}}
 
 ## 🚧 Column groups
 

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -29,7 +29,7 @@ This abstraction also set constraints that allow the component to implement new 
 import { DataGrid } from '@material-ui/data-grid';
 ```
 
-{{"demo": "pages/components/data-grid/overview/DataGridDemo.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/overview/DataGridDemo.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 ### Commercial version [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
@@ -39,7 +39,7 @@ The following grid displays 31 columns and 100,000 rows - over 3 million cells i
 import { XGrid } from '@material-ui/x-grid';
 ```
 
-{{"demo": "pages/components/data-grid/overview/XGridDemo.js", "defaultCodeOpen": false, "disableAd": true}}
+{{"demo": "pages/components/data-grid/overview/XGridDemo.js", "defaultCodeOpen": false, "disableAd": true, "bg": "inline"}}
 
 ## Features
 

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -13,27 +13,27 @@ On the other hand, the commercial `XGrid` component displays, by default, all th
 
 ## Basic example
 
-{{"demo": "pages/components/data-grid/pagination/BasicPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/BasicPaginationGrid.js", "bg": "inline"}}
 
 ## Page size
 
 - The default page size is `100`, you can change this value with the `pageSize` prop.
 - You can configure the possible page size the user can choose from with the `rowsPerPageOptions` prop.
 
-{{"demo": "pages/components/data-grid/pagination/SizePaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/SizePaginationGrid.js", "bg": "inline"}}
 
 ## Controlled pagination
 
 While the previous demos show how the pagination can be uncontrolled, the active page can be controlled with the `page`/`onPageChange` props.
 
-{{"demo": "pages/components/data-grid/pagination/ControlledPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/ControlledPaginationGrid.js", "bg": "inline"}}
 
 ## Auto size
 
 The `autoPageSize` prop allows to auto-scale the `pageSize` to match the container height and the max number of rows that can be displayed without a vertical scroll bar.
 By default, this feature is off.
 
-{{"demo": "pages/components/data-grid/pagination/AutoPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/AutoPaginationGrid.js", "bg": "inline"}}
 
 ## Custom pagination component
 
@@ -46,7 +46,7 @@ To switch it to server-side, set `paginationMode="server"`.
 You also need to set the `rowCount` prop to so the grid know the total number of pages.
 Finally, you need to handle the `onPageChange` callback to load the rows for the corresponding page.
 
-{{"demo": "pages/components/data-grid/pagination/ServerPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/ServerPaginationGrid.js", "bg": "inline"}}
 
 ## apiRef [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
@@ -61,7 +61,7 @@ The grid exposes a set of methods that enables all of these features using the i
 
 Below is an example of how you can reset the page using the imperative `setPage` method.
 
-{{"demo": "pages/components/data-grid/pagination/ApiRefPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/pagination/ApiRefPaginationGrid.js", "bg": "inline"}}
 
 ## Paginate > 100 rows [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
@@ -69,4 +69,4 @@ The `DataGrid` component can display up to 100 rows per page.
 The `XGrid` component removes this limitation.
 The following demo displays 200 rows per page:
 
-{{"demo": "pages/components/data-grid/pagination/200PaginationGrid.js", "disableAd": true}}
+{{"demo": "pages/components/data-grid/pagination/200PaginationGrid.js", "disableAd": true, "bg": "inline"}}

--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -32,7 +32,7 @@ const columns: ColDef[] = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/ValueGetterGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/ValueGetterGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 The value generated is used for filtering, sorting, rendering, etc unless overridden by a more specific configuration.
 
@@ -53,7 +53,7 @@ const columns: ColDef[] = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/ValueFormatterGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/ValueFormatterGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 The value generated is used for filtering, sorting, rendering in the cell and outside, etc unless overridden by a more specific configuration.
 
@@ -88,7 +88,7 @@ const columns: ColDef[] = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/RenderCellGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/RenderCellGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 ### Render header
 
@@ -114,7 +114,7 @@ const columns: ColDef[] = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/RenderHeaderGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/RenderHeaderGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 ### Styling header
 
@@ -139,7 +139,7 @@ const columns: Columns = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/StylingHeaderGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/StylingHeaderGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 ### Styling cells
 
@@ -167,7 +167,7 @@ const columns: Columns = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rendering/StylingCellsGrid.js", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/rendering/StylingCellsGrid.js", "defaultCodeOpen": false, "bg": "inline"}}
 
 ## Layout
 
@@ -177,13 +177,13 @@ By default, the grid has no intrinsic dimensions. It occupies the space its pare
 
 It's recommended to use a flex container to render the grid. This allows a flexible layout, resizes well, and works on all devices.
 
-{{"demo": "pages/components/data-grid/rendering/FlexLayoutGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/FlexLayoutGrid.js", "bg": "inline"}}
 
 ### Predefined dimensions
 
 You can predefine dimensions for the parent of the grid.
 
-{{"demo": "pages/components/data-grid/rendering/FixedSizeGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/FixedSizeGrid.js", "bg": "inline"}}
 
 ### Auto height
 
@@ -192,7 +192,7 @@ This means that the number of rows will drive the height of the grid and consequ
 
 > ⚠️ This is not recommended for large datasets as row virtualization will not be able to improve performance by limiting the number of elements rendered in the DOM.
 
-{{"demo": "pages/components/data-grid/rendering/AutoHeightGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/AutoHeightGrid.js", "bg": "inline"}}
 
 ## Virtualization
 
@@ -219,7 +219,7 @@ Column virtualization is the insertion and removal of columns as the grid scroll
 
 By default, 2 columns are rendered outside of the viewport. You can change this option with the `columnBuffer` prop. The following demo renders 1,000 columns in total:
 
-{{"demo": "pages/components/data-grid/rendering/ColumnVirtualizationGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/ColumnVirtualizationGrid.js", "bg": "inline"}}
 
 You can disable column virtualization by setting the column buffer to a higher number than the number of rendered columns, e.g. with `columnBuffer={columns.length}` or `columnBuffer={Number.MAX_SAFE_INTEGER}`.
 
@@ -238,13 +238,13 @@ As part of the customization API, the grid allows you to replace and override ne
 By default, the loading overlay displays a circular progress.
 This demo replaces it with a linear progress.
 
-{{"demo": "pages/components/data-grid/rendering/CustomLoadingOverlayGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/CustomLoadingOverlayGrid.js", "bg": "inline"}}
 
 ### No rows overlay
 
 In the following demo, an illustration is added on top of the default "No Rows" message.
 
-{{"demo": "pages/components/data-grid/rendering/CustomEmptyOverlayGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/CustomEmptyOverlayGrid.js", "bg": "inline"}}
 
 ### Footer
 
@@ -258,10 +258,10 @@ The grid exposes props to hide specific elements of the UI:
 By default, pagination uses the [TablePagination](/components/pagination/#table-pagination) component that is optimized for handling tabular data.
 This demo replaces it with the [Pagination](/components/pagination/) component.
 
-{{"demo": "pages/components/data-grid/rendering/CustomPaginationGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/CustomPaginationGrid.js", "bg": "inline"}}
 
 ## Customization example
 
 The following grid leverages the CSS customization API to match the Ant Design specification.
 
-{{"demo": "pages/components/data-grid/rendering/AntDesignGrid.js"}}
+{{"demo": "pages/components/data-grid/rendering/AntDesignGrid.js", "bg": "inline"}}

--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -264,4 +264,4 @@ This demo replaces it with the [Pagination](/components/pagination/) component.
 
 The following grid leverages the CSS customization API to match the Ant Design specification.
 
-{{"demo": "pages/components/data-grid/rendering/AntDesignGrid.js", "bg": "inline"}}
+{{"demo": "pages/components/data-grid/rendering/AntDesignGrid.js"}}

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -14,7 +14,7 @@ Grid rows can be defined with the `rows` prop.
 Rows should have this type: `RowData[]`.
 The columns' "field" property should match a key of the row object (`RowData`).
 
-{{"demo": "pages/components/data-grid/rows/RowsGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/RowsGrid.js", "bg": "inline"}}
 
 ## Updating rows
 
@@ -35,7 +35,7 @@ This is an imperative API that is designed to solve the previous two limitations
 
 The following demo updates the rows every 200ms.
 
-{{"demo": "pages/components/data-grid/rows/ApiRefRowsGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/ApiRefRowsGrid.js", "bg": "inline"}}
 
 ## Row sorting
 
@@ -55,7 +55,7 @@ const sortModel = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rows/BasicSortingGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/BasicSortingGrid.js", "bg": "inline"}}
 
 ### Custom comparator
 
@@ -71,7 +71,7 @@ To extend or modify this behavior in a specific column, you can pass in a custom
 
 In the example below, the `username` column combines `name` and `age`, but it is sorted by `age` using a custom comparator:
 
-{{"demo": "pages/components/data-grid/rows/ComparatorSortingGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/ComparatorSortingGrid.js", "bg": "inline"}}
 
 ### Sort order
 
@@ -87,7 +87,7 @@ This behavior can be overwritten by setting the `sortingOrder` prop.
 
 In the example below columns are only sortable in descending or ascending order.
 
-{{"demo": "pages/components/data-grid/rows/OrderSortingGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/OrderSortingGrid.js", "bg": "inline"}}
 
 ### Disable sorting
 
@@ -98,7 +98,7 @@ This can be revoked using the sortable prop of the `ColDef` interface:
 const columns: ColDef = [{ field: 'name', sortable: false }];
 ```
 
-{{"demo": "pages/components/data-grid/rows/DisableSortingGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/DisableSortingGrid.js", "bg": "inline"}}
 
 ### Server-side sorting
 
@@ -106,7 +106,7 @@ By default, sorting works client-side.
 To switch it to server-side, set `sortingMode="server"`.
 Then you need to handle the `onSortModelChange` callback, sort the rows on the server-side, and update the `rows` prop with the newly sorted rows.
 
-{{"demo": "pages/components/data-grid/rows/ServerSortingGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/ServerSortingGrid.js", "bg": "inline"}}
 
 ### apiRef [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
@@ -136,7 +136,7 @@ const sortModel = [
 ];
 ```
 
-{{"demo": "pages/components/data-grid/rows/MultiSortingGrid.js", "disableAd": true}}
+{{"demo": "pages/components/data-grid/rows/MultiSortingGrid.js", "disableAd": true, "bg": "inline"}}
 
 ## Row height
 
@@ -145,7 +145,7 @@ This matches the normal height in the [Material Design guidelines](https://mater
 
 To change the row height for the whole grid, set the `rowHeight` prop:
 
-{{"demo": "pages/components/data-grid/rows/DenseHeightGrid.js"}}
+{{"demo": "pages/components/data-grid/rows/DenseHeightGrid.js", "bg": "inline"}}
 
 ## 🚧 Row spanning
 

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -30,29 +30,29 @@ Row selection can be performed with a simple mouse click, or using the [keyboard
 Single row selection is enable by default with the `DataGrid` component.
 For the `XGrid`, you need to disable multiple row selection with `disableMultipleSelection={true}`.
 
-{{"demo": "pages/components/data-grid/selection/SingleRowSelectionGrid.js"}}
+{{"demo": "pages/components/data-grid/selection/SingleRowSelectionGrid.js", "bg": "inline"}}
 
 ### Multiple row selection [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 
 To activate multiple selection, put focus the `XGrid` component and hold the <kbd>CTRL</kbd> key while selecting rows.
 
-{{"demo": "pages/components/data-grid/selection/MultipleRowSelectionGrid.js", "disableAd": true}}
+{{"demo": "pages/components/data-grid/selection/MultipleRowSelectionGrid.js", "disableAd": true, "bg": "inline"}}
 
 ## Checkbox selection
 
 To activate checkbox selection set `checkboxSelection={true}`.
 
-{{"demo": "pages/components/data-grid/selection/CheckboxSelectionGrid.js"}}
+{{"demo": "pages/components/data-grid/selection/CheckboxSelectionGrid.js", "bg": "inline"}}
 
 ## Disable selection on click
 
 You might have interactive content in the cells and need to disable the selection of the row on click. Use the `disableClickEventBubbling` option in this case.
 
-{{"demo": "pages/components/data-grid/selection/DisableClickSelectionGrid.js"}}
+{{"demo": "pages/components/data-grid/selection/DisableClickSelectionGrid.js", "bg": "inline"}}
 
 ## Controlled selection
 
-{{"demo": "pages/components/data-grid/selection/ControlledSelectionGrid.js"}}
+{{"demo": "pages/components/data-grid/selection/ControlledSelectionGrid.js", "bg": "inline"}}
 
 ## apiRef
 


### PR DESCRIPTION
**Before**

<img width="861" alt="b" src="https://user-images.githubusercontent.com/3165635/93908706-40aa8b00-fcff-11ea-824a-7b33ac61cbaa.png">

**After**

<img width="863" alt="a" src="https://user-images.githubusercontent.com/3165635/93908694-3e483100-fcff-11ea-8bf8-e17dc8f79caa.png">
