### PR TITLE
[DataGrid] Improve DX popups

### DIFF
--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
@@ -16,17 +16,17 @@ export const ColumnHeaderMenuIcon: React.FC<ColumnHeaderFilterIconProps> = ({ co
   const icons = useIcons();
   const apiRef = React.useContext(ApiContext);
   const columnMenuState = useGridSelector(apiRef, columnMenuStateSelector);
-  const icon = React.createElement(icons.ColumnMenu!, { fontSize: 'small' });
+  const Icon = icons.ColumnMenu as React.ElementType;
 
-  const menuIconClick = React.useCallback(
+  const handleMenuIconClick = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       event.preventDefault();
       event.stopPropagation();
       const lastMenuState = apiRef!.current.getState<GridState>().columnMenu;
       if (!lastMenuState.open || lastMenuState.field !== column.field) {
-        apiRef?.current.showColumnMenu(column.field);
+        apiRef!.current.showColumnMenu(column.field);
       } else {
-        apiRef?.current.hideColumnMenu();
+        apiRef!.current.hideColumnMenu();
       }
     },
     [apiRef, column.field],
@@ -36,12 +36,13 @@ export const ColumnHeaderMenuIcon: React.FC<ColumnHeaderFilterIconProps> = ({ co
   return (
     <div className={classnames('MuiDataGrid-menuIcon', { 'MuiDataGrid-menuOpen': isOpen })}>
       <IconButton
-        className={'MuiDataGrid-menuIconButton'}
+        className="MuiDataGrid-menuIconButton"
         aria-label="Menu"
+        title="Menu"
         size="small"
-        onClick={menuIconClick}
+        onClick={handleMenuIconClick}
       >
-        {icon}
+        <Icon fontSize="small" />
       </IconButton>
     </div>
   );

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -3,14 +3,19 @@ import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Grow from '@material-ui/core/Grow';
 import MenuList from '@material-ui/core/MenuList';
 import Paper from '@material-ui/core/Paper';
-import Popper from '@material-ui/core/Popper';
+import Popper, { PopperProps } from '@material-ui/core/Popper';
 
-export interface MenuProps {
+export interface MenuProps extends Omit<PopperProps, 'onKeyDown'> {
   open: boolean;
   target: React.ReactNode;
   onKeyDown: (event: React.KeyboardEvent<HTMLUListElement>) => void;
   onClickAway: (event: React.MouseEvent<Document, MouseEvent>) => void;
 }
+
+const transformOrigin = {
+  'bottom-start': 'top left',
+  'bottom-end': 'top right',
+};
 
 export const GridMenu: React.FC<MenuProps> = ({
   open,
@@ -18,14 +23,12 @@ export const GridMenu: React.FC<MenuProps> = ({
   onKeyDown,
   onClickAway,
   children,
+  ...other
 }) => {
   return (
-    <Popper open={open} anchorEl={target as any} transition>
+    <Popper open={open} anchorEl={target as any} transition {...other}>
       {({ TransitionProps, placement }) => (
-        <Grow
-          {...TransitionProps}
-          style={{ transformOrigin: placement === 'bottom' ? 'center top' : 'center bottom' }}
-        >
+        <Grow {...TransitionProps} style={{ transformOrigin: transformOrigin[placement] }}>
           <Paper>
             <ClickAwayListener onClickAway={onClickAway}>
               <MenuList autoFocusItem={open} id="menu-list-grow" onKeyDown={onKeyDown}>

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/ColumnsMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/ColumnsMenuItem.tsx
@@ -22,5 +22,5 @@ export const ColumnsMenuItem: React.FC<FilterItemProps> = ({ onClick }) => {
     return null;
   }
 
-  return <MenuItem onClick={showColumns}>Show Columns</MenuItem>;
+  return <MenuItem onClick={showColumns}>Show columns</MenuItem>;
 };

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -71,8 +71,10 @@ export function GridColumnHeaderMenu() {
   if (!target) {
     return null;
   }
+
   return (
     <GridMenu
+      placement={`bottom-${currentColumn!.align === 'right' ? 'start' : 'end'}` as any}
       open={columnMenuState.open}
       target={target}
       onKeyDown={handleListKeyDown}

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/SortMenuItems.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/SortMenuItems.tsx
@@ -36,15 +36,11 @@ export const SortMenuItems: React.FC<FilterItemProps> = ({ column, onClick }) =>
       <MenuItem onClick={onSortMenuItemClick} disabled={sortDirection == null}>
         Unsort
       </MenuItem>
-      <MenuItem onClick={onSortMenuItemClick} data-value={'asc'} disabled={sortDirection === 'asc'}>
-        Sort By Asc
+      <MenuItem onClick={onSortMenuItemClick} data-value="asc" disabled={sortDirection === 'asc'}>
+        Sort by Asc
       </MenuItem>
-      <MenuItem
-        onClick={onSortMenuItemClick}
-        data-value={'desc'}
-        disabled={sortDirection === 'desc'}
-      >
-        Sort By Desc
+      <MenuItem onClick={onSortMenuItemClick} data-value="desc" disabled={sortDirection === 'desc'}>
+        Sort by Desc
       </MenuItem>
     </React.Fragment>
   );

--- a/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
 import Switch from '@material-ui/core/Switch';
 import Button from '@material-ui/core/Button';
@@ -14,19 +13,18 @@ import { DragIcon } from '../icons/index';
 
 const useStyles = makeStyles(
   {
-    columnsListContainer: {
-      paddingTop: 8,
-      paddingLeft: 12,
+    container: {
+      padding: '8px 0px 8px 8px',
     },
     column: {
       display: 'flex',
       justifyContent: 'space-between',
-      padding: '2px 4px',
+      padding: '1px 8px 1px 7px',
     },
     switch: {
       marginRight: 4,
     },
-    dragIconRoot: {
+    dragIcon: {
       justifyContent: 'flex-end',
     },
   },
@@ -63,8 +61,8 @@ export function ColumnsPanel() {
   const showAllColumns = React.useCallback(() => toggleAllColumns(false), [toggleAllColumns]);
   const hideAllColumns = React.useCallback(() => toggleAllColumns(true), [toggleAllColumns]);
 
-  const onSearchColumnValueChange = React.useCallback((event) => {
-    setSearchValue(event.target.value.toLowerCase());
+  const handleSearchValueChange = React.useCallback((event) => {
+    setSearchValue(event.target.value);
   }, []);
 
   const currentColumns = React.useMemo(
@@ -73,8 +71,9 @@ export function ColumnsPanel() {
         ? columns
         : columns.filter(
             (column) =>
-              column.field.toLowerCase().indexOf(searchValue) > -1 ||
-              (column.headerName && column.headerName.toLowerCase().indexOf(searchValue) > -1),
+              column.field.toLowerCase().indexOf(searchValue.toLowerCase()) > -1 ||
+              (column.headerName &&
+                column.headerName.toLowerCase().indexOf(searchValue.toLowerCase()) > -1),
           ),
     [columns, searchValue],
   );
@@ -88,16 +87,15 @@ export function ColumnsPanel() {
       <div className="MuiDataGridPanel-header">
         <TextField
           label="Find column"
-          placeholder="Column Title"
+          placeholder="Column title"
           inputRef={searchInputRef}
           value={searchValue}
-          onChange={onSearchColumnValueChange}
-          type="text"
+          onChange={handleSearchValueChange}
           fullWidth
         />
       </div>
       <div className="MuiDataGridPanel-container">
-        <div className={classes.columnsListContainer}>
+        <div className={classes.container}>
           {currentColumns.map((column) => (
             <div key={column.field} className={classes.column}>
               <FormControlLabel
@@ -114,16 +112,16 @@ export function ColumnsPanel() {
                 label={column.headerName || column.field}
               />
               {!disableColumnReorder && (
-                <FormControl draggable className={classes.dragIconRoot}>
-                  <IconButton
-                    aria-label="Drag to reorder column"
-                    title="Reorder Column"
-                    size="small"
-                    disabled
-                  >
-                    <DragIcon />
-                  </IconButton>
-                </FormControl>
+                <IconButton
+                  draggable
+                  className={classes.dragIcon}
+                  aria-label="Drag to reorder column"
+                  title="Reorder Column"
+                  size="small"
+                  disabled
+                >
+                  <DragIcon />
+                </IconButton>
               )}
             </div>
           ))}

--- a/packages/grid/_modules_/grid/components/panel/Panel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/Panel.tsx
@@ -1,34 +1,31 @@
+import * as React from 'react';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Paper from '@material-ui/core/Paper';
 import Popper from '@material-ui/core/Popper';
 import { makeStyles, Theme } from '@material-ui/core/styles';
-import * as React from 'react';
-import { useGridSelector } from '../../hooks/features/core/useGridSelector';
-import { viewportSizeStateSelector } from '../../hooks/features/preferencesPanel/preferencePanelSelector';
 import { ApiContext } from '../api-context';
 
 const useStyles = makeStyles(
   (theme: Theme) => ({
-    paper: {
+    root: {
       backgroundColor: theme.palette.background.paper,
       minWidth: 300,
+      maxHeight: 450,
       display: 'flex',
       flexDirection: 'column',
-    },
-    panel: {
-      display: 'flex',
-      flexDirection: 'column',
-      overflow: 'hidden',
       flex: 1,
+      '& .MuiDataGridPanel-header': {
+        padding: 8,
+      },
       '& .MuiDataGridPanel-container': {
         display: 'flex',
         flexDirection: 'column',
         overflow: 'auto',
         flex: '1 1',
       },
-      '& .MuiDataGridPanel-footer, .MuiDataGridPanel-header': {
-        padding: 8,
-        display: 'inline-flex',
+      '& .MuiDataGridPanel-footer': {
+        padding: 4,
+        display: 'flex',
         justifyContent: 'space-between',
       },
     },
@@ -45,14 +42,13 @@ export function Panel(props: PanelProps) {
   const { children, open } = props;
   const classes = useStyles();
   const apiRef = React.useContext(ApiContext);
-  const viewportSizes = useGridSelector(apiRef, viewportSizeStateSelector);
 
-  const hidePreferences = React.useCallback(() => {
-    apiRef?.current.hidePreferences();
+  const handleClickAway = React.useCallback(() => {
+    apiRef!.current.hidePreferences();
   }, [apiRef]);
 
   let anchorEl;
-  if (apiRef?.current && apiRef?.current.columnHeadersElementRef!.current) {
+  if (apiRef!.current && apiRef!.current.columnHeadersElementRef!.current) {
     anchorEl = apiRef?.current.columnHeadersElementRef!.current;
   }
 
@@ -61,22 +57,10 @@ export function Panel(props: PanelProps) {
   }
 
   return (
-    <Popper
-      placement={'bottom-start'}
-      open={open}
-      anchorEl={anchorEl}
-      style={{ position: 'relative', zIndex: 100 }}
-    >
-      <ClickAwayListener onClickAway={hidePreferences}>
-        <Paper
-          className={classes.paper}
-          style={{
-            maxHeight: viewportSizes.height > 600 ? 600 : viewportSizes.height,
-            maxWidth: viewportSizes.width,
-          }}
-          elevation={8}
-        >
-          <div className={classes.panel}>{children}</div>
+    <Popper placement="bottom-start" open={open} anchorEl={anchorEl}>
+      <ClickAwayListener onClickAway={handleClickAway}>
+        <Paper className={classes.root} elevation={8}>
+          {children}
         </Paper>
       </ClickAwayListener>
     </Popper>

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -42,9 +42,11 @@ const useStyles = makeStyles(
     filterValueInput: {
       width: 190,
     },
-    closeIconRoot: {
+    closeIcon: {
       flexShrink: 0,
       justifyContent: 'flex-end',
+      marginRight: 6,
+      marginBottom: 2,
     },
   }),
   { name: 'MuiDataGridFilterForm' },
@@ -131,6 +133,11 @@ export function FilterForm(props: FilterFormProps) {
 
   return (
     <div className={classes.root}>
+      <FormControl className={classes.closeIcon}>
+        <IconButton aria-label="Delete" title="Delete" onClick={handleDeleteFilter} size="small">
+          <CloseIcon fontSize="small" />
+        </IconButton>
+      </FormControl>
       <FormControl
         className={classes.linkOperatorSelect}
         style={{
@@ -195,11 +202,6 @@ export function FilterForm(props: FilterFormProps) {
             applyValue: applyFilterChanges,
             ...currentOperator.InputComponentProps,
           })}
-      </FormControl>
-      <FormControl className={classes.closeIconRoot}>
-        <IconButton aria-label="Delete" title="Delete" onClick={handleDeleteFilter} size="small">
-          <CloseIcon />
-        </IconButton>
       </FormControl>
     </div>
   );


### PR DESCRIPTION
I didn't describe the bugs I went after, happy to do so if somebody wants the information.


The last items I **didn't** handle:

1. The keyboard navigation on the column menu popup is broken, this API isn't possible, it needs `MenuList > MenuItem` to work:
https://github.com/mui-org/material-ui-x/blob/b844a259edb21e777e1a72719ae8f9e56605e695/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx#L75-L85
2. The distance the mouse has to travel could be reduced:
<img width="595" alt="distance we can save" src="https://user-images.githubusercontent.com/3165635/101261720-9c4eb700-3739-11eb-9535-71a1b2f1c7e1.png">
3. The close icon could be disabled, it lures you into thinking it can be clicked but it does nothing:
<img width="549" alt="close icon" src="https://user-images.githubusercontent.com/3165635/101261756-dcae3500-3739-11eb-9921-c2dea4da070e.png">
