### PR TITLE
[DataGrid] Fix display of row count and selected rows on mobile

### DIFF
--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -33,7 +33,7 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       <SelectedRowCount selectedRowCount={selectedRowCount} />
     );
     const justifyItemsEnd =
-      !selectedRowCount && !options.hideFooterSelectedRowCount && isPaginationAvailable;
+      !selectedRowCount && !options.hideFooterSelectedRowCount;
 
     return (
       <GridFooter
@@ -43,8 +43,8 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
           'MuiDataGrid-footer-justifyContentEnd': justifyItemsEnd,
         })}
       >
-        {showRowCount}
         {showSelectedRowCount}
+        {showRowCount}
         {paginationComponent}
       </GridFooter>
     );

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -32,8 +32,7 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
     const showSelectedRowCount = !options.hideFooterSelectedRowCount && (
       <SelectedRowCount selectedRowCount={selectedRowCount} />
     );
-    const justifyItemsEnd =
-      !selectedRowCount && !options.hideFooterSelectedRowCount;
+    const justifyItemsEnd = !selectedRowCount && !options.hideFooterSelectedRowCount;
 
     return (
       <GridFooter

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -7,6 +7,7 @@ import { ApiContext } from './api-context';
 import { RowCount } from './row-count';
 import { SelectedRowCount } from './selected-row-count';
 import { GridFooter } from './styled-wrappers/GridFooter';
+import { classnames } from '../utils';
 
 export interface DefaultFooterProps {
   paginationComponent: React.ReactNode;
@@ -24,15 +25,19 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       return null;
     }
 
-    const showRowCount = !options.hideFooterRowCount && !paginationComponent && (
-      <RowCount rowCount={totalRowCount} />
-    );
-    const showSelectedRowCount = !options.hideFooterSelectedRowCount && !paginationComponent && (
+    const isPaginationAvailable = !!paginationComponent;
+    const showRowCount = !options.hideFooterRowCount && <RowCount rowCount={totalRowCount} />;
+    const showSelectedRowCount = !options.hideFooterSelectedRowCount && (
       <SelectedRowCount selectedRowCount={selectedRowCount} />
     );
 
     return (
-      <GridFooter ref={ref}>
+      <GridFooter
+        ref={ref}
+        className={classnames({
+          'MuiDataGrid-footer-pagination-visible': isPaginationAvailable,
+        })}
+      >
         {showRowCount}
         {showSelectedRowCount}
         {paginationComponent}

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -32,15 +32,15 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
     const showSelectedRowCount = !options.hideFooterSelectedRowCount && (
       <SelectedRowCount selectedRowCount={selectedRowCount} />
     );
-    const justifyItemsRight =
+    const justifyItemsEnd =
       !selectedRowCount && !options.hideFooterSelectedRowCount && isPaginationAvailable;
 
     return (
       <GridFooter
         ref={ref}
         className={classnames({
-          'MuiDataGrid-footer-pagination-visible': isPaginationAvailable,
-          'MuiDataGrid-footer-justifyContent-right': justifyItemsRight,
+          'MuiDataGrid-footer-paginationAvailable': isPaginationAvailable,
+          'MuiDataGrid-footer-justifyContentEnd': justifyItemsEnd,
         })}
       >
         {showRowCount}

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -24,12 +24,17 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       return null;
     }
 
+    const showRowCount = !options.hideFooterRowCount && !paginationComponent && (
+      <RowCount rowCount={totalRowCount} />
+    );
+    const showSelectedRowCount = !options.hideFooterSelectedRowCount && !paginationComponent && (
+      <SelectedRowCount selectedRowCount={selectedRowCount} />
+    );
+
     return (
       <GridFooter ref={ref}>
-        {!options.hideFooterRowCount && <RowCount rowCount={totalRowCount} />}
-        {!options.hideFooterSelectedRowCount && (
-          <SelectedRowCount selectedRowCount={selectedRowCount} />
-        )}
+        {showRowCount}
+        {showSelectedRowCount}
         {paginationComponent}
       </GridFooter>
     );

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -26,16 +26,21 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
     }
 
     const isPaginationAvailable = !!paginationComponent;
-    const showRowCount = !options.hideFooterRowCount && <RowCount rowCount={totalRowCount} />;
+    const showRowCount = !options.hideFooterRowCount && !isPaginationAvailable && (
+      <RowCount rowCount={totalRowCount} />
+    );
     const showSelectedRowCount = !options.hideFooterSelectedRowCount && (
       <SelectedRowCount selectedRowCount={selectedRowCount} />
     );
+    const justifyItemsRight =
+      !selectedRowCount && !options.hideFooterSelectedRowCount && isPaginationAvailable;
 
     return (
       <GridFooter
         ref={ref}
         className={classnames({
           'MuiDataGrid-footer-pagination-visible': isPaginationAvailable,
+          'MuiDataGrid-footer-justifyContent-right': justifyItemsRight,
         })}
       >
         {showRowCount}

--- a/packages/grid/_modules_/grid/components/pagination.tsx
+++ b/packages/grid/_modules_/grid/components/pagination.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import TablePagination from '@material-ui/core/TablePagination';
-import { makeStyles } from '@material-ui/core';
+import { makeStyles, Theme } from '@material-ui/core/styles';
 
 export interface PaginationComponentProps {
   pageCount: number;
@@ -13,14 +13,23 @@ export interface PaginationComponentProps {
 }
 
 // Used to hide the drop down select from the TablePaginagion
-const useStyles = makeStyles({
-  select: {
+const useStyles = makeStyles((theme: Theme) => ({
+  caption: {
     display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block',
+    },
+    '& ~ &': {
+      display: 'block',
+    },
   },
-  selectIcon: {
+  input: {
     display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block',
+    },
   },
-});
+}));
 
 export const Pagination: React.FC<PaginationComponentProps> = ({
   setPage,
@@ -48,6 +57,7 @@ export const Pagination: React.FC<PaginationComponentProps> = ({
 
   return (
     <TablePagination
+      classes={classes}
       component="div"
       count={rowCount}
       page={currentPage - 1}
@@ -57,8 +67,6 @@ export const Pagination: React.FC<PaginationComponentProps> = ({
       }
       rowsPerPage={pageSize}
       onChangeRowsPerPage={onPageSizeChange}
-      labelRowsPerPage=""
-      classes={classes}
     />
   );
 };

--- a/packages/grid/_modules_/grid/components/pagination.tsx
+++ b/packages/grid/_modules_/grid/components/pagination.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import TablePagination from '@material-ui/core/TablePagination';
+import { makeStyles } from '@material-ui/core';
 
 export interface PaginationComponentProps {
   pageCount: number;
@@ -11,6 +12,16 @@ export interface PaginationComponentProps {
   rowsPerPageOptions?: number[];
 }
 
+// Used to hide the drop down select from the TablePaginagion
+const useStyles = makeStyles({
+  select: {
+    display: 'none',
+  },
+  selectIcon: {
+    display: 'none',
+  },
+});
+
 export const Pagination: React.FC<PaginationComponentProps> = ({
   setPage,
   setPageSize,
@@ -19,6 +30,7 @@ export const Pagination: React.FC<PaginationComponentProps> = ({
   currentPage,
   rowsPerPageOptions,
 }) => {
+  const classes = useStyles();
   const onPageSizeChange = React.useCallback(
     (event: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) => {
       const newPageSize = Number(event.target.value);
@@ -45,6 +57,8 @@ export const Pagination: React.FC<PaginationComponentProps> = ({
       }
       rowsPerPage={pageSize}
       onChangeRowsPerPage={onPageSizeChange}
+      labelRowsPerPage={''}
+      classes={classes}
     />
   );
 };

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -206,16 +206,24 @@ export const useStyles = makeStyles(
         '& .MuiDataGrid-cellCenter': {
           textAlign: 'center',
         },
+        '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
+          alignItems: 'center',
+          display: 'flex',
+          margin: theme.spacing(0, 2),
+        },
         '& .MuiDataGrid-footer': {
           display: 'flex',
           justifyContent: 'space-between',
           alignItems: 'center',
           minHeight: 52, // Match TablePagination min height
-        },
-        '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
-          alignItems: 'center',
-          display: 'flex',
-          margin: theme.spacing(0, 2),
+          '&.MuiDataGrid-footer-pagination-visible': {
+            '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
+              display: 'none',
+              [theme.breakpoints.up('md')]: {
+                display: 'flex',
+              },
+            },
+          },
         },
         '& .MuiDataGrid-colCell-dropZone .MuiDataGrid-colCell-draggable': {
           cursor: 'move',

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -219,7 +219,7 @@ export const useStyles = makeStyles(
           '&.MuiDataGrid-footer-paginationAvailable': {
             '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
               visibility: 'hidden',
-              [theme.breakpoints.up('sm')]: {
+              [theme.breakpoints.up('md')]: {
                 visibility: 'visible',
               },
             },

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -218,11 +218,14 @@ export const useStyles = makeStyles(
           minHeight: 52, // Match TablePagination min height
           '&.MuiDataGrid-footer-pagination-visible': {
             '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
-              display: 'none',
+              visibility: 'hidden',
               [theme.breakpoints.up('md')]: {
-                display: 'flex',
+                visibility: 'visible',
               },
             },
+          },
+          '&.MuiDataGrid-footer-justifyContent-right': {
+            justifyContent: 'flex-end',
           },
         },
         '& .MuiDataGrid-colCell-dropZone .MuiDataGrid-colCell-draggable': {

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -214,11 +214,8 @@ export const useStyles = makeStyles(
         },
         '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
           alignItems: 'center',
-          display: 'none',
+          display: 'flex',
           margin: theme.spacing(0, 2),
-          [theme.breakpoints.up('md')]: {
-            display: 'flex',
-          },
         },
         '& .MuiDataGrid-colCell-dropZone .MuiDataGrid-colCell-draggable': {
           cursor: 'move',

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -219,7 +219,7 @@ export const useStyles = makeStyles(
           '&.MuiDataGrid-footer-paginationAvailable': {
             '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
               visibility: 'hidden',
-              [theme.breakpoints.up('md')]: {
+              [theme.breakpoints.up('sm')]: {
                 visibility: 'visible',
               },
             },

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -216,7 +216,7 @@ export const useStyles = makeStyles(
           justifyContent: 'space-between',
           alignItems: 'center',
           minHeight: 52, // Match TablePagination min height
-          '&.MuiDataGrid-footer-pagination-visible': {
+          '&.MuiDataGrid-footer-paginationAvailable': {
             '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
               visibility: 'hidden',
               [theme.breakpoints.up('md')]: {
@@ -224,7 +224,7 @@ export const useStyles = makeStyles(
               },
             },
           },
-          '&.MuiDataGrid-footer-justifyContent-right': {
+          '&.MuiDataGrid-footer-justifyContentEnd': {
             justifyContent: 'flex-end',
           },
         },


### PR DESCRIPTION
Fixes #440 

This PR aims to solve the issue of having the `Total Rows` and  `rows selected` counts hidden on small screens. I didn't change the styling but only made the 2 files visible.

![Screenshot 2020-10-29 at 15 22 44](https://user-images.githubusercontent.com/5858539/97587042-416bc680-19fb-11eb-95cb-545d164cd808.png)
