### PR TITLE
[DataGrid] Fix row cells leaking CSS 'text-align' from parent

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -88,6 +88,7 @@ The `ref` is forwarded to the root element.
 |  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
 |  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellCenter</span> | Styles applied to the centered cell element.|
 |  | <span class="prop-name">.MuiDataGrid-footer</span> | Styles applied to the footer element.|
 |  | <span class="prop-name">.MuiDataGrid-rowCount</span> | Styles applied to the footer row count element.|

--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -87,8 +87,8 @@ The `ref` is forwarded to the root element.
 |  | <span class="prop-name">.Mui-selected</span> | Styles applied to the selected row element.|
 |  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
-|  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellCenter</span> | Styles applied to the centered cell element.|
 |  | <span class="prop-name">.MuiDataGrid-footer</span> | Styles applied to the footer element.|
 |  | <span class="prop-name">.MuiDataGrid-rowCount</span> | Styles applied to the footer row count element.|

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -93,6 +93,7 @@ The `ref` is forwarded to the root element.
 |  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
 |  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellCenter</span> | Styles applied to the centered cell element.|
 |  | <span class="prop-name">.MuiDataGrid-footer</span> | Styles applied to the footer element.|
 |  | <span class="prop-name">.MuiDataGrid-rowCount</span> | Styles applied to the footer row count element.|

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -92,8 +92,8 @@ The `ref` is forwarded to the root element.
 |  | <span class="prop-name">.Mui-selected</span> | Styles applied to the selected row element.|
 |  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
-|  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellCenter</span> | Styles applied to the centered cell element.|
 |  | <span class="prop-name">.MuiDataGrid-footer</span> | Styles applied to the footer element.|
 |  | <span class="prop-name">.MuiDataGrid-rowCount</span> | Styles applied to the footer row count element.|

--- a/packages/grid/_modules_/grid/components/Cell.tsx
+++ b/packages/grid/_modules_/grid/components/Cell.tsx
@@ -75,7 +75,7 @@ Cell.displayName = 'GridCell';
 interface EmptyCellProps {
   width?: number;
   height?: number;
-  align: Alignment;
+  align?: Alignment;
 }
 
 export const LeftEmptyCell: React.FC<EmptyCellProps> = React.memo(

--- a/packages/grid/_modules_/grid/components/Cell.tsx
+++ b/packages/grid/_modules_/grid/components/Cell.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { capitalize } from '@material-ui/core/utils';
 import { Alignment, CellValue } from '../models';
 import { CELL_CSS_CLASS } from '../constants/cssClassesConstants';
 import { classnames } from '../utils';
@@ -18,14 +19,9 @@ export interface GridCellProps {
   rowIndex?: number;
 }
 
-const alignPropToCssClass = {
-  center: 'MuiDataGrid-cellCenter',
-  right: 'MuiDataGrid-cellRight',
-};
-
 export const Cell: React.FC<GridCellProps> = React.memo((props) => {
   const {
-    align,
+    align = 'left',
     children,
     colIndex,
     cssClass,
@@ -52,12 +48,9 @@ export const Cell: React.FC<GridCellProps> = React.memo((props) => {
   return (
     <div
       ref={cellRef}
-      className={classnames(
-        CELL_CSS_CLASS,
-        cssClass,
-        { 'MuiDataGrid-withBorder': showRightBorder },
-        align && align !== 'left' ? alignPropToCssClass[align] : '',
-      )}
+      className={classnames(CELL_CSS_CLASS, cssClass, `MuiDataGrid-cell${capitalize(align)}`, {
+        'MuiDataGrid-withBorder': showRightBorder,
+      })}
       role="cell"
       data-value={value}
       data-field={field}

--- a/packages/grid/_modules_/grid/components/Cell.tsx
+++ b/packages/grid/_modules_/grid/components/Cell.tsx
@@ -12,7 +12,7 @@ export interface GridCellProps {
   height: number;
   showRightBorder?: boolean;
   hasFocus?: boolean;
-  align?: Alignment;
+  align: Alignment;
   cssClass?: string;
   tabIndex?: number;
   colIndex?: number;
@@ -21,7 +21,7 @@ export interface GridCellProps {
 
 export const Cell: React.FC<GridCellProps> = React.memo((props) => {
   const {
-    align = 'left',
+    align,
     children,
     colIndex,
     cssClass,
@@ -72,18 +72,20 @@ export const Cell: React.FC<GridCellProps> = React.memo((props) => {
 
 Cell.displayName = 'GridCell';
 
-export const LeftEmptyCell: React.FC<{
+interface EmptyCellProps {
   width?: number;
   height?: number;
-}> = React.memo(({ width, height }) =>
-  !width || !height ? null : <Cell width={width} height={height} />,
+  align: Alignment;
+}
+
+export const LeftEmptyCell: React.FC<EmptyCellProps> = React.memo(
+  ({ width, height, align = 'left' }) =>
+    !width || !height ? null : <Cell width={width} height={height} align={align} />,
 );
 LeftEmptyCell.displayName = 'LeftEmptyCell';
 
-export const RightEmptyCell: React.FC<{
-  width?: number;
-  height?: number;
-}> = React.memo(({ width, height }) =>
-  !width || !height ? null : <Cell width={width} height={height} />,
+export const RightEmptyCell: React.FC<EmptyCellProps> = React.memo(
+  ({ width, height, align = 'left' }) =>
+    !width || !height ? null : <Cell width={width} height={height} align={align} />,
 );
 RightEmptyCell.displayName = 'RightEmptyCell';

--- a/packages/grid/_modules_/grid/components/Cell.tsx
+++ b/packages/grid/_modules_/grid/components/Cell.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Alignement, CellValue } from '../models';
+import { Alignment, CellValue } from '../models';
 import { CELL_CSS_CLASS } from '../constants/cssClassesConstants';
 import { classnames } from '../utils';
 
@@ -11,7 +11,7 @@ export interface GridCellProps {
   height: number;
   showRightBorder?: boolean;
   hasFocus?: boolean;
-  align?: Alignement;
+  align?: Alignment;
   cssClass?: string;
   tabIndex?: number;
   colIndex?: number;

--- a/packages/grid/_modules_/grid/components/Cell.tsx
+++ b/packages/grid/_modules_/grid/components/Cell.tsx
@@ -75,17 +75,14 @@ Cell.displayName = 'GridCell';
 interface EmptyCellProps {
   width?: number;
   height?: number;
-  align?: Alignment;
 }
 
-export const LeftEmptyCell: React.FC<EmptyCellProps> = React.memo(
-  ({ width, height, align = 'left' }) =>
-    !width || !height ? null : <Cell width={width} height={height} align={align} />,
+export const LeftEmptyCell: React.FC<EmptyCellProps> = React.memo(({ width, height }) =>
+  !width || !height ? null : <Cell width={width} height={height} align="left" />,
 );
 LeftEmptyCell.displayName = 'LeftEmptyCell';
 
-export const RightEmptyCell: React.FC<EmptyCellProps> = React.memo(
-  ({ width, height, align = 'left' }) =>
-    !width || !height ? null : <Cell width={width} height={height} align={align} />,
+export const RightEmptyCell: React.FC<EmptyCellProps> = React.memo(({ width, height }) =>
+  !width || !height ? null : <Cell width={width} height={height} align="left" />,
 );
 RightEmptyCell.displayName = 'RightEmptyCell';

--- a/packages/grid/_modules_/grid/components/RowCells.tsx
+++ b/packages/grid/_modules_/grid/components/RowCells.tsx
@@ -108,7 +108,7 @@ export const RowCells: React.FC<RowCellsProps> = React.memo((props) => {
       height: rowHeight,
       showRightBorder,
       ...formattedValueProp,
-      align: column.align,
+      align: column.align || 'left',
       ...cssClassProp,
       tabIndex: domIndex === 0 && colIdx === 0 ? 0 : -1,
       rowIndex,

--- a/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts
@@ -234,6 +234,9 @@ export const useStyles = makeStyles(
         '& .MuiDataGrid-withBorder': {
           borderRight: `1px solid ${borderColor}`,
         },
+        '& .MuiDataGrid-cellLeft': {
+          textAlign: 'left',
+        },
         '& .MuiDataGrid-cellRight': {
           textAlign: 'right',
         },

--- a/packages/grid/_modules_/grid/models/colDef/colDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/colDef.ts
@@ -8,9 +8,9 @@ import { ComparatorFn, SortDirection } from '../sortModel';
 import { ColType, NativeColTypes } from './colType';
 
 /**
- * Alignement used in position elements in Cells.
+ * Alignment used in position elements in Cells.
  */
-export type Alignement = 'left' | 'right' | 'center';
+export type Alignment = 'left' | 'right' | 'center';
 
 /**
  * Column Definition interface.
@@ -72,7 +72,7 @@ export interface ColDef {
   /**
    * Allows to align the column values in cells.
    */
-  align?: Alignement;
+  align?: Alignment;
   /**
    * Function that allows to get a specific data instead of field to render in the cell.
    * @param params
@@ -108,7 +108,7 @@ export interface ColDef {
   /**
    * Header cell element alignment.
    */
-  headerAlign?: Alignement;
+  headerAlign?: Alignment;
   /**
    * Toggle the visibility of the sort icons.
    */


### PR DESCRIPTION
Fixes #381 

Tested on storybook to reproduce it before the fix and whether it works properly after the fix.



