### PR TITLE
[DataGrid] Rely on the event

### DIFF
--- a/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/virtualization/useVirtualRows.ts
@@ -288,9 +288,8 @@ export const useVirtualRows = (
         windowRef.current.scrollTop = params.top;
         logger.debug(`Scrolling top: ${params.top}`);
       }
-      updateViewport();
     },
-    [logger, windowRef, updateViewport, colRef],
+    [logger, windowRef, colRef],
   );
 
   const getContainerPropsState = React.useCallback(() => {


### PR DESCRIPTION
updateViewport is already triggered by the scroll listener.

Proof:

```jsx
const dummy = document.createElement('div');
const container = document.createElement('div');
container.style.width = '10px';
container.style.height = '1px';
dummy.appendChild(container);
dummy.style.fontSize = '14px';
dummy.style.width = '4px';
dummy.style.height = '1px';
dummy.style.position = 'absolute';
dummy.style.top = '-1000px';
dummy.style.overflow = 'scroll';

document.body.appendChild(dummy);

dummy.addEventListener('scroll', () => console.log('scroll'));
dummy.scrollLeft = 1;
```