### PR TITLE
[core] Dont need to fire resize

### DIFF
--- a/packages/grid/x-grid/src/XGrid.test.tsx
+++ b/packages/grid/x-grid/src/XGrid.test.tsx
@@ -178,9 +178,6 @@ describe('<XGrid />', () => {
     rect = container.querySelector('[role="row"][data-rowindex="0"]').getBoundingClientRect();
     expect(rect.width).to.equal(300 - 2);
     setProps({ width: 400 });
-    act(() => {
-      window.dispatchEvent(new window.Event('resize', {}));
-    });
     await sleep(100); // resize debounce
     await sleep(100); // Not sure why
     // @ts-ignore

--- a/packages/grid/x-grid/src/XGrid.test.tsx
+++ b/packages/grid/x-grid/src/XGrid.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 // @ts-expect-error need to migrate helpers to TypeScript
-import { screen, createClientRender, act, fireEvent } from 'test/utils';
+import { screen, createClientRender, fireEvent } from 'test/utils';
 import { expect } from 'chai';
 import { XGrid, useApiRef, Columns } from '@material-ui/x-grid';
 import { useData } from 'packages/storybook/src/hooks/useData';


### PR DESCRIPTION
I must have copied the resize firing event from an existing test in the core. It's harmful, removing it. It's not what we want to test. We need it to work without it.

Found in #532