### PR TITLE
[test] We don't need to wait 100ms

### DIFF
--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -138,7 +138,8 @@ describe('<DataGrid /> - Layout & Warnings', () => {
               <DataGrid {...baselineProps} />
             </div>,
           );
-          clock.tick(100);
+          // Use timeout to allow simpler tests in JSDOM.
+          clock.tick(0);
           // @ts-expect-error need to migrate helpers to TypeScript
         }).toWarnDev(
           'Material-UI: useResizeContainer - The parent of the grid has an empty height.',
@@ -154,7 +155,8 @@ describe('<DataGrid /> - Layout & Warnings', () => {
               </div>
             </div>,
           );
-          clock.tick(100);
+          // Use timeout to allow simpler tests in JSDOM.
+          clock.tick(0);
           // @ts-expect-error need to migrate helpers to TypeScript
         }).toWarnDev(
           'Material-UI: useResizeContainer - The parent of the grid has an empty width.',


### PR DESCRIPTION
The underlying logic is a setTimeout with no defined duration, so 0ms.

https://github.com/mui-org/material-ui-x/blob/49afdd372e58af45d24d237208457596c522add7/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts#L17