### PR TITLE
[DataGrid] Fix webpack v5

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
+++ b/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
@@ -1,14 +1,13 @@
 import * as React from 'react';
 import { ApiRef } from '../../models/api/apiRef';
 import { GridApi } from '../../models/api/gridApi';
-
-const EventEmitter = require('events').EventEmitter;
+import { EventEmitter } from '../../utils/EventEmitter';
 
 /**
  * Hook that instantiate an ApiRef to pass in component prop.
  */
 export function useApiRef(apiRefProp?: ApiRef): ApiRef {
-  const internalApiRef = React.useRef<GridApi>(new EventEmitter());
+  const internalApiRef = React.useRef<GridApi>(new EventEmitter() as GridApi);
 
   const apiRef = React.useMemo(() => apiRefProp || internalApiRef, [apiRefProp, internalApiRef]);
 

--- a/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
+++ b/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
@@ -11,6 +11,5 @@ export function useApiRef(apiRefProp?: ApiRef): ApiRef {
 
   const apiRef = React.useMemo(() => apiRefProp || internalApiRef, [apiRefProp, internalApiRef]);
 
-
   return apiRef;
 }

--- a/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
+++ b/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
@@ -11,5 +11,6 @@ export function useApiRef(apiRefProp?: ApiRef): ApiRef {
 
   const apiRef = React.useMemo(() => apiRefProp || internalApiRef, [apiRefProp, internalApiRef]);
 
+
   return apiRef;
 }

--- a/packages/grid/_modules_/grid/models/api/coreApi.ts
+++ b/packages/grid/_modules_/grid/models/api/coreApi.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from '../../utils/EventEmitter';
 
 /**
  * The core API interface that is available in the grid [[apiRef]].

--- a/packages/grid/_modules_/grid/utils/EventEmitter.ts
+++ b/packages/grid/_modules_/grid/utils/EventEmitter.ts
@@ -1,5 +1,8 @@
 type Listener = (...args: any[]) => void;
 
+// Used https://gist.github.com/mudge/5830382 as a starting point.
+// See https://github.com/browserify/events/blob/master/events.js for
+// the Node.js polyfill used by webpack.
 export class EventEmitter {
   events: { [key: string]: Listener[] } = {};
 

--- a/packages/grid/_modules_/grid/utils/EventEmitter.ts
+++ b/packages/grid/_modules_/grid/utils/EventEmitter.ts
@@ -1,0 +1,51 @@
+type Listener = (...args: any[]) => void;
+
+export class EventEmitter {
+  events: { [key: string]: Listener[] } = {};
+
+  on(event: string, listener: Listener): void {
+    if (!Array.isArray(this.events[event])) {
+      this.events[event] = [];
+    }
+
+    this.events[event].push(listener);
+  }
+
+  removeListener(event: string, listener: Listener): void {
+    if (Array.isArray(this.events[event])) {
+      const idx = this.events[event].indexOf(listener);
+
+      if (idx > -1) {
+        this.events[event].splice(idx, 1);
+      }
+    }
+  }
+
+  removeAllListeners(event?: string): void {
+    if (!event) {
+      this.events = {};
+    } else if (Array.isArray(this.events[event])) {
+      this.events[event] = [];
+    }
+  }
+
+  emit(event: string, ...args: any[]): void {
+    if (Array.isArray(this.events[event])) {
+      const listeners = this.events[event].slice();
+      const length = listeners.length;
+
+      for (let i = 0; i < length; i += 1) {
+        listeners[i].apply(this, args);
+      }
+    }
+  }
+
+  once(event: string, listener: Listener): void {
+    // eslint-disable-next-line consistent-this
+    const that = this;
+    this.on(event, function oneTimeListener(...args) {
+      that.removeListener(event, oneTimeListener);
+      listener.apply(that, args);
+    });
+  }
+}

--- a/packages/grid/_modules_/grid/utils/EventEmitter.ts
+++ b/packages/grid/_modules_/grid/utils/EventEmitter.ts
@@ -17,14 +17,16 @@ export class EventEmitter {
 
     this.events[eventName].push(listener);
 
-    if (this.events[eventName].length > this.maxListeners && this.warnOnce === false) {
-      this.warnOnce = true;
-      console.warn(
-        [
-          `Possible EventEmitter memory leak detected. ${this.events[eventName].length} ${eventName} listeners added.`,
-          `Use emitter.setMaxListeners() to increase limit.`,
-        ].join('\n'),
-      );
+    if (process.env.NODE_ENV !== 'production') {
+      if (this.events[eventName].length > this.maxListeners && this.warnOnce === false) {
+        this.warnOnce = true;
+        console.warn(
+          [
+            `Possible EventEmitter memory leak detected. ${this.events[eventName].length} ${eventName} listeners added.`,
+            `Use emitter.setMaxListeners() to increase limit.`,
+          ].join('\n'),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
webpack v5 does no longer polyfill Node.js modules https://webpack.js.org/blog/2020-10-10-webpack-5-release/. This fixes the component under this environment. It replaces https://github.com/browserify/events with a custom version. Help with #447.

It should also remove some bundle size, using a simplified version of the polyfill used by webpack v4.