### PR TITLE
[docs] Sync with docs to fix images

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3166,7 +3166,7 @@
 
 "@material-ui/monorepo@https://github.com/mui-org/material-ui.git#master":
   version "4.11.1"
-  resolved "https://github.com/mui-org/material-ui.git#34be88ec011d91d7f0fe6ddb0ec04e588149bdfe"
+  resolved "https://github.com/mui-org/material-ui.git#7fe8a4254155c5475c3e14971b0c01d88f57efa8"
 
 "@material-ui/monorepo@https://github.com/mui-org/material-ui.git#next":
   version "5.0.0-alpha.18"


### PR DESCRIPTION
The issue

<img width="473" alt="Capture d’écran 2020-12-23 à 11 55 15" src="https://user-images.githubusercontent.com/3165635/102989365-c95ee000-4515-11eb-907f-87b31a66fad5.png">
