### PR TITLE
[XGrid] Second iteration on resizing logic

### DIFF
--- a/packages/grid/_modules_/grid/GridComponent.tsx
+++ b/packages/grid/_modules_/grid/GridComponent.tsx
@@ -94,7 +94,7 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
   );
 
   const onColumnReorder = useColumnReorder(columnsHeaderRef, apiRef);
-  const onResizeColumn = useColumnResize(columnsHeaderRef, apiRef, internalOptions.headerHeight);
+  const separatorProps = useColumnResize(columnsHeaderRef, apiRef);
   const paginationProps = usePagination(internalRows, internalColumns, internalOptions, apiRef);
 
   React.useEffect(() => {
@@ -222,7 +222,7 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
                       ref={columnsHeaderRef}
                       columns={internalColumns.visible || []}
                       hasScrollX={!!renderCtx?.hasScrollX}
-                      onResizeColumn={onResizeColumn}
+                      separatorProps={separatorProps}
                       onColumnHeaderDragOver={onColumnReorder.handleColumnHeaderDragOver}
                       onColumnDragStart={onColumnReorder.handleDragStart}
                       onColumnDragEnter={onColumnReorder.handleDragEnter}

--- a/packages/grid/_modules_/grid/components/AutoSizer.tsx
+++ b/packages/grid/_modules_/grid/components/AutoSizer.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { useForkRef, ownerWindow, useEventCallback } from '@material-ui/core/utils';
+import { useForkRef, ownerWindow } from '@material-ui/core/utils';
+import { useEventCallback } from '../utils/material-ui-utils';
 import createDetectElementResize from '../lib/createDetectElementResize';
 // TODO replace with https://caniuse.com/resizeobserver.
 
@@ -118,7 +119,6 @@ export const AutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>(functi
 
     const detectElementResize = createDetectElementResize(nonce, win);
     detectElementResize.addResizeListener(parentElement.current, handleResize);
-    // @ts-expect-error fixed in v5
     handleResize();
 
     return () => {

--- a/packages/grid/_modules_/grid/components/column-header-item.tsx
+++ b/packages/grid/_modules_/grid/components/column-header-item.tsx
@@ -36,11 +36,14 @@ export const ColumnHeaderItem = React.memo((props: ColumnHeaderItemProps) => {
   );
 
   const [resizing, setResizing] = React.useState(false);
-  const handleResizeStart = React.useCallback((params) => {
-    if (column.field === params.field) {
-      setResizing(true);
-    }
-  }, [column.field]);
+  const handleResizeStart = React.useCallback(
+    (params) => {
+      if (column.field === params.field) {
+        setResizing(true);
+      }
+    },
+    [column.field],
+  );
   const handleResizeStop = React.useCallback(() => {
     setResizing(false);
   }, []);

--- a/packages/grid/_modules_/grid/components/column-header-item.tsx
+++ b/packages/grid/_modules_/grid/components/column-header-item.tsx
@@ -1,8 +1,11 @@
 import * as React from 'react';
 import { ColDef } from '../models/colDef';
+import { ApiRef } from '../models/api';
 import { ApiContext } from './api-context';
 import { HEADER_CELL_CSS_CLASS } from '../constants/cssClassesConstants';
+import { COL_RESIZE_START, COL_RESIZE_STOP } from '../constants/eventsConstants';
 import { classnames } from '../utils';
+import { useApiEventHandler } from '../hooks/root/useApiEventHandler';
 import { ColumnHeaderSortIcon } from './column-header-sort-icon';
 import { ColumnHeaderTitle } from './column-header-title';
 import { ColumnHeaderSeparator } from './column-header-separator';
@@ -10,111 +13,122 @@ import { OptionsContext } from './options-context';
 import { CursorCoordinates } from '../hooks/features/useColumnReorder';
 
 interface ColumnHeaderItemProps {
-  column: ColDef;
   colIndex: number;
-  onResizeColumn?: (c: any) => void;
-  onColumnDragStart?: (col: ColDef, currentTarget: HTMLElement) => void;
+  column: ColDef;
   onColumnDragEnter?: (event: Event) => void;
   onColumnDragOver?: (col: ColDef, coordinates: CursorCoordinates) => void;
+  onColumnDragStart?: (col: ColDef, currentTarget: HTMLElement) => void;
+  separatorProps: React.HTMLAttributes<HTMLDivElement>;
 }
 
-export const ColumnHeaderItem = React.memo(
-  ({
-    column,
+export const ColumnHeaderItem = React.memo((props: ColumnHeaderItemProps) => {
+  const {
     colIndex,
-    onResizeColumn,
-    onColumnDragStart,
+    column,
     onColumnDragEnter,
     onColumnDragOver,
-  }: ColumnHeaderItemProps) => {
-    const api = React.useContext(ApiContext);
-    const { showColumnRightBorder, disableColumnResize, disableColumnReorder } = React.useContext(
-      OptionsContext,
-    );
+    onColumnDragStart,
+    separatorProps,
+  } = props;
+  const apiRef = React.useContext(ApiContext) as ApiRef;
+  const { showColumnRightBorder, disableColumnResize, disableColumnReorder } = React.useContext(
+    OptionsContext,
+  );
 
-    let headerComponent: React.ReactElement | null = null;
-    if (column.renderHeader) {
-      headerComponent = column.renderHeader({
-        api: api!.current!,
-        colDef: column,
-        colIndex,
-        field: column.field,
-      });
+  const [resizing, setResizing] = React.useState(false);
+  const handleResizeStart = React.useCallback((params) => {
+    if (column.field === params.field) {
+      setResizing(true);
     }
+  }, [column.field]);
+  const handleResizeStop = React.useCallback(() => {
+    setResizing(false);
+  }, []);
+  useApiEventHandler(apiRef, COL_RESIZE_START, handleResizeStart);
+  useApiEventHandler(apiRef, COL_RESIZE_STOP, handleResizeStop);
 
-    const handleResize = onResizeColumn && (() => onResizeColumn(column));
-    const dragConfig = {
-      draggable:
-        !disableColumnReorder && !!onColumnDragStart && !!onColumnDragEnter && !!onColumnDragOver,
-      onDragStart: onColumnDragStart && ((event) => onColumnDragStart(column, event.currentTarget)),
-      onDragEnter: onColumnDragEnter && ((event) => onColumnDragEnter(event)),
-      onDragOver:
-        onColumnDragOver &&
-        ((event) => {
-          onColumnDragOver(column, {
-            x: event.clientX,
-            y: event.clientY,
-          });
-        }),
-    };
-    const width = column.width!;
+  let headerComponent: React.ReactElement | null = null;
+  if (column.renderHeader) {
+    headerComponent = column.renderHeader({
+      api: apiRef.current!,
+      colDef: column,
+      colIndex,
+      field: column.field,
+    });
+  }
 
-    let ariaSort: any;
-    if (column.sortDirection != null) {
-      ariaSort = { 'aria-sort': column.sortDirection === 'asc' ? 'ascending' : 'descending' };
-    }
+  const dragConfig = {
+    draggable:
+      !disableColumnReorder && !!onColumnDragStart && !!onColumnDragEnter && !!onColumnDragOver,
+    onDragStart: onColumnDragStart && ((event) => onColumnDragStart(column, event.currentTarget)),
+    onDragEnter: onColumnDragEnter && ((event) => onColumnDragEnter(event)),
+    onDragOver:
+      onColumnDragOver &&
+      ((event) => {
+        onColumnDragOver(column, {
+          x: event.clientX,
+          y: event.clientY,
+        });
+      }),
+  };
+  const width = column.width!;
 
-    return (
-      <div
-        className={classnames(
-          HEADER_CELL_CSS_CLASS,
-          showColumnRightBorder ? 'MuiDataGrid-withBorder' : '',
-          column.headerClassName,
-          column.headerAlign === 'center' && 'MuiDataGrid-colCellCenter',
-          column.headerAlign === 'right' && 'MuiDataGrid-colCellRight',
-          { 'MuiDataGrid-colCellSortable': column.sortable },
+  let ariaSort: any;
+  if (column.sortDirection != null) {
+    ariaSort = { 'aria-sort': column.sortDirection === 'asc' ? 'ascending' : 'descending' };
+  }
+
+  return (
+    <div
+      className={classnames(
+        HEADER_CELL_CSS_CLASS,
+        showColumnRightBorder ? 'MuiDataGrid-withBorder' : '',
+        column.headerClassName,
+        column.headerAlign === 'center' && 'MuiDataGrid-colCellCenter',
+        column.headerAlign === 'right' && 'MuiDataGrid-colCellRight',
+        { 'MuiDataGrid-colCellSortable': column.sortable },
+      )}
+      key={column.field}
+      data-field={column.field}
+      style={{
+        width,
+        minWidth: width,
+        maxWidth: width,
+      }}
+      role="columnheader"
+      tabIndex={-1}
+      aria-colindex={colIndex + 1}
+      {...ariaSort}
+    >
+      <div className="MuiDataGrid-colCell-draggable" {...dragConfig}>
+        {column.type === 'number' && (
+          <ColumnHeaderSortIcon
+            direction={column.sortDirection}
+            index={column.sortIndex}
+            hide={column.hideSortIcons}
+          />
         )}
-        key={column.field}
-        data-field={column.field}
-        style={{
-          width,
-          minWidth: width,
-          maxWidth: width,
-        }}
-        role="columnheader"
-        tabIndex={-1}
-        aria-colindex={colIndex + 1}
-        {...ariaSort}
-      >
-        <div className="MuiDataGrid-colCell-draggable" {...dragConfig}>
-          {column.type === 'number' && (
-            <ColumnHeaderSortIcon
-              direction={column.sortDirection}
-              index={column.sortIndex}
-              hide={column.hideSortIcons}
-            />
-          )}
-          {headerComponent || (
-            <ColumnHeaderTitle
-              label={column.headerName || column.field}
-              description={column.description}
-              columnWidth={width}
-            />
-          )}
-          {column.type !== 'number' && (
-            <ColumnHeaderSortIcon
-              direction={column.sortDirection}
-              index={column.sortIndex}
-              hide={column.hideSortIcons}
-            />
-          )}
-        </div>
-        <ColumnHeaderSeparator
-          resizable={!disableColumnResize && column.resizable}
-          onResize={handleResize}
-        />
+        {headerComponent || (
+          <ColumnHeaderTitle
+            label={column.headerName || column.field}
+            description={column.description}
+            columnWidth={width}
+          />
+        )}
+        {column.type !== 'number' && (
+          <ColumnHeaderSortIcon
+            direction={column.sortDirection}
+            index={column.sortIndex}
+            hide={column.hideSortIcons}
+          />
+        )}
       </div>
-    );
-  },
-);
+      <ColumnHeaderSeparator
+        resizable={disableColumnResize ? false : Boolean(column.resizable)}
+        resizing={resizing}
+        {...separatorProps}
+      />
+    </div>
+  );
+});
 ColumnHeaderItem.displayName = 'ColumnHeaderItem';

--- a/packages/grid/_modules_/grid/components/column-header-separator.tsx
+++ b/packages/grid/_modules_/grid/components/column-header-separator.tsx
@@ -1,32 +1,31 @@
 import * as React from 'react';
 import { useIcons } from '../hooks/utils/useIcons';
+import { classnames } from '../utils';
 import { OptionsContext } from './options-context';
 
-export interface ColumnHeaderSeparatorProps {
-  resizable: boolean | undefined;
-  onResize?: () => void;
+export interface ColumnHeaderSeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  resizable: boolean;
+  resizing: boolean;
 }
 
-export const ColumnHeaderSeparator: React.FC<ColumnHeaderSeparatorProps> = React.memo(
-  ({ onResize, resizable }) => {
-    const icons = useIcons();
-    const { showColumnRightBorder, headerHeight } = React.useContext(OptionsContext);
+export const ColumnHeaderSeparator = React.memo(function ColumnHeaderSeparator(
+  props: ColumnHeaderSeparatorProps,
+) {
+  const { resizable, resizing, ...other } = props;
+  const icons = useIcons();
+  const { showColumnRightBorder, headerHeight } = React.useContext(OptionsContext);
+  const Icon = icons!.columnResize!;
 
-    const resizeIconProps = {
-      className: `MuiDataGrid-iconSeparator ${resizable ? 'MuiDataGrid-resizable' : ''}`,
-      ...(resizable && onResize ? { onMouseDown: onResize } : {}),
-    };
-
-    const icon = React.createElement(icons!.columnResize!, resizeIconProps);
-
-    return (
-      <div
-        className="MuiDataGrid-columnSeparator"
-        style={{ minHeight: headerHeight, opacity: showColumnRightBorder ? 0 : 1 }}
-      >
-        {icon}
-      </div>
-    );
-  },
-);
-ColumnHeaderSeparator.displayName = 'ColumnHeaderSeparator';
+  return (
+    <div
+      className={classnames('MuiDataGrid-columnSeparator', {
+        'MuiDataGrid-columnSeparatorResizable': resizable,
+        'Mui-resizing': resizing,
+      })}
+      style={{ minHeight: headerHeight, opacity: showColumnRightBorder ? 0 : 1 }}
+      {...other}
+    >
+      <Icon className="MuiDataGrid-iconSeparator" />
+    </div>
+  );
+});

--- a/packages/grid/_modules_/grid/components/column-headers.tsx
+++ b/packages/grid/_modules_/grid/components/column-headers.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { ColDef, Columns, RenderContextProps } from '../models';
+import { Columns, RenderContextProps } from '../models';
+import { ColDef } from '../models/colDef';
 import { ColumnHeaderItem } from './column-header-item';
 import { ApiContext } from './api-context';
 import { LeftEmptyCell, RightEmptyCell } from './cell';
@@ -9,34 +10,35 @@ import { CursorCoordinates } from '../hooks';
 
 export interface ColumnHeadersItemCollectionProps {
   columns: Columns;
-  onResizeColumn?: (col: ColDef) => void;
-  onColumnDragStart?: (col: ColDef, htmlEL: HTMLElement) => void;
   onColumnDragEnter?: (event: Event) => void;
   onColumnDragOver?: (col: ColDef, pos: CursorCoordinates) => void;
+  onColumnDragStart?: (col: ColDef, htmlEL: HTMLElement) => void;
+  separatorProps: React.HTMLAttributes<HTMLDivElement>;
 }
-export const ColumnHeaderItemCollection: React.FC<ColumnHeadersItemCollectionProps> = React.memo(
-  ({ onResizeColumn, onColumnDragStart, onColumnDragEnter, onColumnDragOver, columns }) => {
-    const items = columns.map((col, idx) => (
-      <ColumnHeaderItem
-        key={col.field}
-        column={col}
-        colIndex={idx}
-        onResizeColumn={onResizeColumn}
-        onColumnDragStart={onColumnDragStart}
-        onColumnDragEnter={onColumnDragEnter}
-        onColumnDragOver={onColumnDragOver}
-      />
-    ));
 
-    return <React.Fragment>{items}</React.Fragment>;
-  },
-);
-ColumnHeaderItemCollection.displayName = 'ColumnHeaderItemCollection';
+export const ColumnHeaderItemCollection = React.memo(function ColumnHeaderItemCollection(
+  props: ColumnHeadersItemCollectionProps,
+) {
+  const { separatorProps, onColumnDragStart, onColumnDragEnter, onColumnDragOver, columns } = props;
+  const items = columns.map((col, idx) => (
+    <ColumnHeaderItem
+      key={col.field}
+      column={col}
+      colIndex={idx}
+      separatorProps={separatorProps}
+      onColumnDragStart={onColumnDragStart}
+      onColumnDragEnter={onColumnDragEnter}
+      onColumnDragOver={onColumnDragOver}
+    />
+  ));
+
+  return <React.Fragment>{items}</React.Fragment>;
+});
 
 export interface ColumnsHeaderProps {
   columns: Columns;
   hasScrollX: boolean;
-  onResizeColumn?: (col: ColDef) => void;
+  separatorProps: React.HTMLAttributes<HTMLDivElement>;
   onColumnHeaderDragOver?: (event: Event) => void;
   onColumnDragOver?: (col: ColDef, pos: CursorCoordinates) => void;
   onColumnDragStart?: (col: ColDef, htmlEl: HTMLElement) => void;
@@ -45,80 +47,76 @@ export interface ColumnsHeaderProps {
 }
 
 export const ColumnsHeader = React.memo(
-  React.forwardRef<HTMLDivElement, ColumnsHeaderProps>(
-    (
-      {
-        columns,
-        hasScrollX,
-        onResizeColumn,
-        onColumnHeaderDragOver,
-        onColumnDragOver,
-        onColumnDragStart,
-        onColumnDragEnter,
-        renderCtx,
-      },
-      ref,
-    ) => {
-      const wrapperCssClasses = `MuiDataGrid-colCellWrapper ${hasScrollX ? 'scroll' : ''}`;
-      const api = React.useContext(ApiContext);
-      const { disableColumnReorder } = React.useContext(OptionsContext);
+  React.forwardRef<HTMLDivElement, ColumnsHeaderProps>((props, ref) => {
+    const {
+      columns,
+      hasScrollX,
+      onColumnDragEnter,
+      onColumnDragOver,
+      onColumnDragStart,
+      onColumnHeaderDragOver,
+      renderCtx,
+      separatorProps,
+    } = props;
+    const wrapperCssClasses = `MuiDataGrid-colCellWrapper ${hasScrollX ? 'scroll' : ''}`;
+    const api = React.useContext(ApiContext);
+    const { disableColumnReorder } = React.useContext(OptionsContext);
 
-      if (!api) {
-        throw new Error('Material-UI: ApiRef was not found in context.');
-      }
-      const lastRenderedColIndexes = React.useRef({
-        first: renderCtx?.firstColIdx,
-        last: renderCtx?.lastColIdx,
-      });
-      const [renderedCols, setRenderedCols] = React.useState(columns);
+    if (!api) {
+      throw new Error('Material-UI: ApiRef was not found in context.');
+    }
+    const lastRenderedColIndexes = React.useRef({
+      first: renderCtx?.firstColIdx,
+      last: renderCtx?.lastColIdx,
+    });
+    const [renderedCols, setRenderedCols] = React.useState(columns);
 
-      React.useEffect(() => {
-        if (renderCtx && renderCtx.firstColIdx != null && renderCtx.lastColIdx != null) {
-          setRenderedCols(columns.slice(renderCtx.firstColIdx, renderCtx.lastColIdx + 1));
+    React.useEffect(() => {
+      if (renderCtx && renderCtx.firstColIdx != null && renderCtx.lastColIdx != null) {
+        setRenderedCols(columns.slice(renderCtx.firstColIdx, renderCtx.lastColIdx + 1));
 
-          if (
-            lastRenderedColIndexes.current.first !== renderCtx.firstColIdx ||
-            lastRenderedColIndexes.current.last !== renderCtx.lastColIdx
-          ) {
-            lastRenderedColIndexes.current = {
-              first: renderCtx.firstColIdx,
-              last: renderCtx.lastColIdx,
-            };
-          }
+        if (
+          lastRenderedColIndexes.current.first !== renderCtx.firstColIdx ||
+          lastRenderedColIndexes.current.last !== renderCtx.lastColIdx
+        ) {
+          lastRenderedColIndexes.current = {
+            first: renderCtx.firstColIdx,
+            last: renderCtx.lastColIdx,
+          };
         }
-      }, [renderCtx, columns]);
+      }
+    }, [renderCtx, columns]);
 
-      const handleDragOver =
-        onColumnHeaderDragOver && !disableColumnReorder
-          ? (event) => onColumnHeaderDragOver(event)
-          : undefined;
+    const handleDragOver =
+      onColumnHeaderDragOver && !disableColumnReorder
+        ? (event) => onColumnHeaderDragOver(event)
+        : undefined;
 
-      return (
-        <React.Fragment>
-          <ScrollArea scrollDirection="left" />
-          <div
-            ref={ref}
-            className={wrapperCssClasses}
-            aria-rowindex={1}
-            tabIndex={0}
-            role="row"
-            style={{ minWidth: renderCtx?.totalSizes?.width }}
-            onDragOver={handleDragOver}
-          >
-            <LeftEmptyCell width={renderCtx?.leftEmptyWidth} />
-            <ColumnHeaderItemCollection
-              columns={renderedCols}
-              onResizeColumn={onResizeColumn}
-              onColumnDragStart={onColumnDragStart}
-              onColumnDragOver={onColumnDragOver}
-              onColumnDragEnter={onColumnDragEnter}
-            />
-            <RightEmptyCell width={renderCtx?.rightEmptyWidth} />
-          </div>
-          <ScrollArea scrollDirection="right" />
-        </React.Fragment>
-      );
-    },
-  ),
+    return (
+      <React.Fragment>
+        <ScrollArea scrollDirection="left" />
+        <div
+          ref={ref}
+          className={wrapperCssClasses}
+          aria-rowindex={1}
+          tabIndex={0}
+          role="row"
+          style={{ minWidth: renderCtx?.totalSizes?.width }}
+          onDragOver={handleDragOver}
+        >
+          <LeftEmptyCell width={renderCtx?.leftEmptyWidth} />
+          <ColumnHeaderItemCollection
+            columns={renderedCols}
+            onColumnDragStart={onColumnDragStart}
+            onColumnDragOver={onColumnDragOver}
+            onColumnDragEnter={onColumnDragEnter}
+            separatorProps={separatorProps}
+          />
+          <RightEmptyCell width={renderCtx?.rightEmptyWidth} />
+        </div>
+        <ScrollArea scrollDirection="right" />
+      </React.Fragment>
+    );
+  }),
 );
 ColumnsHeader.displayName = 'GridColumnsHeader';

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -120,12 +120,15 @@ export const useStyles = makeStyles(
           display: 'flex',
           flexDirection: 'column',
           justifyContent: 'center',
-        },
-        '& .MuiDataGrid-iconSeparator': {
           color: borderColor,
         },
-        '& .MuiDataGrid-columnSeparator:hover .MuiDataGrid-resizable': {
+        '& .MuiDataGrid-columnSeparatorResizable': {
           cursor: 'col-resize',
+          '&:hover, &.Mui-resizing': {
+            color: theme.palette.text.primary,
+          },
+        },
+        '& .MuiDataGrid-iconSeparator': {
           color: 'inherit',
         },
         '& .MuiDataGrid-colCellWrapper.scroll .MuiDataGrid-colCell:last-child': {

--- a/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
@@ -72,6 +72,7 @@ export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, api
       return;
     }
 
+    // Skip if the column isn't resizable
     if (!event.currentTarget.classList.contains('MuiDataGrid-columnSeparatorResizable')) {
       return;
     }

--- a/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { useEventCallback, ownerDocument } from '@material-ui/core/utils';
+import { ownerDocument } from '@material-ui/core/utils';
 import { ColDef } from '../../models/colDef';
 import { useLogger } from '../utils';
+import { useEventCallback } from '../../utils/material-ui-utils';
 import { COL_RESIZE_START, COL_RESIZE_STOP } from '../../constants/eventsConstants';
 import { HEADER_CELL_CSS_CLASS } from '../../constants/cssClassesConstants';
 import { findCellElementsFromCol } from '../../utils';
@@ -53,8 +54,7 @@ export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, api
   const handleResizeMouseMove = useEventCallback((nativeEvent) => {
     // Cancel move in case some other element consumed a mouseup event and it was not fired.
     if (nativeEvent.buttons === 0) {
-      // @ts-expect-error fixed in v5
-      handleResizeMouseUp(nativeEvent);
+      handleResizeMouseUp();
       return;
     }
 
@@ -105,18 +105,14 @@ export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, api
       (colDefRef.current.width as number) -
       (event.clientX - colElementRef.current!.getBoundingClientRect().left);
 
-    // @ts-expect-error fixed in v5
     doc.addEventListener('mousemove', handleResizeMouseMove);
-    // @ts-expect-error fixed in v5
     doc.addEventListener('mouseup', handleResizeMouseUp);
   });
 
   const stopListening = React.useCallback(() => {
     const doc = ownerDocument(apiRef.current.rootElementRef!.current as HTMLElement);
     doc.body.style.removeProperty('cursor');
-    // @ts-expect-error fixed in v5
     doc.removeEventListener('mousemove', handleResizeMouseMove);
-    // @ts-expect-error fixed in v5
     doc.removeEventListener('mouseup', handleResizeMouseUp);
   }, [apiRef, handleResizeMouseMove, handleResizeMouseUp]);
 
@@ -127,7 +123,5 @@ export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, api
     };
   }, [stopListening]);
 
-  return React.useMemo(() => ({ onMouseDown: handleMouseDown }), [
-    handleMouseDown,
-  ]) as React.HTMLAttributes<HTMLDivElement>;
+  return React.useMemo(() => ({ onMouseDown: handleMouseDown }), [handleMouseDown]);
 };

--- a/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
@@ -1,204 +1,130 @@
 import * as React from 'react';
+import { useEventCallback, ownerDocument } from '@material-ui/core/utils';
 import { ColDef } from '../../models/colDef';
-import { ScrollParams, useLogger } from '../utils';
-import { COL_RESIZE_START, COL_RESIZE_STOP, SCROLLING } from '../../constants/eventsConstants';
-import { findCellElementsFromCol, findDataContainerFromCurrent } from '../../utils';
-import { useStateRef } from '../utils/useStateRef';
+import { useLogger } from '../utils';
+import { COL_RESIZE_START, COL_RESIZE_STOP } from '../../constants/eventsConstants';
+import { HEADER_CELL_CSS_CLASS } from '../../constants/cssClassesConstants';
+import { findCellElementsFromCol } from '../../utils';
 import { ApiRef } from '../../models';
 
 const MIN_COL_WIDTH = 50;
-const MOUSE_LEFT_TIMEOUT = 1000;
 
-// TODO improve experience for last column
-export const useColumnResize = (
-  columnsRef: React.RefObject<HTMLDivElement>,
-  apiRef: ApiRef,
-  headerHeight: number,
-) => {
+export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, apiRef: ApiRef) => {
   const logger = useLogger('useColumnResize');
+  const colDefRef = React.useRef<ColDef>();
+  const colElementRef = React.useRef<HTMLDivElement>();
+  const colCellElementsRef = React.useRef<NodeListOf<Element>>();
+  const initialOffset = React.useRef<number>();
+  const stopResizeEventTimeout = React.useRef<number>();
 
-  const isResizing = React.useRef<boolean>(false);
-  const isLastColumn = React.useRef<boolean>(false);
-  const mouseLeftTimeout = React.useRef<any>();
-  const stopResizeEventTimeout = React.useRef<any>();
+  const updateWidth = (newWidth: number) => {
+    logger.debug(`Updating width to ${newWidth} for col ${colDefRef.current!.field}`);
 
-  const currentColDefRef = React.useRef<ColDef>();
-  const currentColElem = React.useRef<HTMLDivElement>();
-  const currentColPosition = React.useRef<number>();
-  const currentColPreviousWidth = React.useRef<number>();
-  const currentColCellsElems = React.useRef<NodeListOf<Element>>();
+    colDefRef.current!.width = newWidth;
 
-  const dataContainerElemRef = React.useRef<HTMLDivElement>();
-  const dataContainerPreviousWidth = React.useRef<number>();
-  const scrollOffset = React.useRef<number>(0);
-  const resizingMouseMove = React.useRef<{ x: number; y: number }>();
+    colElementRef.current!.style.width = `${newWidth}px`;
+    colElementRef.current!.style.minWidth = `${newWidth}px`;
+    colElementRef.current!.style.maxWidth = `${newWidth}px`;
 
-  const onScrollHandler = React.useCallback((params: ScrollParams) => {
-    scrollOffset.current = params.left;
-  }, []);
+    colCellElementsRef.current!.forEach((element) => {
+      const div = element as HTMLDivElement;
+      div.style.width = `${newWidth}px`;
+      div.style.minWidth = `${newWidth}px`;
+      div.style.maxWidth = `${newWidth}px`;
+    });
+  };
 
-  React.useEffect(() => {
-    return apiRef.current.subscribeEvent(SCROLLING, onScrollHandler);
-  }, [apiRef, onScrollHandler]);
+  const handleResizeMouseUp = useEventCallback(() => {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    stopListening();
 
-  const handleMouseDown = React.useCallback(
-    (col: ColDef): void => {
-      logger.debug(`Start Resize on col ${col.field}`);
-      apiRef.current.publishEvent(COL_RESIZE_START);
-      isResizing.current = true;
-      currentColDefRef.current = col;
-      currentColPreviousWidth.current = col.width;
-      currentColElem.current = columnsRef?.current?.querySelector(
-        `[data-field="${col.field}"]`,
-      ) as HTMLDivElement;
-      currentColCellsElems.current = findCellElementsFromCol(currentColElem.current) || undefined;
-      dataContainerElemRef.current =
-        findDataContainerFromCurrent(currentColElem.current) || undefined;
-      dataContainerPreviousWidth.current = Number(
-        dataContainerElemRef.current!.style.minWidth.replace('px', ''),
-      );
-      currentColPosition.current = apiRef.current.getColumnPosition(col.field);
-      isLastColumn.current =
-        apiRef.current.getColumnIndex(col.field) === apiRef.current.getVisibleColumns().length - 1;
-    },
-    [apiRef, columnsRef, logger],
-  );
+    apiRef.current!.updateColumn(colDefRef.current as ColDef);
 
-  const stopResize = React.useCallback((): void => {
-    isResizing.current = false;
-    currentColPosition.current = undefined;
-    currentColElem.current = undefined;
-    currentColCellsElems.current = undefined;
-    resizingMouseMove.current = undefined;
-    isLastColumn.current = false;
-    if (currentColDefRef.current) {
-      logger.debug(
-        `Updating col ${currentColDefRef.current.field} with new width: ${currentColDefRef.current.width}`,
-      );
-      apiRef?.current?.updateColumn(currentColDefRef.current);
-      currentColDefRef.current = undefined;
-    }
-
+    clearTimeout(stopResizeEventTimeout.current);
     stopResizeEventTimeout.current = setTimeout(() => {
       apiRef.current.publishEvent(COL_RESIZE_STOP);
-    }, 200);
-  }, [apiRef, logger]);
+    });
 
-  const updateWidth = React.useCallback(
-    (newWidth: number) => {
-      logger.debug(`Updating width to ${newWidth} for col ${currentColDefRef.current!.field}`);
-      if (currentColDefRef.current) {
-        currentColDefRef.current.width = newWidth;
-      }
-      if (currentColElem.current) {
-        currentColElem.current.style.width = `${newWidth}px`;
-        currentColElem.current.style.minWidth = `${newWidth}px`;
-        currentColElem.current.style.maxWidth = `${newWidth}px`;
-      }
-      if (dataContainerElemRef.current) {
-        const diffWithPrev = newWidth - currentColPreviousWidth.current!;
-        dataContainerElemRef.current.style.minWidth = `${
-          dataContainerPreviousWidth.current! + diffWithPrev
-        }px`;
+    logger.debug(
+      `Updating col ${colDefRef.current!.field} with new width: ${colDefRef.current!.width}`,
+    );
+  });
 
-        if (isLastColumn.current) {
-          apiRef.current.scroll({ left: dataContainerPreviousWidth.current! + diffWithPrev });
-        }
-      }
-      if (currentColCellsElems.current) {
-        currentColCellsElems.current.forEach((el) => {
-          const div = el as HTMLDivElement;
-          div.style.width = `${newWidth}px`;
-          div.style.minWidth = `${newWidth}px`;
-          div.style.maxWidth = `${newWidth}px`;
-        });
-      }
-    },
-    [apiRef, logger],
-  );
-
-  const handleMouseEnter = React.useCallback((): void => {
-    if (mouseLeftTimeout.current != null) {
-      clearTimeout(mouseLeftTimeout.current);
+  const handleResizeMouseMove = useEventCallback((nativeEvent) => {
+    // Cancel move in case some other element consumed a mouseup event and it was not fired.
+    if (nativeEvent.buttons === 0) {
+      // @ts-expect-error fixed in v5
+      handleResizeMouseUp(nativeEvent);
+      return;
     }
-  }, []);
-  const handleMouseLeave = React.useCallback((): void => {
-    if (
-      isLastColumn.current &&
-      resizingMouseMove.current &&
-      resizingMouseMove.current.y >= 0 &&
-      resizingMouseMove.current.y <= headerHeight &&
-      currentColDefRef.current
-    ) {
-      logger.debug(`Mouse left and same row, so extending last column width of 100`);
 
-      // we are resizing the last column outside the window
-      updateWidth(currentColDefRef.current.width! + 10);
-      mouseLeftTimeout.current = setTimeout(() => {
-        stopResize();
-      }, MOUSE_LEFT_TIMEOUT);
-    } else if (isResizing) {
-      mouseLeftTimeout.current = setTimeout(() => {
-        stopResize();
-      }, MOUSE_LEFT_TIMEOUT);
+    let newWidth =
+      initialOffset.current +
+      nativeEvent.clientX -
+      colElementRef.current!.getBoundingClientRect().left;
+    newWidth = Math.max(MIN_COL_WIDTH, newWidth);
+
+    updateWidth(newWidth);
+  });
+  const handleMouseDown = useEventCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    // Only handle left clicks
+    if (event.button !== 0) {
+      return;
     }
-  }, [headerHeight, logger, stopResize, updateWidth]);
 
-  const handleMouseMove = React.useCallback(
-    (ev: MouseEvent): void => {
-      if (isResizing.current) {
-        const target = ev.currentTarget! as HTMLDivElement;
-        const rect = target.getBoundingClientRect();
-
-        resizingMouseMove.current = { x: ev.clientX - rect.left, y: ev.clientY - rect.top };
-
-        const offsetLeft = !isLastColumn.current ? rect.left : scrollOffset.current * -1;
-
-        let newWidth = ev.clientX - offsetLeft - currentColPosition.current!;
-        newWidth = newWidth > MIN_COL_WIDTH ? newWidth : MIN_COL_WIDTH;
-        updateWidth(newWidth);
-      }
-    },
-    [updateWidth],
-  );
-
-  // This a hack due to the limitation of react as I cannot put columnsRef in the dependency array of the effect adding the Event listener
-  const columnsRefState = useStateRef(columnsRef);
-
-  React.useEffect(() => {
-    if (columnsRef && columnsRef.current) {
-      logger.info('Adding resizing event listener');
-      const columnsRefEvents = columnsRef.current;
-      columnsRef.current.addEventListener('mouseup', stopResize);
-      columnsRef.current.addEventListener('mouseleave', handleMouseLeave);
-      columnsRef.current.addEventListener('mouseenter', handleMouseEnter);
-      columnsRef.current.addEventListener('mousemove', handleMouseMove);
-
-      return () => {
-        columnsRefEvents.removeEventListener('mouseup', stopResize);
-        columnsRefEvents.removeEventListener('mouseleave', handleMouseLeave);
-        columnsRefEvents.removeEventListener('mouseenter', handleMouseEnter);
-        columnsRefEvents.removeEventListener('mousemove', handleMouseMove);
-      };
+    if (!event.currentTarget.classList.contains('MuiDataGrid-columnSeparatorResizable')) {
+      return;
     }
-    return undefined;
-  }, [
-    columnsRefState,
-    columnsRef,
-    handleMouseLeave,
-    handleMouseDown,
-    handleMouseMove,
-    handleMouseEnter,
-    logger,
-    stopResize,
-  ]);
+
+    // Avoid text selection
+    event.preventDefault();
+
+    colElementRef.current = event.currentTarget.closest(
+      `.${HEADER_CELL_CSS_CLASS}`,
+    ) as HTMLDivElement;
+    const field = colElementRef.current.getAttribute('data-field') as string;
+    const colDef = apiRef.current.getColumnFromField(field);
+
+    logger.debug(`Start Resize on col ${colDef.field}`);
+    apiRef.current.publishEvent(COL_RESIZE_START, { field });
+
+    colDefRef.current = colDef;
+    colElementRef.current = columnsRef.current!.querySelector(
+      `[data-field="${colDef.field}"]`,
+    ) as HTMLDivElement;
+
+    colCellElementsRef.current = findCellElementsFromCol(colElementRef.current) as NodeListOf<
+      Element
+    >;
+
+    const doc = ownerDocument(apiRef.current.rootElementRef!.current as HTMLElement);
+    doc.body.style.cursor = 'col-resize';
+
+    initialOffset.current =
+      (colDefRef.current.width as number) -
+      (event.clientX - colElementRef.current!.getBoundingClientRect().left);
+
+    // @ts-expect-error fixed in v5
+    doc.addEventListener('mousemove', handleResizeMouseMove);
+    // @ts-expect-error fixed in v5
+    doc.addEventListener('mouseup', handleResizeMouseUp);
+  });
+
+  const stopListening = React.useCallback(() => {
+    const doc = ownerDocument(apiRef.current.rootElementRef!.current as HTMLElement);
+    doc.body.style.removeProperty('cursor');
+    // @ts-expect-error fixed in v5
+    doc.removeEventListener('mousemove', handleResizeMouseMove);
+    // @ts-expect-error fixed in v5
+    doc.removeEventListener('mouseup', handleResizeMouseUp);
+  }, [apiRef, handleResizeMouseMove, handleResizeMouseUp]);
 
   React.useEffect(() => {
     return () => {
-      clearTimeout(mouseLeftTimeout.current);
       clearTimeout(stopResizeEventTimeout.current);
+      stopListening();
     };
-  }, []);
+  }, [stopListening]);
 
-  return handleMouseDown;
+  return React.useMemo(() => ({ onMouseDown: handleMouseDown }), [handleMouseDown]) as {};
 };

--- a/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/useColumnResize.tsx
@@ -127,5 +127,7 @@ export const useColumnResize = (columnsRef: React.RefObject<HTMLDivElement>, api
     };
   }, [stopListening]);
 
-  return React.useMemo(() => ({ onMouseDown: handleMouseDown }), [handleMouseDown]) as {};
+  return React.useMemo(() => ({ onMouseDown: handleMouseDown }), [
+    handleMouseDown,
+  ]) as React.HTMLAttributes<HTMLDivElement>;
 };

--- a/packages/grid/_modules_/grid/utils/material-ui-utils.ts
+++ b/packages/grid/_modules_/grid/utils/material-ui-utils.ts
@@ -1,0 +1,6 @@
+import { useEventCallback as muiUseEventCallback } from '@material-ui/core/utils';
+
+export function useEventCallback<T extends (...args: any[]) => any>(func: T): T {
+  // @ts-expect-error TODO remove wrapper once upgraded to v5
+  return muiUseEventCallback(func);
+}


### PR DESCRIPTION
- Fix #177
- Fix #191
- Fix #209
- Fix initial mouse move width jump

![jump](https://user-images.githubusercontent.com/3165635/95688320-ae185000-0c09-11eb-8f15-0582c4def0f0.gif)

- Fix scrolling on the last column

![scroll](https://user-images.githubusercontent.com/3165635/95688378-16673180-0c0a-11eb-8f6e-7dc02d4d8f98.gif)

- Fix alternatives button clicks, e.g. if you click on the previous page button while your mouse is over the dragging area, it fails.

- Fix interaction area, the whole separator should be interactive

![zone](https://user-images.githubusercontent.com/3165635/96237399-8f191580-0f9d-11eb-8d84-870883392112.gif)

- Fix keep resizing even after releasing the mouse

![keep resizing](https://user-images.githubusercontent.com/3165635/96197735-2efd8180-0f53-11eb-81f1-9d53623c32dc.gif)
