### PR TITLE
[DataGrid] Fix last column missing padding

### DIFF
--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
@@ -14,6 +14,7 @@ import { ColumnHeaderMenuIcon } from './ColumnHeaderMenuIcon';
 import { ColumnHeaderFilterIcon } from './ColumnHeaderFilterIcon';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { densityHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
+import { optionsSelector } from '../../hooks/utils/useOptionsProp';
 
 interface ColumnHeaderItemProps {
   colIndex: number;
@@ -24,7 +25,7 @@ interface ColumnHeaderItemProps {
   sortIndex?: number;
   options: GridOptions;
   filterItemsCounter?: number;
-  width: number;
+  isLastColumn: boolean;
 }
 
 export const ColumnHeaderItem = ({
@@ -36,10 +37,11 @@ export const ColumnHeaderItem = ({
   sortIndex,
   options,
   filterItemsCounter,
-  width,
+  isLastColumn,
 }: ColumnHeaderItemProps) => {
   const apiRef = React.useContext(ApiContext);
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
+  const { scrollbarSize } = useGridSelector(apiRef, optionsSelector);
   const {
     disableColumnReorder,
     showColumnRightBorder,
@@ -105,6 +107,7 @@ export const ColumnHeaderItem = ({
     onDragEnter,
     onDragOver,
   };
+  const width = column.width!;
 
   let ariaSort: any;
   if (sortDirection != null) {
@@ -166,6 +169,7 @@ export const ColumnHeaderItem = ({
         height={headerHeight}
         onMouseDown={apiRef?.current.startResizeOnMouseDown}
       />
+      {isLastColumn && <div style={{ width: scrollbarSize }} />}
     </div>
   );
 };

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
@@ -24,6 +24,7 @@ interface ColumnHeaderItemProps {
   sortIndex?: number;
   options: GridOptions;
   filterItemsCounter?: number;
+  width: number;
 }
 
 export const ColumnHeaderItem = ({
@@ -35,6 +36,7 @@ export const ColumnHeaderItem = ({
   sortIndex,
   options,
   filterItemsCounter,
+  width,
 }: ColumnHeaderItemProps) => {
   const apiRef = React.useContext(ApiContext);
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
@@ -103,7 +105,6 @@ export const ColumnHeaderItem = ({
     onDragEnter,
     onDragOver,
   };
-  const width = column.width!;
 
   let ariaSort: any;
   if (sortDirection != null) {

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaders.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaders.tsx
@@ -19,11 +19,11 @@ export const ColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function Colum
 ) {
   const apiRef = React.useContext(ApiContext);
   const columns = useGridSelector(apiRef, visibleColumnsSelector);
-  const { disableColumnReorder, scrollbarSize } = useGridSelector(apiRef, optionsSelector);
+  const { disableColumnReorder } = useGridSelector(apiRef, optionsSelector);
   const containerSizes = useGridSelector(apiRef, containerSizesSelector);
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
   const renderCtx = useGridSelector(apiRef, renderStateSelector).renderContext;
-  const { hasScrollX, hasScrollY } = useGridSelector(apiRef, scrollbarStateSelector);
+  const { hasScrollX } = useGridSelector(apiRef, scrollbarStateSelector);
   const wrapperCssClasses = `MuiDataGrid-colCellWrapper ${hasScrollX ? 'scroll' : ''}`;
 
   const renderedCols = React.useMemo(() => {
@@ -52,11 +52,7 @@ export const ColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function Colum
         onDragOver={handleDragOver}
       >
         <LeftEmptyCell width={renderCtx?.leftEmptyWidth} height={headerHeight} />
-        <ColumnHeaderItemCollection
-          hasScroll={{ x: hasScrollX, y: hasScrollY }}
-          columns={renderedCols}
-          scrollSize={scrollbarSize}
-        />
+        <ColumnHeaderItemCollection columns={renderedCols} />
         <RightEmptyCell width={renderCtx?.rightEmptyWidth} height={headerHeight} />
       </div>
       <ScrollArea scrollDirection="right" />

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaders.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaders.tsx
@@ -19,11 +19,11 @@ export const ColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function Colum
 ) {
   const apiRef = React.useContext(ApiContext);
   const columns = useGridSelector(apiRef, visibleColumnsSelector);
-  const { disableColumnReorder } = useGridSelector(apiRef, optionsSelector);
+  const { disableColumnReorder, scrollbarSize } = useGridSelector(apiRef, optionsSelector);
   const containerSizes = useGridSelector(apiRef, containerSizesSelector);
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
   const renderCtx = useGridSelector(apiRef, renderStateSelector).renderContext;
-  const { hasScrollX } = useGridSelector(apiRef, scrollbarStateSelector);
+  const { hasScrollX, hasScrollY } = useGridSelector(apiRef, scrollbarStateSelector);
   const wrapperCssClasses = `MuiDataGrid-colCellWrapper ${hasScrollX ? 'scroll' : ''}`;
 
   const renderedCols = React.useMemo(() => {
@@ -52,7 +52,11 @@ export const ColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function Colum
         onDragOver={handleDragOver}
       >
         <LeftEmptyCell width={renderCtx?.leftEmptyWidth} height={headerHeight} />
-        <ColumnHeaderItemCollection columns={renderedCols} />
+        <ColumnHeaderItemCollection
+          hasScroll={{ x: hasScrollX, y: hasScrollY }}
+          columns={renderedCols}
+          scrollSize={scrollbarSize}
+        />
         <RightEmptyCell width={renderCtx?.rightEmptyWidth} height={headerHeight} />
       </div>
       <ScrollArea scrollDirection="right" />

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeadersItemCollection.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeadersItemCollection.tsx
@@ -14,12 +14,10 @@ import { ColumnHeaderItem } from './ColumnHeaderItem';
 
 export interface ColumnHeadersItemCollectionProps {
   columns: Columns;
-  hasScroll: { y: boolean; x: boolean };
-  scrollSize: number;
 }
 
 export function ColumnHeaderItemCollection(props: ColumnHeadersItemCollectionProps) {
-  const { columns, hasScroll, scrollSize } = props;
+  const { columns } = props;
   const [resizingColField, setResizingColField] = React.useState('');
   const apiRef = React.useContext(ApiContext);
   const options = useGridSelector(apiRef, optionsSelector);
@@ -39,8 +37,6 @@ export function ColumnHeaderItemCollection(props: ColumnHeadersItemCollectionPro
   useApiEventHandler(apiRef!, COL_RESIZE_STOP, handleResizeStop);
   const items = columns.map((col, idx) => {
     const isLastColumn = idx === columns.length - 1;
-    const removeScrollWidth = isLastColumn && hasScroll.y && hasScroll.x;
-    const width = removeScrollWidth ? Math.abs(col.width! - scrollSize * 2) : col.width!;
     return (
       <ColumnHeaderItem
         key={col.field}
@@ -50,7 +46,7 @@ export function ColumnHeaderItemCollection(props: ColumnHeadersItemCollectionPro
         isDragging={col.field === dragCol}
         column={col}
         colIndex={idx}
-        width={width}
+        isLastColumn={isLastColumn}
         isResizing={resizingColField === col.field}
       />
     );

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeadersItemCollection.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeadersItemCollection.tsx
@@ -14,10 +14,12 @@ import { ColumnHeaderItem } from './ColumnHeaderItem';
 
 export interface ColumnHeadersItemCollectionProps {
   columns: Columns;
+  hasScroll: { y: boolean; x: boolean };
+  scrollSize: number;
 }
 
 export function ColumnHeaderItemCollection(props: ColumnHeadersItemCollectionProps) {
-  const { columns } = props;
+  const { columns, hasScroll, scrollSize } = props;
   const [resizingColField, setResizingColField] = React.useState('');
   const apiRef = React.useContext(ApiContext);
   const options = useGridSelector(apiRef, optionsSelector);
@@ -35,19 +37,24 @@ export function ColumnHeaderItemCollection(props: ColumnHeadersItemCollectionPro
   // TODO refactor by putting resizing in the state so we avoid adding listeners.
   useApiEventHandler(apiRef!, COL_RESIZE_START, handleResizeStart);
   useApiEventHandler(apiRef!, COL_RESIZE_STOP, handleResizeStop);
-
-  const items = columns.map((col, idx) => (
-    <ColumnHeaderItem
-      key={col.field}
-      {...sortColumnLookup[col.field]}
-      filterItemsCounter={filterColumnLookup[col.field] && filterColumnLookup[col.field].length}
-      options={options}
-      isDragging={col.field === dragCol}
-      column={col}
-      colIndex={idx}
-      isResizing={resizingColField === col.field}
-    />
-  ));
+  const items = columns.map((col, idx) => {
+    const isLastColumn = idx === columns.length - 1;
+    const removeScrollWidth = isLastColumn && hasScroll.y && hasScroll.x;
+    const width = removeScrollWidth ? Math.abs(col.width! - scrollSize * 2) : col.width!;
+    return (
+      <ColumnHeaderItem
+        key={col.field}
+        {...sortColumnLookup[col.field]}
+        filterItemsCounter={filterColumnLookup[col.field] && filterColumnLookup[col.field].length}
+        options={options}
+        isDragging={col.field === dragCol}
+        column={col}
+        colIndex={idx}
+        width={width}
+        isResizing={resizingColField === col.field}
+      />
+    );
+  });
 
   return (
     <React.Fragment>


### PR DESCRIPTION
Fixes #442 

Added an empty div element to show space above the scroll on the last column. This especially happens if there is a menu item on a NUMERIC column type i.e when the menu is on the left side.

I had tried padding or reducing the width for last column header like this,
```js
const isLastColumn = idx === columns.length - 1;
const removeScrollWidth = isLastColumn && hasScroll.y && hasScroll.x;
const width = removeScrollWidth ? Math.abs(col.width! - scrollSize * 2) : col.width!;
```

But then the text is overflowing as shown below:
![Screenshot 2020-12-15 at 4 34 34 PM](https://user-images.githubusercontent.com/20900032/102214016-a15ff300-3efd-11eb-8940-43119bf7a2ff.png)

----
Now after fix:
![Screenshot 2020-12-15 at 5 44 27 PM](https://user-images.githubusercontent.com/20900032/102214083-b76db380-3efd-11eb-90cb-de0aaf19fa31.png)

I know it is not a good solution to add an extra div into the DOM tree just for spacing but couldn't find a better solution. 
If there is a better solution, help would be appreciated!
Issue can be reproduced in storybook.