### PR TITLE
[DataGrid] Restore regression test

### DIFF
--- a/packages/grid/data-grid/src/DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/DataGrid.test.tsx
@@ -140,8 +140,7 @@ describe('<DataGrid />', () => {
       }).toErrorDev('Material-UI: `<DataGrid pagination={false} />` is not a valid prop.');
     });
 
-    // eslint-disable-next-line mocha/no-skipped-tests
-    xit('should throw if the rows has no id', function test() {
+    it('should throw if the rows has no id', function test() {
       // TODO is this fixed?
       if (!/jsdom/.test(window.navigator.userAgent)) {
         // can't catch render errors in the browser for unknown reason
@@ -166,7 +165,7 @@ describe('<DataGrid />', () => {
       }).toErrorDev([
         'The data grid component requires all rows to have a unique id property',
         'The above error occurred in the <ForwardRef(GridComponent)> component',
-        'The above error occurred in the <ForwardRef(DataGrid)> component',
+        'The above error occurred in the <ForwardRef(GridComponent)> component',
       ]);
       expect((errorRef.current as any).errors).to.have.length(1);
       expect((errorRef.current as any).errors[0].toString()).to.include(


### PR DESCRIPTION
The test was skipped in #412.

@eps1lon In this case, we are only interested in testing that the error boundary reports the problem. It's the same as https://github.com/mui-org/material-ui/blob/db3581f75f88905e2791560c0527010f98a92a9b/packages/material-ui/src/Select/Select.test.js#L849.

Is there a way to ignore the console.error calls? I guess @dtassone has skipped the test because it wasn't obvious, at first sight, what was the solution. But anyway, it's probably an edge case, we can move forward like this :)