### PR TITLE
[test] Allow running all the tests in strict mode

### DIFF
--- a/packages/grid/data-grid/src/DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/DataGrid.test.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-// @ts-expect-error need to migrate helpers to TypeScript
-import { createClientRender, fireEvent, screen, ErrorBoundary, createEvent } from 'test/utils';
+import {
+  createClientRenderStrictMode,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  fireEvent,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  screen,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  ErrorBoundary,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  createEvent,
+} from 'test/utils';
 import { useFakeTimers, spy } from 'sinon';
 import { expect } from 'chai';
 import { DataGrid, RowsProp } from '@material-ui/data-grid';
@@ -12,7 +21,8 @@ import {
 } from 'packages/grid/_modules_/grid/hooks/features/density/useDensity';
 
 describe('<DataGrid />', () => {
-  const render = createClientRender();
+  // TODO v5: replace with createClientRender
+  const render = createClientRenderStrictMode();
 
   const defaultProps = {
     rows: [

--- a/packages/grid/data-grid/src/DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/DataGrid.test.tsx
@@ -544,7 +544,6 @@ describe('<DataGrid />', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid {...defaultProps} hideToolbar={false} rowHeight={rowHeight} />
         </div>,
-        { strict: false },
       );
 
       fireEvent.click(getByText('Density'));
@@ -562,7 +561,6 @@ describe('<DataGrid />', () => {
         <div style={{ width: 300, height: 300 }}>
           <DataGrid {...defaultProps} hideToolbar={false} rowHeight={rowHeight} />
         </div>,
-        { strict: false },
       );
 
       fireEvent.click(getByText('Density'));

--- a/packages/grid/x-grid/src/XGrid.test.tsx
+++ b/packages/grid/x-grid/src/XGrid.test.tsx
@@ -1,13 +1,14 @@
 import * as React from 'react';
 // @ts-expect-error need to migrate helpers to TypeScript
-import { fireEvent, screen, createClientRender } from 'test/utils';
+import { fireEvent, screen, createClientRenderStrictMode } from 'test/utils';
 import { getActiveCell, sleep, raf, getColumnValues } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import { XGrid, useApiRef, Columns } from '@material-ui/x-grid';
 import { useData } from 'packages/storybook/src/hooks/useData';
 
 describe('<XGrid />', () => {
-  const render = createClientRender();
+  // TODO v5: replace with createClientRender
+  const render = createClientRenderStrictMode();
 
   const defaultProps = {
     rows: [

--- a/test/utils/index.ts
+++ b/test/utils/index.ts
@@ -1,1 +1,0 @@
-export * from '@material-ui/monorepo/test/utils';

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { ThemeProvider, unstable_createMuiStrictModeTheme } from '@material-ui/core/styles';
+import { createClientRender } from '@material-ui/monorepo/test/utils';
+
+export * from '@material-ui/monorepo/test/utils';
+
+export const createClientRenderStrictMode = () => {
+  const render = createClientRender();
+  const strictTheme = unstable_createMuiStrictModeTheme();
+  const Wrapper = (props) => <ThemeProvider theme={strictTheme} {...props} />;
+
+  return (element: React.ReactElement, options = {}) =>
+    render(element, {
+      wrapper: Wrapper,
+      ...options,
+    });
+};


### PR DESCRIPTION
@DanailH Could you test that these changes [allow removing the `strict: false`](https://github.com/mui-org/material-ui-x/pull/606/files#diff-376d9a2f4302fcb871a0a80f03b87f87c3d701f71557a27ceb58d34c1cae8edcR511) from the density pull request? We face the same issue when testing the filters and column selector feature.