### PR TITLE
[docs] Update feature comparison table for Column reorder

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -131,7 +131,7 @@ The following table summarizes the features available in the community `DataGrid
 | **Column**                                                                              |           |                |
 | [Column resizing](/components/data-grid/columns/#column-resizing)                       | ❌        | ✅             |
 | [Column groups](/components/data-grid/columns/#column-groups)                           | 🚧        | 🚧             |
-| [Column reorder](/components/data-grid/columns/#column-reorder)                         | ❌        | 🚧             |
+| [Column reorder](/components/data-grid/columns/#column-reorder)                         | ❌        | ✅             |
 | [Column pinning](/components/data-grid/columns/#column-pinning)                         | ❌        | 🚧             |
 | [Column spanning](/components/data-grid/columns/#column-spanning)                       | 🚧        | 🚧             |
 | **Rows**                                                                                |           |                |


### PR DESCRIPTION
This PR fixed the `Getting Started` part of the `DataGrid` documentation, showing that we have the Column Reorder feature available on the enterprise version of the grid.