### PR TITLE
[DataGrid] sortingMode=server not being honored in a few cases

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -195,7 +195,7 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
         return;
       }
       const sortItem = createSortItem(column, direction);
-      let sortModel;
+      let sortModel: SortItem | SortItem[];
       if (!allowMultipleSorting.current) {
         sortModel = !sortItem ? [] : [sortItem];
       } else {
@@ -214,12 +214,16 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
   );
 
   const onRowsUpdated = React.useCallback(() => {
-    apiRef.current.applySorting();
-  }, [apiRef]);
+    if (options.sortingMode === FeatureModeConstant.client) {
+      apiRef.current.applySorting();
+    }
+  }, [apiRef, options.sortingMode]);
 
   const onResetRows = React.useCallback(() => {
-    apiRef.current.applySorting(true);
-  }, [apiRef]);
+    if (options.sortingMode === FeatureModeConstant.client) {
+      apiRef.current.applySorting(true);
+    }
+  }, [apiRef, options.sortingMode]);
 
   const getSortModel = React.useCallback(() => gridState.sorting.sortModel, [
     gridState.sorting.sortModel,
@@ -257,8 +261,10 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
 
   React.useEffect(() => {
     // When the rows prop change, we re apply the sorting.
-    apiRef.current.applySorting();
-  }, [apiRef, rowsProp]);
+    if (options.sortingMode === FeatureModeConstant.client) {
+      apiRef.current.applySorting();
+    }
+  }, [apiRef, rowsProp, options.sortingMode]);
 
   React.useEffect(() => {
     if (rowCount > 0 && options.sortingMode === FeatureModeConstant.client) {

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -139,15 +139,21 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
 
   const applySorting = React.useCallback(
     (noRerender = false) => {
+      const rowModels = apiRef.current.getRowModels();
+
       if (options.sortingMode === FeatureModeConstant.server) {
         logger.info('Skipping sorting rows as sortingMode = server');
+        setGridState((oldState) => {
+          return {
+            ...oldState,
+            sorting: { ...oldState.sorting, sortedRows: rowModels.map((row) => row.id) },
+          };
+        });
         return;
       }
 
-      const rowModels = apiRef.current.getRowModels();
       const sortModel = apiRef.current.getState<GridState>().sorting.sortModel;
       logger.info('Sorting rows with ', sortModel);
-
       const sorted = [...rowModels];
       if (sortModel.length > 0) {
         comparatorList.current = buildComparatorList(sortModel);
@@ -157,7 +163,7 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
       setGridState((oldState) => {
         return {
           ...oldState,
-          sorting: { ...oldState.sorting, sortedRows: [...sorted.map((row) => row.id)] },
+          sorting: { ...oldState.sorting, sortedRows: sorted.map((row) => row.id) },
         };
       });
       if (!noRerender) {

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -195,13 +195,7 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
       apiRef.current.publishEvent(SORT_MODEL_CHANGE, getSortModelParams(sortModel));
       apiRef.current.applySorting();
     },
-    [
-      setGridState,
-      forceUpdate,
-      visibleColumns.length,
-      apiRef,
-      getSortModelParams,
-    ],
+    [setGridState, forceUpdate, visibleColumns.length, apiRef, getSortModelParams],
   );
 
   const sortColumn = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -201,7 +201,6 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
       visibleColumns.length,
       apiRef,
       getSortModelParams,
-      options.sortingMode,
     ],
   );
 

--- a/packages/grid/data-grid/src/DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/DataGrid.test.tsx
@@ -463,7 +463,7 @@ describe('<DataGrid />', () => {
         return (
           <div style={{ width: 300, height: 300 }}>
             <DataGrid
-              {...defaultProps}
+              {...baselineProps}
               sortingMode="server"
               rows={rows}
               sortModel={[

--- a/packages/grid/data-grid/src/DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/DataGrid.test.tsx
@@ -415,6 +415,50 @@ describe('<DataGrid />', () => {
         expect(getColumnValues()).to.deep.equal(['Asics', 'Hugo', 'RedBull']);
       });
     });
+
+    it('should support server-side sorting', () => {
+      interface TestCaseProps {
+        rows: any[];
+      }
+      const TestCase = (props: TestCaseProps) => {
+        const { rows } = props;
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid
+              {...defaultProps}
+              sortingMode="server"
+              rows={rows}
+              sortModel={[
+                {
+                  field: 'brand',
+                  sort: 'desc',
+                },
+              ]}
+            />
+          </div>
+        );
+      };
+
+      const rows = [
+        {
+          id: 3,
+          brand: 'Asics',
+        },
+        {
+          id: 4,
+          brand: 'RedBull',
+        },
+        {
+          id: 5,
+          brand: 'Hugo',
+        },
+      ];
+
+      const { setProps } = render(<TestCase rows={[rows[0], rows[1]]} />);
+      expect(getColumnValues()).to.deep.equal(['Asics', 'RedBull']);
+      setProps({ rows });
+      expect(getColumnValues()).to.deep.equal(['Asics', 'RedBull', 'Hugo']);
+    });
   });
 
   describe('keyboard', () => {


### PR DESCRIPTION
There seem to be a few cases where applySorting is being called without checking if it's being handled by the server first. This leads to cases where the server response sends sorted rows but the client re-sorts the page before rendering them.

First PR (here) so be easy on me if I missed something. Thanks!