### PR TITLE
[DataGrid] getValueError in valueGetter if incorrect field is supplied

### DIFF
--- a/packages/grid/_modules_/grid/utils/paramsUtils.ts
+++ b/packages/grid/_modules_/grid/utils/paramsUtils.ts
@@ -5,6 +5,8 @@ import { GridApi } from '../models/api/gridApi';
 import { CellParams } from '../models/params/cellParams';
 import { RowParams } from '../models/params/rowParams';
 
+let warnedOnce = false;
+
 export function buildCellParams({
   element,
   value,
@@ -27,9 +29,23 @@ export function buildCellParams({
     getValue: (field: string) => {
       // We are getting the value of another column here, field
       const col = api.getColumnFromField(field);
+
+      if (process.env.NODE_ENV !== 'production') {
+        if (!col && !warnedOnce) {
+          console.warn(
+            [
+              `Material-UI: You are calling getValue('${field}') but the column \`${field}\` is not defined.`,
+              `Instead, you can access the data from \`params.row.${field}\`.`,
+            ].join('\n'),
+          );
+          warnedOnce = true;
+        }
+      }
+
       if (!col || !col.valueGetter) {
         return rowModel[field];
       }
+
       return col.valueGetter(
         buildCellParams({
           value: rowModel[field],

--- a/packages/grid/_modules_/grid/utils/paramsUtils.ts
+++ b/packages/grid/_modules_/grid/utils/paramsUtils.ts
@@ -27,7 +27,7 @@ export function buildCellParams({
     getValue: (field: string) => {
       // We are getting the value of another column here, field
       const col = api.getColumnFromField(field);
-      if (!col.valueGetter) {
+      if (!col || !col.valueGetter) {
         return rowModel[field];
       }
       return col.valueGetter(

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -131,15 +131,15 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         ];
 
         const rows = [
-          { id: 1, lastName: 'Snow', firstName: 'Jon' },
-          { id: 2, lastName: 'Lannister', firstName: 'Cersei' },
+          { id: 1, lastName: 'Snow', firstName: 'Jon', age: 1 },
+          { id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 2 },
         ];
         render(
           <div style={{ width: 300, height: 300 }}>
             <DataGrid rows={rows} columns={columns} />
           </div>,
         );
-        expect(getColumnValues()).to.deep.equal(['', '']);
+        expect(getColumnValues()).to.deep.equal(['1', '2']);
       });
     });
 

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -118,6 +118,29 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         );
         expect(getColumnValues()).to.deep.equal(['Jon Snow', 'Cersei Lannister']);
       });
+
+      it('should support columns.valueGetter even if field param supplied is incorrect resulting in no data to be rendered', () => {
+        const columns = [
+          { field: 'id', hide: true },
+          { field: 'firstName', hide: true },
+          { field: 'lastName', hide: true },
+          {
+            field: 'fullName',
+            valueGetter: (params) => params.getValue('age'), // incorrect field parameter supplied to 'getValue'
+          },
+        ];
+
+        const rows = [
+          { id: 1, lastName: 'Snow', firstName: 'Jon' },
+          { id: 2, lastName: 'Lannister', firstName: 'Cersei' },
+        ];
+        render(
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid rows={rows} columns={columns} />
+          </div>,
+        );
+        expect(getColumnValues()).to.deep.equal(['', '']);
+      });
     });
 
     describe('warnings', () => {

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -7,7 +7,7 @@ import {
 } from 'test/utils';
 import { useFakeTimers } from 'sinon';
 import { expect } from 'chai';
-import { DataGrid } from '@material-ui/data-grid';
+import { DataGrid, ValueGetterParams } from '@material-ui/data-grid';
 import { getColumnValues, raf } from 'test/utils/helperFn';
 
 describe('<DataGrid /> - Layout & Warnings', () => {
@@ -118,29 +118,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         );
         expect(getColumnValues()).to.deep.equal(['Jon Snow', 'Cersei Lannister']);
       });
-
-      it('should support columns.valueGetter even if field param supplied is incorrect resulting in no data to be rendered', () => {
-        const columns = [
-          { field: 'id', hide: true },
-          { field: 'firstName', hide: true },
-          { field: 'lastName', hide: true },
-          {
-            field: 'fullName',
-            valueGetter: (params) => params.getValue('age'), // incorrect field parameter supplied to 'getValue'
-          },
-        ];
-
-        const rows = [
-          { id: 1, lastName: 'Snow', firstName: 'Jon', age: 1 },
-          { id: 2, lastName: 'Lannister', firstName: 'Cersei', age: 2 },
-        ];
-        render(
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid rows={rows} columns={columns} />
-          </div>,
-        );
-        expect(getColumnValues()).to.deep.equal(['1', '2']);
-      });
     });
 
     describe('warnings', () => {
@@ -182,6 +159,29 @@ describe('<DataGrid /> - Layout & Warnings', () => {
         }).toWarnDev(
           'Material-UI: useResizeContainer - The parent of the grid has an empty width.',
         );
+      });
+
+      it('should warn when CellParams.valueGetter is called with a missing column', () => {
+        const rows = [
+          { id: 1, age: 1 },
+          { id: 2, age: 2 },
+        ];
+        const columns = [
+          { field: 'id', hide: true },
+          {
+            field: 'fullName',
+            valueGetter: (params: ValueGetterParams) => params.getValue('age'),
+          },
+        ];
+        expect(() => {
+          render(
+            <div style={{ width: 300, height: 300 }}>
+              <DataGrid rows={rows} columns={columns} />
+            </div>,
+          );
+          // @ts-expect-error need to migrate helpers to TypeScript
+        }).toWarnDev(["You are calling getValue('age') but the column `age` is not defined"]);
+        expect(getColumnValues()).to.deep.equal(['1', '2']);
       });
     });
 


### PR DESCRIPTION
Fixes #749 

Render empty row data if column field for `valueGetter` method is incorrect instead of app crashing.

Not sure if throwing error in console instead would be a better idea like:
```js
 const col = api.getColumnFromField(field);
 if(!col) {
    throw new Error(`Material-UI: The field ${field} supplied to valueGetter element is invalid.`);
 }
 if (!col.valueGetter) {
   return rowModel[field];
 }
```

