### PR TITLE
[core] Remove dead-code

### DIFF
--- a/packages/demo-app/src/app/app.tsx
+++ b/packages/demo-app/src/app/app.tsx
@@ -17,7 +17,7 @@ export function App() {
   const [state, dispatch] = React.useReducer(appReducer, { isOpen: false });
   const toggleDrawer = React.useCallback(
     () => dispatch({ type: state.isOpen ? 'close-drawer' : 'open-drawer' }),
-    [state, dispatch],
+    [state],
   );
 
   const { theme, themeId, toggleTheme, isDark } = useTheme();

--- a/packages/demo-app/src/app/demos/grid/components/settings-panel.tsx
+++ b/packages/demo-app/src/app/demos/grid/components/settings-panel.tsx
@@ -35,27 +35,24 @@ export const SettingsPanel: React.FC<SettingsPanelProps> = ({ onApply, type, siz
     (e: React.ChangeEvent<{ name?: string; value: any }>) => {
       setType(e.target.value);
     },
-    [setType],
+    [],
   );
 
-  const onSizeChange = React.useCallback(
-    (e: React.ChangeEvent<{ name?: string; value: any }>) => {
-      setSize(Number(e.target.value));
-    },
-    [setSize],
-  );
+  const onSizeChange = React.useCallback((e: React.ChangeEvent<{ name?: string; value: any }>) => {
+    setSize(Number(e.target.value));
+  }, []);
   const onPaginationChange = React.useCallback(
     (e: React.ChangeEvent<{ name?: string; value: any }>) => {
       setSelectedPaginationValue(e.target.value);
       // setSize(Number(e.target.value));
     },
-    [setSelectedPaginationValue],
+    [],
   );
   const onSelectedThemeChange = React.useCallback(
     (e: React.ChangeEvent<{ name?: string; value: any }>) => {
       setSelectedTheme(e.target.value);
     },
-    [setSelectedTheme],
+    [],
   );
 
   return (

--- a/packages/grid/_modules_/grid/components/checkbox-renderer.tsx
+++ b/packages/grid/_modules_/grid/components/checkbox-renderer.tsx
@@ -25,7 +25,7 @@ export const HeaderCheckbox: React.FC<ColParams> = ({ api }) => {
       setChecked(isAllSelected || !hasNoneSelected);
       setIndeterminate(!isAllSelected && !hasNoneSelected);
     },
-    [api, setIndeterminate, setChecked],
+    [api],
   );
 
   React.useEffect(() => {

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -22,7 +22,7 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       }
 
       return undefined;
-    }, [api, setSelectedCount]);
+    }, [api]);
 
     if (options.hideFooter) {
       return null;

--- a/packages/grid/_modules_/grid/hooks/features/usePagination.ts
+++ b/packages/grid/_modules_/grid/hooks/features/usePagination.ts
@@ -64,14 +64,11 @@ export const usePagination = (
   const prevPageRef = React.useRef<number>(1);
   const [state, dispatch] = React.useReducer(paginationReducer, initialState);
 
-  const updateState = React.useCallback(
-    (stateUpdate: Partial<PaginationState>) => {
-      const newState = { ...stateRef.current, ...stateUpdate };
-      stateRef.current = newState;
-      dispatch(updateStateAction(newState));
-    },
-    [dispatch],
-  );
+  const updateState = React.useCallback((stateUpdate: Partial<PaginationState>) => {
+    const newState = { ...stateRef.current, ...stateUpdate };
+    stateRef.current = newState;
+    dispatch(updateStateAction(newState));
+  }, []);
 
   const setPage = React.useCallback(
     (page: number) => {
@@ -125,7 +122,7 @@ export const usePagination = (
       updateState(newState);
       setPage(newPage);
     },
-    [stateRef, apiRef, setPage, updateState, logger],
+    [apiRef, setPage, updateState, logger],
   );
 
   const onPageChange = React.useCallback(
@@ -173,7 +170,7 @@ export const usePagination = (
     if (apiRef.current?.isInitialised) {
       apiRef.current.publishEvent(PAGE_CHANGED, stateRef.current);
     }
-  }, [apiRef, stateRef, apiRef.current?.isInitialised]);
+  }, [apiRef, apiRef.current?.isInitialised]);
 
   React.useEffect(() => {
     const rowCount = options.rowCount == null ? rows.length : options.rowCount;

--- a/packages/grid/_modules_/grid/hooks/features/useSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/useSelection.ts
@@ -92,7 +92,6 @@ export const useSelection = (
       forceUpdate((p: any) => !p);
     },
     [
-      forceUpdate,
       apiRef,
       logger,
       selectedItemsRef,
@@ -134,7 +133,7 @@ export const useSelection = (
       };
       apiRef.current.publishEvent(SELECTION_CHANGED, selectionChangeParam);
     },
-    [apiRef, selectedItemsRef, forceUpdate, getSelectedRows],
+    [apiRef, selectedItemsRef, getSelectedRows],
   );
 
   const rowClickHandler = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/root/useEvents.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useEvents.ts
@@ -177,11 +177,11 @@ export function useEvents(
 
   const handleResizeStart = React.useCallback(() => {
     isResizingRef.current = true;
-  }, [isResizingRef]);
+  }, []);
 
   const handleResizeStop = React.useCallback(() => {
     isResizingRef.current = false;
-  }, [isResizingRef]);
+  }, []);
 
   const resize = React.useCallback(() => apiRef.current.publishEvent(RESIZE), [apiRef]);
   const eventsApi: EventsApi = { resize, onUnmount, onResize };

--- a/packages/grid/_modules_/grid/hooks/root/useKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useKeyboard.ts
@@ -45,15 +45,13 @@ const getNextCellIndexes = (code: string, indexes: CellIndexCoordinates) => {
 
 export const useKeyboard = (options: GridOptions, initialised: boolean, apiRef: ApiRef): void => {
   const logger = useLogger('useKeyboard');
-  const isMultipleKeyPressed = React.useRef(false);
   const rafFocusOnCellRef = React.useRef(0);
 
   const onMultipleKeyChange = React.useCallback(
     (isPressed: boolean) => {
-      isMultipleKeyPressed.current = isPressed;
       apiRef.current.publishEvent(MULTIPLE_KEY_PRESS_CHANGED, isPressed);
     },
-    [apiRef, isMultipleKeyPressed],
+    [apiRef],
   );
 
   const navigateCells = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/root/useRows.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useRows.ts
@@ -145,12 +145,9 @@ export const useRows = (
     [updateRowModels, logger, getRowFromId],
   );
 
-  const onSortModelUpdated = React.useCallback(
-    ({ sortModel }: any) => {
-      isSortedRef.current = sortModel.length > 0;
-    },
-    [isSortedRef],
-  );
+  const onSortModelUpdated = React.useCallback(({ sortModel }: any) => {
+    isSortedRef.current = sortModel.length > 0;
+  }, []);
 
   const getRowModels = React.useCallback(() => rowModelsRef.current, [rowModelsRef]);
   const getRowsCount = React.useCallback(() => rowModelsRef.current.length, [rowModelsRef]);

--- a/packages/grid/_modules_/grid/hooks/root/useRows.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useRows.ts
@@ -60,7 +60,7 @@ export const useRows = (
         setRowModelsState(() => allNewRows);
       }
     },
-    [logger, idLookupRef, rowModelsRef, setRowModelsState],
+    [logger, rowModelsRef, setRowModelsState],
   );
 
   React.useEffect(() => {
@@ -69,7 +69,7 @@ export const useRows = (
     updateAllRows(rowModels);
   }, [rows, logger, rowModels, updateAllRows]);
 
-  const getRowsLookup = React.useCallback(() => idLookupRef.current as IdLookup, [idLookupRef]);
+  const getRowsLookup = React.useCallback(() => idLookupRef.current as IdLookup, []);
   const getRowIndexFromId = React.useCallback((id: RowId): number => getRowsLookup()[id], [
     getRowsLookup,
   ]);

--- a/packages/storybook/src/stories/grid-error.stories.tsx
+++ b/packages/storybook/src/stories/grid-error.stories.tsx
@@ -244,12 +244,9 @@ export const OnErrorHandler = () => {
     },
   };
 
-  const onError = React.useCallback(
-    ({ error }) => {
-      setErrorMessage(`Oops! Something went wrong! ${error.message}`);
-    },
-    [setErrorMessage],
-  );
+  const onError = React.useCallback(({ error }) => {
+    setErrorMessage(`Oops! Something went wrong! ${error.message}`);
+  }, []);
 
   return (
     <React.Fragment>

--- a/packages/storybook/src/stories/grid-pagination.stories.tsx
+++ b/packages/storybook/src/stories/grid-pagination.stories.tsx
@@ -236,17 +236,14 @@ export function ServerPaginationWithEventHandler() {
   const [rows, setRows] = React.useState<RowsProp>([]);
   const [loading, setLoading] = React.useState<boolean>(false);
 
-  const onPageChange = React.useCallback(
-    (params) => {
-      action('onPageChange')(params);
-      setLoading(true);
-      loadServerRows(params).then((newData) => {
-        setRows(newData.rows);
-        setLoading(false);
-      });
-    },
-    [setRows, setLoading],
-  );
+  const onPageChange = React.useCallback((params) => {
+    action('onPageChange')(params);
+    setLoading(true);
+    loadServerRows(params).then((newData) => {
+      setRows(newData.rows);
+      setLoading(false);
+    });
+  }, []);
 
   return (
     <div className="grid-container">

--- a/packages/storybook/src/stories/grid-sorting.stories.tsx
+++ b/packages/storybook/src/stories/grid-sorting.stories.tsx
@@ -298,13 +298,10 @@ export const SortedEventsApi = () => {
   const cols = React.useMemo(() => getColumns(), []);
   const [loggedEvents, setEvents] = React.useState<any[]>([]);
 
-  const handleEvent = React.useCallback(
-    (name, params) => {
-      action(name)(params);
-      setEvents((prev: any[]) => [...prev, name]);
-    },
-    [setEvents],
-  );
+  const handleEvent = React.useCallback((name, params) => {
+    action(name)(params);
+    setEvents((prev: any[]) => [...prev, name]);
+  }, []);
 
   React.useEffect(() => {
     apiRef.current.onSortModelChange((params) => handleEvent('onSortModelChange', params));
@@ -337,13 +334,10 @@ export const SortedEventsOptions = () => {
   const cols = React.useMemo(() => getColumns(), []);
   const [loggedEvents, setEvents] = React.useState<any[]>([]);
 
-  const handleEvent = React.useCallback(
-    (name, params) => {
-      action(name)(params);
-      setEvents((prev: any[]) => [...prev, name]);
-    },
-    [setEvents],
-  );
+  const handleEvent = React.useCallback((name, params) => {
+    action(name)(params);
+    setEvents((prev: any[]) => [...prev, name]);
+  }, []);
 
   const onSortModelChange = React.useCallback(
     (params) => handleEvent('onSortModelChange', params),
@@ -418,7 +412,7 @@ export const ServerSideSorting = () => {
       setRows(newRows);
       setLoading(false);
     },
-    [setLoading, rows, setRows],
+    [rows],
   );
 
   // We use `useMemo` here, to keep the same ref and not trigger another sort on the next rendering

--- a/packages/x-license/src/useLicenseVerifier.ts
+++ b/packages/x-license/src/useLicenseVerifier.ts
@@ -21,7 +21,7 @@ export function useLicenseVerifier() {
     } else if (newLicenseStatus === LicenseStatus.Expired) {
       showExpiredLicenseError();
     }
-  }, [setLicenseStatus]);
+  }, []);
 
   return licenseStatus;
 }


### PR DESCRIPTION
The fewer dependencies in the array, the simpler to understand when it updates. Ref, setState, setReducer never change during a mount lifecycle.