### PR TITLE
[DataGrid] Performance optimization for updating rows={...}

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "docs",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "private": true,
   "author": "Material-UI Team",
   "license": "MIT",

--- a/lerna.json
+++ b/lerna.json
@@ -10,7 +10,7 @@
     "packages/*",
     "packages/grid/*"
   ],
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/demo-app/package.json
+++ b/packages/demo-app/package.json
@@ -1,12 +1,12 @@
 {
   "name": "demo-app",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "private": true,
   "dependencies": {
     "@material-ui/core": "^4.9.12",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
-    "@material-ui/x-grid": "^4.0.0-alpha.11",
+    "@material-ui/x-grid": "^4.0.0-alpha.12",
     "@material-ui/x-grid-data-generator": "^4.0.0-alpha.11",
     "@trendmicro/react-interpolate": "^0.5.5",
     "react": "^16.13.1",

--- a/packages/grid/_modules_/grid/components/RowElements.tsx
+++ b/packages/grid/_modules_/grid/components/RowElements.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { CellIndexCoordinates, Columns, GridOptions, RenderContextProps, RowModel } from '../models';
+import { LeftEmptyCell, RightEmptyCell } from './Cell';
+import { Row } from './Row';
+import { RowCells } from './RowCells';
+
+export const RowElements: React.FC<{
+  row: RowModel;
+  domIndex: number;
+  renderContext: RenderContextProps;
+  options: GridOptions;
+  columns: Columns;
+  cellFocus: CellIndexCoordinates | null;
+  hasScroll: { y: boolean; x: boolean };
+  selected: boolean;
+  rowHeight: number
+}> = React.memo(({
+  row,
+  domIndex,
+  renderContext,
+  options,
+  columns,
+  cellFocus,
+  hasScroll,
+  selected,
+  rowHeight,
+}) => {
+  return (
+    <Row
+      className={
+        (renderContext.firstRowIdx + domIndex) % 2 === 0 ? 'Mui-even' : 'Mui-odd'
+      }
+      id={row.id}
+      selected={selected}
+      rowIndex={renderContext.firstRowIdx + domIndex}
+    >
+      <LeftEmptyCell width={renderContext.leftEmptyWidth} height={rowHeight} />
+      <RowCells
+        columns={columns}
+        row={row}
+        firstColIdx={renderContext.firstColIdx}
+        lastColIdx={renderContext.lastColIdx}
+        hasScroll={hasScroll}
+        scrollSize={options.scrollbarSize}
+        showCellRightBorder={!!options.showCellRightBorder}
+        extendRowFullWidth={!options.disableExtendRowFullWidth}
+        rowIndex={renderContext.firstRowIdx + domIndex}
+        cellFocus={cellFocus}
+        domIndex={domIndex}
+      />
+      <RightEmptyCell width={renderContext.rightEmptyWidth} height={rowHeight} />
+    </Row>
+  )
+});
+RowElements.displayName = 'RowElements';

--- a/packages/grid/_modules_/grid/components/Viewport.tsx
+++ b/packages/grid/_modules_/grid/components/Viewport.tsx
@@ -10,11 +10,10 @@ import { renderStateSelector } from '../hooks/features/virtualization/renderingS
 import { useLogger } from '../hooks/utils/useLogger';
 import { optionsSelector } from '../hooks/utils/useOptionsProp';
 import { ApiContext } from './api-context';
-import { LeftEmptyCell, RightEmptyCell } from './Cell';
 import { RenderingZone } from './RenderingZone';
-import { Row } from './Row';
-import { RowCells } from './RowCells';
 import { StickyContainer } from './StickyContainer';
+import { RowElements } from './RowElements';
+import { RenderContextProps } from '../models';
 
 type ViewportType = React.ForwardRefExoticComponent<React.RefAttributes<HTMLDivElement>>;
 
@@ -43,37 +42,25 @@ export const Viewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
       if (renderState.renderContext == null) {
         return null;
       }
+      const renderContext = renderState.renderContext as RenderContextProps
 
       const renderedRows = rows.slice(
-        renderState.renderContext.firstRowIdx,
-        renderState.renderContext.lastRowIdx!,
+        renderContext.firstRowIdx,
+        renderContext.lastRowIdx,
       );
       return renderedRows.map((r, idx) => (
-        <Row
-          className={
-            (renderState.renderContext!.firstRowIdx! + idx) % 2 === 0 ? 'Mui-even' : 'Mui-odd'
-          }
+        <RowElements
           key={r.id}
-          id={r.id}
+          row={r}
+          domIndex={idx}
+          renderContext={renderContext}
+          options={options}
+          columns={visibleColumns}
+          cellFocus={cellFocus}
+          hasScroll={hasScroll}
           selected={!!selectionState[r.id]}
-          rowIndex={renderState.renderContext!.firstRowIdx! + idx}
-        >
-          <LeftEmptyCell width={renderState.renderContext!.leftEmptyWidth} height={rowHeight} />
-          <RowCells
-            columns={visibleColumns}
-            row={r}
-            firstColIdx={renderState.renderContext!.firstColIdx!}
-            lastColIdx={renderState.renderContext!.lastColIdx!}
-            hasScroll={hasScroll}
-            scrollSize={options.scrollbarSize}
-            showCellRightBorder={!!options.showCellRightBorder}
-            extendRowFullWidth={!options.disableExtendRowFullWidth}
-            rowIndex={renderState.renderContext!.firstRowIdx! + idx}
-            cellFocus={cellFocus}
-            domIndex={idx}
-          />
-          <RightEmptyCell width={renderState.renderContext!.rightEmptyWidth} height={rowHeight} />
-        </Row>
+          rowHeight={rowHeight}
+        />
       ));
     };
 

--- a/packages/grid/_modules_/grid/components/Viewport.tsx
+++ b/packages/grid/_modules_/grid/components/Viewport.tsx
@@ -33,6 +33,7 @@ export const Viewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
     const scrollBarState = useGridSelector(apiRef, scrollBarSizeSelector);
     const visibleColumns = useGridSelector(apiRef, visibleColumnsSelector);
     const renderState = useGridSelector(apiRef, renderStateSelector);
+    const hasScroll = React.useMemo(() => ({ y: scrollBarState!.hasScrollY, x: scrollBarState.hasScrollX }), [scrollBarState])
     const cellFocus = useGridSelector(apiRef, keyboardCellSelector);
     const selectionState = useGridSelector(apiRef, selectionStateSelector);
     const rows = useGridSelector(apiRef, visibleSortedRowsSelector);
@@ -63,7 +64,7 @@ export const Viewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
             row={r}
             firstColIdx={renderState.renderContext!.firstColIdx!}
             lastColIdx={renderState.renderContext!.lastColIdx!}
-            hasScroll={{ y: scrollBarState!.hasScrollY, x: scrollBarState.hasScrollX }}
+            hasScroll={hasScroll}
             scrollSize={options.scrollbarSize}
             showCellRightBorder={!!options.showCellRightBorder}
             extendRowFullWidth={!options.disableExtendRowFullWidth}

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
@@ -26,7 +26,7 @@ interface ColumnHeaderItemProps {
   filterItemsCounter?: number;
 }
 
-export const ColumnHeaderItem = ({
+export const ColumnHeaderItem = React.memo(({
   column,
   colIndex,
   isDragging,
@@ -167,4 +167,5 @@ export const ColumnHeaderItem = ({
       />
     </div>
   );
-};
+});
+ColumnHeaderItem.displayName = 'ColumnHeaderItem';

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material-ui/data-grid",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "description": "The Material-UI community edition of the data grid component.",
   "author": "Material-UI Team",
   "main": "dist/index-cjs.js",

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@material-ui/x-grid",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "description": "The Material-UI X edition of the data grid component.",
   "author": "Material-UI Team",
   "main": "dist/index-cjs.js",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -1,6 +1,6 @@
 {
   "name": "storybook",
-  "version": "4.0.0-alpha.11",
+  "version": "4.0.0-alpha.12",
   "description": "Storybook components",
   "author": "Material-UI Team",
   "private": true,
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@material-ui/core": "^4.9.12",
-    "@material-ui/data-grid": "^4.0.0-alpha.11",
+    "@material-ui/data-grid": "^4.0.0-alpha.12",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.54",
-    "@material-ui/x-grid": "^4.0.0-alpha.11",
+    "@material-ui/x-grid": "^4.0.0-alpha.12",
     "@material-ui/x-grid-data-generator": "^4.0.0-alpha.11",
     "@material-ui/x-license": "^4.0.0-alpha.11",
     "react": "^16.13.1",


### PR DESCRIPTION
I'm using TextField in 22 columns DataGrid and used Profiler in react-dev-tools to detect hot spot.
This PR reduces re-render for updating rows=[...}

(And bump package.json commit which maybe missing from master branch :)