### PR TITLE
[core] Sync supported browser with v5

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,5 +1,67 @@
-edge >= 83
-firefox >= 77
-chrome >= 83
-safari >= 11
+[modern]
+last 1 chrome version
+last 1 edge version
+last 1 firefox version
+last 1 safari version
+node 14
+
+# Default/Fallback
+# `npx browserslist --mobile-to-desktop "> 0.5%, last 2 versions, Firefox ESR, not dead, not IE 11"` when the last major is released.
+# On update check all #stable-snapshot markers
+[stable]
+and_chr 85
+and_ff 80
+and_qq 10.4
+and_uc 12.12
+android 85
+baidu 7.12
+chrome 84
+edge 85
+firefox 78
+ios_saf 12.2
+kaios 2.5
+op_mini all
+op_mob 70
+opera 70
+safari 13.1
+samsung 11.1-11.2
+
+# Same as `stable` but with IE 11
+[legacy]
+IE 11
+and_chr 85
+and_ff 80
+and_qq 10.4
+and_uc 12.12
+android 85
+baidu 7.12
+chrome 84
+edge 85
+firefox 78
+ios_saf 12.2
+kaios 2.5
+op_mini all
+op_mob 70
+opera 70
+safari 13.1
+samsung 11.1-11.2
+
+# snapshot of `npx browserslist "maintained node versions"`
+[node]
+node 10.0
+
+# same as `node`
+[coverage]
+node 10.0
+
+# same as `node`
+[development]
+node 10.0
+
+# same as `node`
+[test]
+node 10.0
+
+# same as `node`
+[benchmark]
 node 10.0

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -122,9 +122,9 @@ module.exports = function setKarmaConfig(config) {
         BrowserStack_Chrome: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'Sierra',
+          os_version: 'Catalina',
           browser: 'chrome',
-          browser_version: '83.0',
+          browser_version: '84.0',
         },
         BrowserStack_Firefox: {
           base: 'BrowserStack',
@@ -136,16 +136,18 @@ module.exports = function setKarmaConfig(config) {
         BrowserStack_Safari: {
           base: 'BrowserStack',
           os: 'OS X',
-          os_version: 'High Sierra',
+          os_version: 'Mojave',
           browser: 'safari',
-          browser_version: '11.1',
+          // On desktop we support 13.1 but on mobile we support 12.2.
+          // Using desktop 12.1 (12.2 is not available) as an approximation for mobile 12.2.
+          browser_version: '12.1',
         },
         BrowserStack_Edge: {
           base: 'BrowserStack',
           os: 'Windows',
           os_version: '10',
           browser: 'edge',
-          browser_version: '83.0',
+          browser_version: '85.0',
         },
       },
     };


### PR DESCRIPTION
Apply https://github.com/mui-org/material-ui/pull/22814, next, we will need to match the bundling strategy of the core.