### PR TITLE
[DataGrid] Fix autoHeight computation for custom headers and footers

### DIFF
--- a/packages/grid/_modules_/grid/GridComponent.tsx
+++ b/packages/grid/_modules_/grid/GridComponent.tsx
@@ -49,6 +49,7 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
     const handleRef = useForkRef(rootContainerRef, ref);
 
     const footerRef = React.useRef<HTMLDivElement>(null);
+    const headerRef = React.useRef<HTMLDivElement>(null);
     const columnsHeaderRef = React.useRef<HTMLDivElement>(null);
     const columnsContainerRef = React.useRef<HTMLDivElement>(null);
     const windowRef = React.useRef<HTMLDivElement>(null);
@@ -85,7 +86,13 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
 
     // TODO move that to renderCtx
     const getTotalHeight = React.useCallback(
-      (size) => getCurryTotalHeight(gridState.options, gridState.containerSizes, footerRef)(size),
+      (size) =>
+        getCurryTotalHeight(
+          gridState.options,
+          gridState.containerSizes,
+          headerRef,
+          footerRef,
+        )(size),
       [gridState.options, gridState.containerSizes],
     );
 
@@ -129,8 +136,10 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
             >
               <ApiContext.Provider value={apiRef}>
                 <OptionsContext.Provider value={gridState.options}>
-                  {customComponents.headerComponent || (
-                    <GridToolbar>
+                  {customComponents.headerComponent ? (
+                    <div ref={headerRef}>{customComponents.headerComponent}</div>
+                  ) : (
+                    <GridToolbar ref={headerRef}>
                       {/* The components for the separate features go in here */}
                     </GridToolbar>
                   )}
@@ -169,7 +178,9 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
                       </GridDataContainer>
                     </GridWindow>
                   </div>
-                  {customComponents.footerComponent || (
+                  {customComponents.footerComponent ? (
+                    <div ref={footerRef}>{customComponents.footerComponent}</div>
+                  ) : (
                     <DefaultFooter
                       ref={footerRef}
                       paginationComponent={

--- a/packages/grid/_modules_/grid/GridComponent.tsx
+++ b/packages/grid/_modules_/grid/GridComponent.tsx
@@ -136,13 +136,15 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
             >
               <ApiContext.Provider value={apiRef}>
                 <OptionsContext.Provider value={gridState.options}>
-                  {customComponents.headerComponent ? (
-                    <div ref={headerRef}>{customComponents.headerComponent}</div>
-                  ) : (
-                    <GridToolbar ref={headerRef}>
-                      {/* The components for the separate features go in here */}
-                    </GridToolbar>
-                  )}
+                  <div ref={headerRef}>
+                    {customComponents.headerComponent ? (
+                      customComponents.headerComponent
+                    ) : (
+                      <GridToolbar>
+                        {/* The components for the separate features go in here */}
+                      </GridToolbar>
+                    )}
+                  </div>
                   <div className="MuiDataGrid-mainGridContainer">
                     <Watermark licenseStatus={props.licenseStatus} />
                     <GridColumnsContainer
@@ -178,29 +180,30 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
                       </GridDataContainer>
                     </GridWindow>
                   </div>
-                  {customComponents.footerComponent ? (
-                    <div ref={footerRef}>{customComponents.footerComponent}</div>
-                  ) : (
-                    <DefaultFooter
-                      ref={footerRef}
-                      paginationComponent={
-                        !!gridState.options.pagination &&
-                        gridState.pagination.pageSize != null &&
-                        !gridState.options.hideFooterPagination &&
-                        (customComponents.paginationComponent || (
-                          <Pagination
-                            setPage={apiRef.current.setPage}
-                            currentPage={gridState.pagination.page}
-                            pageCount={gridState.pagination.pageCount}
-                            pageSize={gridState.pagination.pageSize}
-                            rowCount={gridState.pagination.rowCount}
-                            setPageSize={apiRef.current.setPageSize}
-                            rowsPerPageOptions={gridState.options.rowsPerPageOptions}
-                          />
-                        ))
-                      }
-                    />
-                  )}
+                  <div ref={footerRef}>
+                    {customComponents.footerComponent ? (
+                      customComponents.footerComponent
+                    ) : (
+                      <DefaultFooter
+                        paginationComponent={
+                          !!gridState.options.pagination &&
+                          gridState.pagination.pageSize != null &&
+                          !gridState.options.hideFooterPagination &&
+                          (customComponents.paginationComponent || (
+                            <Pagination
+                              setPage={apiRef.current.setPage}
+                              currentPage={gridState.pagination.page}
+                              pageCount={gridState.pagination.pageCount}
+                              pageSize={gridState.pagination.pageSize}
+                              rowCount={gridState.pagination.rowCount}
+                              setPageSize={apiRef.current.setPageSize}
+                              rowsPerPageOptions={gridState.options.rowsPerPageOptions}
+                            />
+                          ))
+                        }
+                      />
+                    )}
+                  </div>
                 </OptionsContext.Provider>
               </ApiContext.Provider>
             </ErrorBoundary>

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -5,6 +5,7 @@ import { ContainerProps, GridOptions } from '../models';
 export const getCurryTotalHeight = (
   internalOptions: GridOptions,
   containerSizes: ContainerProps | null,
+  headerRef: React.RefObject<HTMLDivElement>,
   footerRef: React.RefObject<HTMLDivElement>,
 ) => (size: any) => {
   const dataContainerHeight = (containerSizes && containerSizes.dataContainerSizes!.height) || 0;
@@ -12,10 +13,11 @@ export const getCurryTotalHeight = (
     return size.height;
   }
   const footerHeight = (footerRef.current && footerRef.current.getBoundingClientRect().height) || 0;
+  const headerHeight = (headerRef.current && headerRef.current.getBoundingClientRect().height) || 0;
   let dataHeight = dataContainerHeight;
   if (dataHeight < internalOptions.rowHeight) {
     dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
   }
 
-  return footerHeight + dataHeight + internalOptions.headerHeight;
+  return headerHeight + footerHeight + dataHeight + internalOptions.headerHeight;
 };

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -19,5 +19,5 @@ export const getCurryTotalHeight = (
     dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
   }
 
-  return headerHeight + footerHeight + dataHeight + internalOptions.headerHeight;
+  return headerHeight + footerHeight + dataHeight;
 };

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -13,13 +13,11 @@ export const getCurryTotalHeight = (
     return size.height;
   }
   const footerHeight = (footerRef.current && footerRef.current.getBoundingClientRect().height) || 0;
-  const headerHeight =
-    (headerRef.current && headerRef.current.getBoundingClientRect().height) ||
-    internalOptions.headerHeight;
+  const headerHeight = (headerRef.current && headerRef.current.getBoundingClientRect().height) || 0;
   let dataHeight = dataContainerHeight;
   if (dataHeight < internalOptions.rowHeight) {
     dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
   }
 
-  return headerHeight + footerHeight + dataHeight;
+  return headerHeight + footerHeight + dataHeight + internalOptions.headerHeight;
 };

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -13,7 +13,9 @@ export const getCurryTotalHeight = (
     return size.height;
   }
   const footerHeight = (footerRef.current && footerRef.current.getBoundingClientRect().height) || 0;
-  const headerHeight = (headerRef.current && headerRef.current.getBoundingClientRect().height) || 0;
+  const headerHeight =
+    (headerRef.current && headerRef.current.getBoundingClientRect().height) ||
+    internalOptions.headerHeight;
   let dataHeight = dataContainerHeight;
   if (dataHeight < internalOptions.rowHeight) {
     dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay


### PR DESCRIPTION
Fixes #502

This PR aims to fix an issue that occurs when the autoHeight prop is set and a custom header and/or footer is provided. The bug is that the height of the grid, in that case, is not calculated correctly. That results in the last rows being hidden.