### PR TITLE
[DataGrid] Add basic filter demo in docs

### DIFF
--- a/docs/src/pages/components/data-grid/filtering/BasicFilters.js
+++ b/docs/src/pages/components/data-grid/filtering/BasicFilters.js
@@ -1,0 +1,66 @@
+import * as React from 'react';
+import { XGrid } from '@material-ui/x-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+function loadServerRows(page, data) {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve(data.rows.slice((page - 1) * 5, page * 5));
+    }, Math.random() * 500 + 100); // simulate network latency
+  });
+}
+
+export default function ServerPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+
+  const [page, setPage] = React.useState(1);
+  const [rows, setRows] = React.useState([]);
+  const [loading, setLoading] = React.useState(false);
+
+  const handlePageChange = (params) => {
+    setPage(params.page);
+  };
+
+  React.useEffect(() => {
+    let active = true;
+
+    (async () => {
+      setLoading(true);
+      const newRows = await loadServerRows(page, data);
+
+      if (!active) {
+        return;
+      }
+
+      setRows(newRows);
+      setLoading(false);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [page, data]);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <XGrid
+        rows={rows}
+        columns={data.columns}
+        pagination
+        pageSize={5}
+        rowCount={100}
+        paginationMode="server"
+        onPageChange={handlePageChange}
+        loading={loading}
+        hideToolbar={false}
+        disableColumnMenu={false}
+        disableColumnFilter={false}
+        disableColumnSelector={false}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/filtering/BasicFilters.tsx
+++ b/docs/src/pages/components/data-grid/filtering/BasicFilters.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import { RowsProp, DataGrid, PageChangeParams } from '@material-ui/data-grid';
+import { useDemoData, GridData } from '@material-ui/x-grid-data-generator';
+
+function loadServerRows(page: number, data: GridData): Promise<any> {
+  return new Promise<any>((resolve) => {
+    setTimeout(() => {
+      resolve(data.rows.slice((page - 1) * 5, page * 5));
+    }, Math.random() * 500 + 100); // simulate network latency
+  });
+}
+
+export default function ServerPaginationGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 100,
+    maxColumns: 6,
+  });
+  const [page, setPage] = React.useState(1);
+  const [rows, setRows] = React.useState<RowsProp>([]);
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  const handlePageChange = (params: PageChangeParams) => {
+    setPage(params.page);
+  };
+
+  React.useEffect(() => {
+    let active = true;
+
+    (async () => {
+      setLoading(true);
+      const newRows = await loadServerRows(page, data);
+
+      if (!active) {
+        return;
+      }
+
+      setRows(newRows);
+      setLoading(false);
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [page, data]);
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid
+        rows={rows}
+        columns={data.columns}
+        pagination
+        pageSize={5}
+        rowCount={100}
+        paginationMode="server"
+        onPageChange={handlePageChange}
+        loading={loading}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/filtering/BasicFilters.tsx
+++ b/docs/src/pages/components/data-grid/filtering/BasicFilters.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { RowsProp, DataGrid, PageChangeParams } from '@material-ui/data-grid';
+import { RowsProp, XGrid, PageChangeParams } from '@material-ui/x-grid';
 import { useDemoData, GridData } from '@material-ui/x-grid-data-generator';
 
 function loadServerRows(page: number, data: GridData): Promise<any> {
@@ -46,7 +46,7 @@ export default function ServerPaginationGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
+      <XGrid
         rows={rows}
         columns={data.columns}
         pagination
@@ -55,6 +55,10 @@ export default function ServerPaginationGrid() {
         paginationMode="server"
         onPageChange={handlePageChange}
         loading={loading}
+        hideToolbar={false}
+        disableColumnMenu={false}
+        disableColumnFilter={false}
+        disableColumnSelector={false}
       />
     </div>
   );

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -9,6 +9,8 @@ components: DataGrid, XGrid
 
 ## 🚧 Column filter
 
+{{"demo": "pages/components/data-grid/filtering/BasicFilters.js", "bg": "inline"}}
+
 > ⚠️ This feature isn't implemented yet. It's coming.
 >
 > 👍 Upvote [issue #201](https://github.com/mui-org/material-ui-x/issues/201) if you want to see it land faster.

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -10,18 +10,3 @@ components: DataGrid, XGrid
 ## 🚧 Column filter
 
 {{"demo": "pages/components/data-grid/filtering/BasicFilters.js", "bg": "inline"}}
-
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #201](https://github.com/mui-org/material-ui-x/issues/201) if you want to see it land faster.
-
-Column filters are filters that are applied to the data at the column level.
-
-## 🚧 Quick filter
-
-> ⚠️ This feature isn't implemented yet. It's coming.
->
-> 👍 Upvote [issue #202](https://github.com/mui-org/material-ui-x/issues/202) if you want to see it land faster.
-
-In addition to the column specific filtering, a global quick filtering will also be available.
-The provided search text will match against all the cells.


### PR DESCRIPTION
WIP structure:

```
# Data Grid - Filtering

## Column filter

By default, when filtering is enabled.

### Basic filter

Per-column with 3 types: string, number, date/time.

<DataGrid /> open by default for the demo, enabled by default.

### Disable filter

- globally

<DataGrid />

- per column filterable: boolean

<DataGrid />

Benchmark
https://master--material-ui-x.netlify.app/components/data-grid/rows/#disable-sorting
https://ag-grid.com/javascript-grid-filtering/#configuring-filters-on-columns

### Custom filter operator

Demo ideas with Airtable rating ⭐️⭐️⭐️⭐️ or slider progress/quantity.

<DataGrid />

Benchmark
https://www.telerik.com/kendo-react-ui/components/grid/filtering/#toc-custom-filter-operators
https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/filtering/#custom-filter-operations

### Toolbar

How to enable and use the toolbar

### Server-side filter

<DataGrid />

Benchmark
https://master--material-ui-x.netlify.app/components/data-grid/rows/#server-side-sorting
https://devexpress.github.io/devextreme-reactive/react/grid/docs/guides/filtering/#remote-filtering

### Controlled filtering

<DataGrid />

https://master--material-ui-x.netlify.app/components/data-grid/pagination/#controlled-pagination

### Multi-filtering ⚡️

<XGrid />

### apiRef ⚡️

https://master--material-ui-x.netlify.app/components/data-grid/rows/#apiref

## Quick filter
```