### PR TITLE
[DataGrid] Fix iOS issue when scrolling left

### DIFF
--- a/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
@@ -203,21 +203,21 @@ export const useVirtualRows = (
     }
   }, [containerPropsRef, apiRef, getContainerProps, reRender, updateViewport]);
 
-  const scrollingTimeout = React.useRef<any>(0);
+  const scrollingTimeout = React.useRef<any>(null);
   const handleScroll = React.useCallback(() => {
-    // On iOS the inertia scrolling allows to return negative values. 
+    // On iOS the inertia scrolling allows to return negative values.
     if (windowRef.current!.scrollLeft < 0 || windowRef.current!.scrollTop < 0) return;
 
     realScrollRef.current = {
       left: windowRef.current!.scrollLeft,
       top: windowRef.current!.scrollTop,
     };
-    if (scrollingTimeout.current === 0) {
+    if (!scrollingTimeout.current) {
       apiRef.current.publishEvent(SCROLLING_START);
     }
     clearTimeout(scrollingTimeout.current);
     scrollingTimeout.current = setTimeout(() => {
-      scrollingTimeout.current = 0;
+      scrollingTimeout.current = null;
       apiRef.current.publishEvent(SCROLLING_STOP);
     }, 300);
     updateViewport();

--- a/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
@@ -205,6 +205,7 @@ export const useVirtualRows = (
 
   const scrollingTimeout = React.useRef<any>(0);
   const handleScroll = React.useCallback(() => {
+    // On iOS the inertia scrolling allows to return negative values. 
     if (windowRef.current!.scrollLeft < 0 || windowRef.current!.scrollTop < 0) return;
 
     realScrollRef.current = {

--- a/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
@@ -204,23 +204,23 @@ export const useVirtualRows = (
   }, [containerPropsRef, apiRef, getContainerProps, reRender, updateViewport]);
 
   const scrollingTimeout = React.useRef<any>(0);
-  const onScroll: any = React.useCallback(
-    (event: any) => {
-      if (event.target.scrollLeft < 0) return;
+  const handleScroll = React.useCallback(() => {
+    if (windowRef.current!.scrollLeft < 0 || windowRef.current!.scrollTop < 0) return;
 
-      realScrollRef.current = { left: event.target.scrollLeft, top: event.target.scrollTop };
-      if (scrollingTimeout.current === 0) {
-        apiRef.current.publishEvent(SCROLLING_START);
-      }
-      clearTimeout(scrollingTimeout.current);
-      scrollingTimeout.current = setTimeout(() => {
-        scrollingTimeout.current = 0;
-        apiRef.current.publishEvent(SCROLLING_STOP);
-      }, 300);
-      updateViewport();
-    },
-    [apiRef, updateViewport, scrollingTimeout, realScrollRef],
-  );
+    realScrollRef.current = {
+      left: windowRef.current!.scrollLeft,
+      top: windowRef.current!.scrollTop,
+    };
+    if (scrollingTimeout.current === 0) {
+      apiRef.current.publishEvent(SCROLLING_START);
+    }
+    clearTimeout(scrollingTimeout.current);
+    scrollingTimeout.current = setTimeout(() => {
+      scrollingTimeout.current = 0;
+      apiRef.current.publishEvent(SCROLLING_STOP);
+    }, 300);
+    updateViewport();
+  }, [apiRef, updateViewport, scrollingTimeout, realScrollRef, windowRef]);
 
   const scrollToIndexes = React.useCallback(
     (params: CellIndexCoordinates) => {
@@ -333,7 +333,7 @@ export const useVirtualRows = (
   );
 
   useApiEventHandler(apiRef, RESIZE, onResize);
-  useNativeEventListener(apiRef, windowRef, SCROLL, onScroll, { passive: true });
+  useNativeEventListener(apiRef, windowRef, SCROLL, handleScroll, { passive: true });
   useNativeEventListener(
     apiRef,
     () => renderingZoneRef.current?.parentElement,

--- a/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
@@ -206,6 +206,8 @@ export const useVirtualRows = (
   const scrollingTimeout = React.useRef<any>(0);
   const onScroll: any = React.useCallback(
     (event: any) => {
+      if (event.target.scrollLeft < 0) return;
+
       realScrollRef.current = { left: event.target.scrollLeft, top: event.target.scrollTop };
       if (scrollingTimeout.current === 0) {
         apiRef.current.publishEvent(SCROLLING_START);


### PR DESCRIPTION
This PR fixes an iOS scroll stretching issue that is visible when the user tries to scroll left while the grid is at the left position of 0. The issue occurs because when you scroll on an IOS device a scroll event is fired even if there is no space to scroll in that direction (scroll bouncing).

The fix is achieved by checking the `event.target.scrollLeft` and if it is < 0 prevent the update of the viewport.

Fixes #269