### PR TITLE
[DataGrid] Simplify footer logic

### DIFF
--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -7,7 +7,6 @@ import { ApiContext } from './api-context';
 import { RowCount } from './row-count';
 import { SelectedRowCount } from './selected-row-count';
 import { GridFooter } from './styled-wrappers/GridFooter';
-import { classnames } from '../utils';
 
 export interface DefaultFooterProps {
   paginationComponent: React.ReactNode;

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -25,11 +25,12 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       return null;
     }
 
-    const showSelectedRowCount = !options.hideFooterSelectedRowCount && selectedRowCount > 0 ? (
-      <SelectedRowCount selectedRowCount={selectedRowCount} />
-    ) : (
-      <div />
-    );
+    const showSelectedRowCount =
+      !options.hideFooterSelectedRowCount && selectedRowCount > 0 ? (
+        <SelectedRowCount selectedRowCount={selectedRowCount} />
+      ) : (
+        <div />
+      );
 
     const showRowCount =
       !options.hideFooterRowCount && !paginationComponent ? (

--- a/packages/grid/_modules_/grid/components/default-footer.tsx
+++ b/packages/grid/_modules_/grid/components/default-footer.tsx
@@ -25,23 +25,19 @@ export const DefaultFooter = React.forwardRef<HTMLDivElement, DefaultFooterProps
       return null;
     }
 
-    const isPaginationAvailable = !!paginationComponent;
-    const showRowCount = !options.hideFooterRowCount && !isPaginationAvailable && (
-      <RowCount rowCount={totalRowCount} />
-    );
-    const showSelectedRowCount = !options.hideFooterSelectedRowCount && (
+    const showSelectedRowCount = !options.hideFooterSelectedRowCount && selectedRowCount > 0 ? (
       <SelectedRowCount selectedRowCount={selectedRowCount} />
+    ) : (
+      <div />
     );
-    const justifyItemsEnd = !selectedRowCount && !options.hideFooterSelectedRowCount;
+
+    const showRowCount =
+      !options.hideFooterRowCount && !paginationComponent ? (
+        <RowCount rowCount={totalRowCount} />
+      ) : null;
 
     return (
-      <GridFooter
-        ref={ref}
-        className={classnames({
-          'MuiDataGrid-footer-paginationAvailable': isPaginationAvailable,
-          'MuiDataGrid-footer-justifyContentEnd': justifyItemsEnd,
-        })}
-      >
+      <GridFooter ref={ref}>
         {showSelectedRowCount}
         {showRowCount}
         {paginationComponent}

--- a/packages/grid/_modules_/grid/components/selected-row-count.tsx
+++ b/packages/grid/_modules_/grid/components/selected-row-count.tsx
@@ -7,10 +7,6 @@ interface SelectedRowCountProps {
 export function SelectedRowCount(props: SelectedRowCountProps) {
   const { selectedRowCount } = props;
 
-  if (selectedRowCount === 0) {
-    return null;
-  }
-
   return (
     <div className="MuiDataGrid-selectedRowCount">
       {`${selectedRowCount.toLocaleString()} ${selectedRowCount > 1 ? 'rows' : 'row'} selected`}

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -248,16 +248,13 @@ export const useStyles = makeStyles(
           justifyContent: 'space-between',
           alignItems: 'center',
           minHeight: 52, // Match TablePagination min height
-          '&.MuiDataGrid-footer-paginationAvailable': {
-            '& .MuiDataGrid-rowCount, & .MuiDataGrid-selectedRowCount': {
-              visibility: 'hidden',
-              [theme.breakpoints.up('md')]: {
-                visibility: 'visible',
-              },
+          '& .MuiDataGrid-selectedRowCount': {
+            visibility: 'hidden',
+            width: 0,
+            [theme.breakpoints.up('sm')]: {
+              visibility: 'visible',
+              width: 'auto',
             },
-          },
-          '&.MuiDataGrid-footer-justifyContentEnd': {
-            justifyContent: 'flex-end',
           },
         },
         '& .MuiDataGrid-colCell-dropZone .MuiDataGrid-colCell-draggable': {


### PR DESCRIPTION
Fixes #638 with the part around by reducing the breakpoint threshold from `md` to `sm`.

> Footer […] selected rows disappear on adding pagination

**Before**

<img width="592" alt="Capture d’écran 2020-12-03 à 12 56 21" src="https://user-images.githubusercontent.com/3165635/101014971-f9464380-3566-11eb-8ae2-b9f663a3799a.png">

**After**

<img width="579" alt="Capture d’écran 2020-12-03 à 12 56 48" src="https://user-images.githubusercontent.com/3165635/101015020-0b27e680-3567-11eb-960a-6698cb07335c.png">
