### PR TITLE
[docs] Reduce confusion on /export page

### DIFF
--- a/docs/src/pages/components/data-grid/export/export.md
+++ b/docs/src/pages/components/data-grid/export/export.md
@@ -1,9 +1,9 @@
 ---
-title: Data Grid - Export & Import
+title: Data Grid - Export
 components: DataGrid, XGrid
 ---
 
-# Data Grid - Export & Import
+# Data Grid - Export
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 


### PR DESCRIPTION
Removed Import reference in titles as there are no other references to imports or import features. It becomes misleading.