### PR TITLE
[DataGrid] Avoid paint step

### DIFF
--- a/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
@@ -31,6 +31,7 @@ export function useScrollFn(
         if (renderingZoneElementRef.current!.style.pointerEvents !== 'none') {
           renderingZoneElementRef.current!.style.pointerEvents = 'none';
         }
+        // Force the creation of a layer, avoid paint when changing the transform value   
         renderingZoneElementRef.current!.style.transform = `translate3d(-${v.left}px, -${v.top}px, 0)`;
         columnHeadersElementRef.current!.style.transform = `translate3d(-${v.left}px, 0, 0)`;
         debouncedResetPointerEvents();

--- a/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
@@ -31,8 +31,8 @@ export function useScrollFn(
         if (renderingZoneElementRef.current!.style.pointerEvents !== 'none') {
           renderingZoneElementRef.current!.style.pointerEvents = 'none';
         }
-        renderingZoneElementRef.current!.style.transform = `translate(-${v.left}px, -${v.top}px)`;
-        columnHeadersElementRef.current!.style.transform = `translate(-${v.left}px, -0px)`;
+        renderingZoneElementRef.current!.style.transform = `translate3d(-${v.left}px, -${v.top}px, 0)`;
+        columnHeadersElementRef.current!.style.transform = `translate3d(-${v.left}px, 0, 0)`;
         debouncedResetPointerEvents();
         previousValue.current = v;
       }

--- a/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useScrollFn.ts
@@ -31,7 +31,7 @@ export function useScrollFn(
         if (renderingZoneElementRef.current!.style.pointerEvents !== 'none') {
           renderingZoneElementRef.current!.style.pointerEvents = 'none';
         }
-        // Force the creation of a layer, avoid paint when changing the transform value   
+        // Force the creation of a layer, avoid paint when changing the transform value.
         renderingZoneElementRef.current!.style.transform = `translate3d(-${v.left}px, -${v.top}px, 0)`;
         columnHeadersElementRef.current!.style.transform = `translate3d(-${v.left}px, 0, 0)`;
         debouncedResetPointerEvents();


### PR DESCRIPTION
Reduce the green flash surface areas reported by Chrome. It was raised in https://twitter.com/XCSme/status/1323303435152838656 by @Cristy94.

For more context: https://developers.google.com/web/fundamentals/performance/rendering/simplify-paint-complexity-and-reduce-paint-areas.