### PR TITLE
[docs] Fix links to GitHub

### DIFF
--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -36,6 +36,10 @@ module.exports = {
           CONTEXT: JSON.stringify(process.env.CONTEXT),
           LIB_VERSION: JSON.stringify(pkg.version),
           REACT_MODE: JSON.stringify(reactMode),
+          SOURCE_CODE_ROOT_URL: JSON.stringify(
+            'https://github.com/mui-org/material-ui-x/blob/master',
+          ),
+          SOURCE_CODE_REPO: JSON.stringify('https://github.com/mui-org/material-ui-x'),
         },
       }),
     ]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2732,7 +2732,7 @@
 
 "@material-ui/monorepo@https://github.com/mui-org/material-ui.git#master":
   version "4.11.0"
-  resolved "https://github.com/mui-org/material-ui.git#3c078f2f6943976fc4d3ed5d886bbfa0f391e4a2"
+  resolved "https://github.com/mui-org/material-ui.git#41898e1318b0315e5a61e2df7780b6019f3b44f6"
 
 "@material-ui/monorepo@https://github.com/mui-org/material-ui.git#next":
   version "5.0.0-alpha.13"


### PR DESCRIPTION
The introduction of a second GitHub repository means that we can no longer hard-code the URL in the documentation, if we do, we won't point to the right position. https://github.com/mui-org/material-ui/pull/23390 allows configuring the underlying repository, and this PR leverage it. For instance, these two links are now correct:

<img width="226" alt="Capture d’écran 2020-11-04 à 19 21 41" src="https://user-images.githubusercontent.com/3165635/98153141-07a33000-1ed3-11eb-89ad-0043f7d23ca4.png">

<img width="360" alt="Capture d’écran 2020-11-04 à 19 21 47" src="https://user-images.githubusercontent.com/3165635/98153143-083bc680-1ed3-11eb-8e92-765848943333.png">


Proof: https://deploy-preview-538--material-ui-x.netlify.app/components/data-grid/rows/