### PR TITLE
[DataGrid] Fix type definitions

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/selection/selectionSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/selectionSelector.ts
@@ -1,9 +1,13 @@
-import { createSelector } from 'reselect';
+import { createSelector, OutputSelector } from 'reselect';
 import { GridState } from '../core/gridState';
 import { SelectionState } from './selectionState';
 
 export const selectionStateSelector = (state: GridState) => state.selection;
-export const selectedRowsCountSelector = createSelector<GridState, SelectionState, number>(
+export const selectedRowsCountSelector: OutputSelector<
+  GridState,
+  number,
+  (res: SelectionState) => number
+> = createSelector<GridState, SelectionState, number>(
   selectionStateSelector,
   (selection) => Object.keys(selection).length,
 );

--- a/packages/grid/tsconfig.build.json
+++ b/packages/grid/tsconfig.build.json
@@ -10,5 +10,5 @@
     "rootDir": "./"
   },
   "include": ["./data-grid/src", "./x-grid/src", "./_modules_/**/*"],
-  "exclude": ["__tests__", "**/*.test.ts", "node_modules"]
+  "exclude": ["__tests__", "**/*.test.*", "node_modules"]
 }


### PR DESCRIPTION
Closes #573

What I did:

- Prevent `*.test.*` to go through types generation
- Help createSelector to find its right typings