### PR TITLE
[DataGrid] Convert remaining text to use locale text API

### DIFF
--- a/packages/grid/_modules_/grid/GridComponent.tsx
+++ b/packages/grid/_modules_/grid/GridComponent.tsx
@@ -134,7 +134,7 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
             aria-colcount={visibleColumnsLength}
             aria-rowcount={gridState.rows.totalRowCount}
             tabIndex={0}
-            aria-label="grid"
+            aria-label={apiRef!.current.getLocaleText('rootGridLabel')}
             aria-multiselectable={!gridState.options.disableMultipleSelection}
           >
             <ErrorBoundary

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -61,6 +61,7 @@ export function Pagination() {
       }
       rowsPerPage={paginationState.pageSize}
       onChangeRowsPerPage={onPageSizeChange}
+      labelRowsPerPage={apiRef!.current.getLocaleText('footerPaginationRowsPerPage')}
     />
   );
 }

--- a/packages/grid/_modules_/grid/components/RowCount.tsx
+++ b/packages/grid/_modules_/grid/components/RowCount.tsx
@@ -1,8 +1,15 @@
 import * as React from 'react';
+import { ApiContext } from './api-context';
 
 export const RowCount: React.FC<{ rowCount: number }> = ({ rowCount }) => {
+  const apiRef = React.useContext(ApiContext);
+
   if (rowCount === 0) {
     return null;
   }
-  return <div className="MuiDataGrid-rowCount">Total Rows: {rowCount.toLocaleString()}</div>;
+  return (
+    <div className="MuiDataGrid-rowCount">
+      {`${apiRef!.current.getLocaleText('footerTotalRows')} ${rowCount.toLocaleString()}`}
+    </div>
+  );
 };

--- a/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
+++ b/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
@@ -8,9 +8,7 @@ interface SelectedRowCountProps {
 export function SelectedRowCount(props: SelectedRowCountProps) {
   const { selectedRowCount } = props;
   const apiRef = React.useContext(ApiContext);
-  const rowSelectedText = apiRef!.current.getLocaleText('footerRowSelectedPlural')(
-    selectedRowCount,
-  );
+  const rowSelectedText = apiRef!.current.getLocaleText('footerRowSelected')(selectedRowCount);
 
   return <div className="MuiDataGrid-selectedRowCount">{rowSelectedText}</div>;
 }

--- a/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
+++ b/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
@@ -8,14 +8,9 @@ interface SelectedRowCountProps {
 export function SelectedRowCount(props: SelectedRowCountProps) {
   const { selectedRowCount } = props;
   const apiRef = React.useContext(ApiContext);
-  const rowSelectedText =
-    selectedRowCount > 1
-      ? apiRef!.current.getLocaleText('footerRowSelectedPlural')
-      : apiRef!.current.getLocaleText('footerRowSelected');
-
-  return (
-    <div className="MuiDataGrid-selectedRowCount">
-      {`${selectedRowCount.toLocaleString()} ${rowSelectedText}`}
-    </div>
+  const rowSelectedText = apiRef!.current.getLocaleText('footerRowSelectedPlural')(
+    selectedRowCount,
   );
+
+  return <div className="MuiDataGrid-selectedRowCount">{rowSelectedText}</div>;
 }

--- a/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
+++ b/packages/grid/_modules_/grid/components/SelectedRowCount.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { ApiContext } from './api-context';
 
 interface SelectedRowCountProps {
   selectedRowCount: number;
@@ -6,10 +7,15 @@ interface SelectedRowCountProps {
 
 export function SelectedRowCount(props: SelectedRowCountProps) {
   const { selectedRowCount } = props;
+  const apiRef = React.useContext(ApiContext);
+  const rowSelectedText =
+    selectedRowCount > 1
+      ? apiRef!.current.getLocaleText('footerRowSelectedPlural')
+      : apiRef!.current.getLocaleText('footerRowSelected');
 
   return (
     <div className="MuiDataGrid-selectedRowCount">
-      {`${selectedRowCount.toLocaleString()} ${selectedRowCount > 1 ? 'rows' : 'row'} selected`}
+      {`${selectedRowCount.toLocaleString()} ${rowSelectedText}`}
     </div>
   );
 }

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
@@ -55,7 +55,7 @@ export function ColumnHeaderFilterIcon(props: ColumnHeaderFilterIconProps) {
 
   return (
     <Tooltip
-      title={`${counter} ${apiRef!.current.getLocaleText('columnHeaderFiltersTooltipActive')}`}
+      title={apiRef!.current.getLocaleText('columnHeaderFiltersTooltipActive')(counter)}
       enterDelay={1000}
     >
       <div className="MuiDataGrid-iconButtonContainer">

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
@@ -55,7 +55,11 @@ export function ColumnHeaderFilterIcon(props: ColumnHeaderFilterIconProps) {
 
   return (
     <Tooltip
-      title={apiRef!.current.getLocaleText('columnHeaderFiltersTooltipActive')(counter)}
+      title={
+        apiRef!.current.getLocaleText('columnHeaderFiltersTooltipActive')(
+          counter,
+        ) as React.ReactElement
+      }
       enterDelay={1000}
     >
       <div className="MuiDataGrid-iconButtonContainer">

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderFilterIcon.tsx
@@ -43,13 +43,21 @@ export function ColumnHeaderFilterIcon(props: ColumnHeaderFilterIconProps) {
   }
 
   const iconButton = (
-    <IconButton onClick={toggleFilter} color="default" aria-label="Show Filters" size="small">
+    <IconButton
+      onClick={toggleFilter}
+      color="default"
+      aria-label={apiRef!.current.getLocaleText('columnHeaderFiltersLabel')}
+      size="small"
+    >
       {filteredColumnIconElement}
     </IconButton>
   );
 
   return (
-    <Tooltip title={`${counter} active filter(s)`} enterDelay={1000}>
+    <Tooltip
+      title={`${counter} ${apiRef!.current.getLocaleText('columnHeaderFiltersTooltipActive')}`}
+      enterDelay={1000}
+    >
       <div className="MuiDataGrid-iconButtonContainer">
         <div>
           {counter > 1 && (

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
@@ -38,8 +38,8 @@ export function ColumnHeaderMenuIcon(props: ColumnHeaderFilterIconProps) {
     <div className={classnames('MuiDataGrid-menuIcon', { 'MuiDataGrid-menuOpen': open })}>
       <IconButton
         className="MuiDataGrid-menuIconButton"
-        aria-label="Menu"
-        title="Menu"
+        aria-label={apiRef!.current.getLocaleText('columnMenuLabel')}
+        title={apiRef!.current.getLocaleText('columnMenuTitle')}
         size="small"
         onClick={handleMenuIconClick}
       >

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderMenuIcon.tsx
@@ -39,7 +39,7 @@ export function ColumnHeaderMenuIcon(props: ColumnHeaderFilterIconProps) {
       <IconButton
         className="MuiDataGrid-menuIconButton"
         aria-label={apiRef!.current.getLocaleText('columnMenuLabel')}
-        title={apiRef!.current.getLocaleText('columnMenuTitle')}
+        title={apiRef!.current.getLocaleText('columnMenuLabel')}
         size="small"
         onClick={handleMenuIconClick}
       >

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderSortIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderSortIcon.tsx
@@ -34,7 +34,7 @@ export const ColumnHeaderSortIcon = React.memo(function ColumnHeaderSortIcon(
           <Badge badgeContent={index} color="default">
             <IconButton
               aria-label={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
-              title={apiRef!.current.getLocaleText('columnHeaderSortIconTitle')}
+              title={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
               size="small"
             >
               {getIcon(icons, direction)}
@@ -44,7 +44,7 @@ export const ColumnHeaderSortIcon = React.memo(function ColumnHeaderSortIcon(
         {index == null && (
           <IconButton
             aria-label={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
-            title={apiRef!.current.getLocaleText('columnHeaderSortIconTitle')}
+            title={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
             size="small"
           >
             {getIcon(icons, direction)}

--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderSortIcon.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderSortIcon.tsx
@@ -3,6 +3,7 @@ import Badge from '@material-ui/core/Badge';
 import IconButton from '@material-ui/core/IconButton';
 import { IconsOptions, SortDirection } from '../../models/index';
 import { useIcons } from '../../hooks/utils/useIcons';
+import { ApiContext } from '../api-context';
 
 export interface ColumnHeaderSortIconProps {
   direction: SortDirection;
@@ -20,6 +21,7 @@ export const ColumnHeaderSortIcon = React.memo(function ColumnHeaderSortIcon(
 ) {
   const { direction, index, hide } = props;
   const icons = useIcons();
+  const apiRef = React.useContext(ApiContext);
 
   if (hide || direction == null) {
     return null;
@@ -30,13 +32,21 @@ export const ColumnHeaderSortIcon = React.memo(function ColumnHeaderSortIcon(
       <div>
         {index != null && (
           <Badge badgeContent={index} color="default">
-            <IconButton aria-label="Sort" title="Sort" size="small">
+            <IconButton
+              aria-label={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
+              title={apiRef!.current.getLocaleText('columnHeaderSortIconTitle')}
+              size="small"
+            >
               {getIcon(icons, direction)}
             </IconButton>
           </Badge>
         )}
         {index == null && (
-          <IconButton aria-label="Sort" title="Sort" size="small">
+          <IconButton
+            aria-label={apiRef!.current.getLocaleText('columnHeaderSortIconLabel')}
+            title={apiRef!.current.getLocaleText('columnHeaderSortIconTitle')}
+            size="small"
+          >
             {getIcon(icons, direction)}
           </IconButton>
         )}

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/ColumnsMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/ColumnsMenuItem.tsx
@@ -22,5 +22,9 @@ export const ColumnsMenuItem: React.FC<FilterItemProps> = ({ onClick }) => {
     return null;
   }
 
-  return <MenuItem onClick={showColumns}>Show columns</MenuItem>;
+  return (
+    <MenuItem onClick={showColumns}>
+      {apiRef!.current.getLocaleText('columnMenuShowColumns')}
+    </MenuItem>
+  );
 };

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/FilterMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/FilterMenuItem.tsx
@@ -21,5 +21,7 @@ export const FilterMenuItem: React.FC<FilterItemProps> = ({ column, onClick }) =
     return null;
   }
 
-  return <MenuItem onClick={showFilter}>Filter</MenuItem>;
+  return (
+    <MenuItem onClick={showFilter}>{apiRef!.current.getLocaleText('columnMenuFilter')}</MenuItem>
+  );
 };

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/HideColMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/HideColMenuItem.tsx
@@ -25,5 +25,9 @@ export const HideColMenuItem: React.FC<FilterItemProps> = ({ column, onClick }) 
     return null;
   }
 
-  return <MenuItem onClick={toggleColumn}>Hide</MenuItem>;
+  return (
+    <MenuItem onClick={toggleColumn}>
+      {apiRef!.current.getLocaleText('columnMenuHideColumn')}
+    </MenuItem>
+  );
 };

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/SortMenuItems.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/SortMenuItems.tsx
@@ -34,13 +34,13 @@ export const SortMenuItems: React.FC<FilterItemProps> = ({ column, onClick }) =>
   return (
     <React.Fragment>
       <MenuItem onClick={onSortMenuItemClick} disabled={sortDirection == null}>
-        Unsort
+        {apiRef!.current.getLocaleText('columnMenuUnsort')}
       </MenuItem>
       <MenuItem onClick={onSortMenuItemClick} data-value="asc" disabled={sortDirection === 'asc'}>
-        Sort by Asc
+        {apiRef!.current.getLocaleText('columnMenuSortAsc')}
       </MenuItem>
       <MenuItem onClick={onSortMenuItemClick} data-value="desc" disabled={sortDirection === 'desc'}>
-        Sort by Desc
+        {apiRef!.current.getLocaleText('columnMenuSortDesc')}
       </MenuItem>
     </React.Fragment>
   );

--- a/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
@@ -116,7 +116,7 @@ export function ColumnsPanel() {
                   draggable
                   className={classes.dragIcon}
                   aria-label={apiRef!.current.getLocaleText('columnsPanelDragIconLabel')}
-                  title={apiRef!.current.getLocaleText('columnsPanelDragIconTitle')}
+                  title={apiRef!.current.getLocaleText('columnsPanelDragIconLabel')}
                   size="small"
                   disabled
                 >

--- a/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/ColumnsPanel.tsx
@@ -86,8 +86,8 @@ export function ColumnsPanel() {
     <React.Fragment>
       <div className="MuiDataGridPanel-header">
         <TextField
-          label="Find column"
-          placeholder="Column title"
+          label={apiRef!.current.getLocaleText('columnsPanelTextFieldLabel')}
+          placeholder={apiRef!.current.getLocaleText('columnsPanelTextFieldPlaceholder')}
           inputRef={searchInputRef}
           value={searchValue}
           onChange={handleSearchValueChange}
@@ -115,8 +115,8 @@ export function ColumnsPanel() {
                 <IconButton
                   draggable
                   className={classes.dragIcon}
-                  aria-label="Drag to reorder column"
-                  title="Reorder Column"
+                  aria-label={apiRef!.current.getLocaleText('columnsPanelDragIconLabel')}
+                  title={apiRef!.current.getLocaleText('columnsPanelDragIconTitle')}
                   size="small"
                   disabled
                 >
@@ -129,10 +129,10 @@ export function ColumnsPanel() {
       </div>
       <div className="MuiDataGridPanel-footer">
         <Button onClick={hideAllColumns} color="primary">
-          Hide All
+          {apiRef!.current.getLocaleText('columnsPanelHideAllButton')}
         </Button>
         <Button onClick={showAllColumns} color="primary">
-          Show All
+          {apiRef!.current.getLocaleText('columnsPanelShowAllButton')}
         </Button>
       </div>
     </React.Fragment>

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -134,7 +134,12 @@ export function FilterForm(props: FilterFormProps) {
   return (
     <div className={classes.root}>
       <FormControl className={classes.closeIcon}>
-        <IconButton aria-label="Delete" title="Delete" onClick={handleDeleteFilter} size="small">
+        <IconButton
+          aria-label={apiRef!.current.getLocaleText('filterPanelDeleteIconLabel')}
+          title={apiRef!.current.getLocaleText('filterPanelDeleteIconTitle')}
+          onClick={handleDeleteFilter}
+          size="small"
+        >
           <CloseIcon fontSize="small" />
         </IconButton>
       </FormControl>
@@ -145,7 +150,9 @@ export function FilterForm(props: FilterFormProps) {
           visibility: showMultiFilterOperators ? 'visible' : 'hidden',
         }}
       >
-        <InputLabel id="columns-filter-operator-select-label">Operators</InputLabel>
+        <InputLabel id="columns-filter-operator-select-label">
+          {apiRef!.current.getLocaleText('filterPanelOperators')}
+        </InputLabel>
         <Select
           labelId="columns-filter-operator-select-label"
           id="columns-filter-operator-select"
@@ -155,15 +162,17 @@ export function FilterForm(props: FilterFormProps) {
           native
         >
           <option key={LinkOperator.And.toString()} value={LinkOperator.And.toString()}>
-            And
+            {apiRef!.current.getLocaleText('filterPanelOperatorAnd')}
           </option>
           <option key={LinkOperator.Or.toString()} value={LinkOperator.Or.toString()}>
-            Or
+            {apiRef!.current.getLocaleText('filterPanelOperatorOr')}
           </option>
         </Select>
       </FormControl>
       <FormControl className={classes.columnSelect}>
-        <InputLabel id="columns-filter-select-label">Columns</InputLabel>
+        <InputLabel id="columns-filter-select-label">
+          {apiRef!.current.getLocaleText('filterPanelColumns')}
+        </InputLabel>
         <Select
           labelId="columns-filter-select-label"
           id="columns-filter-select"
@@ -179,7 +188,9 @@ export function FilterForm(props: FilterFormProps) {
         </Select>
       </FormControl>
       <FormControl className={classes.operatorSelect}>
-        <InputLabel id="columns-operators-select-label">Operators</InputLabel>
+        <InputLabel id="columns-operators-select-label">
+          {apiRef!.current.getLocaleText('filterPanelOperators')}
+        </InputLabel>
         <Select
           labelId="columns-operators-select-label"
           id="columns-operators-select"

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -136,7 +136,7 @@ export function FilterForm(props: FilterFormProps) {
       <FormControl className={classes.closeIcon}>
         <IconButton
           aria-label={apiRef!.current.getLocaleText('filterPanelDeleteIconLabel')}
-          title={apiRef!.current.getLocaleText('filterPanelDeleteIconTitle')}
+          title={apiRef!.current.getLocaleText('filterPanelDeleteIconLabel')}
           onClick={handleDeleteFilter}
           size="small"
         >

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterPanel.tsx
@@ -68,7 +68,7 @@ export function FilterPanel() {
       {!disableMultipleColumnsFiltering && (
         <div className="MuiDataGridPanel-footer">
           <Button onClick={addNewFilter} startIcon={<AddIcon />} color="primary">
-            Add Filter
+            {apiRef!.current.getLocaleText('filterPanelAddFilter')}
           </Button>
         </div>
       )}

--- a/packages/grid/_modules_/grid/components/toolbar/ColumnsToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/ColumnsToolbarButton.tsx
@@ -24,10 +24,10 @@ export const ColumnsToolbarButton: React.FC<{}> = () => {
     <Button
       onClick={showColumns}
       color="primary"
-      aria-label="Show Column Selector"
+      aria-label={apiRef!.current.getLocaleText('toolbarColumnsLabel')}
       startIcon={iconElement}
     >
-      Columns
+      {apiRef!.current.getLocaleText('toolbarColumns')}
     </Button>
   );
 };

--- a/packages/grid/_modules_/grid/components/toolbar/FilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/FilterToolbarButton.tsx
@@ -24,14 +24,14 @@ export const FilterToolbarButton: React.FC<{}> = () => {
 
   const tooltipContentNode = React.useMemo(() => {
     if (preferencePanel.open) {
-      return 'Hide Filters';
+      return apiRef!.current.getLocaleText('toolbarFiltersTooltipHide') as React.ReactElement;
     }
     if (counter === 0) {
-      return 'Show Filters';
+      return apiRef!.current.getLocaleText('toolbarFiltersTooltipShow') as React.ReactElement;
     }
     return (
       <div>
-        {counter} active filter(s)
+        {counter} {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')}
         <ul>
           {activeFilters.map((item) => ({
             ...(lookup[item.columnField!] && (
@@ -44,7 +44,7 @@ export const FilterToolbarButton: React.FC<{}> = () => {
         </ul>
       </div>
     );
-  }, [preferencePanel.open, counter, activeFilters, lookup]);
+  }, [apiRef, preferencePanel.open, counter, activeFilters, lookup]);
 
   const icons = useIcons();
   const filterIconElement = React.createElement(icons.OpenFilterButtonIcon!, {});
@@ -66,14 +66,14 @@ export const FilterToolbarButton: React.FC<{}> = () => {
       <Button
         onClick={toggleFilter}
         color="primary"
-        aria-label="Show Filters"
+        aria-label={apiRef!.current.getLocaleText('toolbarFiltersLabel')}
         startIcon={
           <Badge badgeContent={counter} color="primary">
             {filterIconElement}
           </Badge>
         }
       >
-        Filters
+        {apiRef!.current.getLocaleText('toolbarFilters')}
       </Button>
     </Tooltip>
   );

--- a/packages/grid/_modules_/grid/components/toolbar/FilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/FilterToolbarButton.tsx
@@ -31,7 +31,7 @@ export const FilterToolbarButton: React.FC<{}> = () => {
     }
     return (
       <div>
-        {counter} {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')}
+        {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')(counter)}
         <ul>
           {activeFilters.map((item) => ({
             ...(lookup[item.columnField!] && (

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -20,19 +20,17 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   toolbarFiltersLabel: 'Show Filters',
   toolbarFiltersTooltipHide: 'Hide Filters',
   toolbarFiltersTooltipShow: 'Show Filters',
-  toolbarFiltersTooltipActive: 'active filter(s)',
+  toolbarFiltersTooltipActive: (count) => `${count} active filter(s)`,
 
   // Columns panel text
   columnsPanelTextFieldLabel: 'Find column',
   columnsPanelTextFieldPlaceholder: 'Column title',
-  columnsPanelDragIconTitle: 'Reorder Column',
-  columnsPanelDragIconLabel: 'Drag to reorder column',
+  columnsPanelDragIconLabel: 'Reorder Column',
   columnsPanelShowAllButton: 'Show All',
   columnsPanelHideAllButton: 'Hide All',
 
   // Filter panel text
   filterPanelAddFilter: 'Add Filter',
-  filterPanelDeleteIconTitle: 'Delete',
   filterPanelDeleteIconLabel: 'Delete',
   filterPanelOperators: 'Operators',
   filterPanelOperatorAnd: 'And',
@@ -40,7 +38,6 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   filterPanelColumns: 'Columns',
 
   // Column menu text
-  columnMenuTitle: 'Menu',
   columnMenuLabel: 'Menu',
   columnMenuShowColumns: 'Show columns',
   columnMenuFilter: 'Filter',
@@ -50,14 +47,16 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   columnMenuSortDesc: 'Sort by Desc',
 
   // Column header text
-  columnHeaderFiltersTooltipActive: 'active filter(s)',
+  columnHeaderFiltersTooltipActive: (count) => `${count} active filter(s)`,
   columnHeaderFiltersLabel: 'Show Filters',
-  columnHeaderSortIconTitle: 'Sort',
   columnHeaderSortIconLabel: 'Sort',
 
   // Rows selected footer text
   footerRowSelected: 'row selected',
-  footerRowSelectedPlural: 'rows selected',
+  footerRowSelectedPlural: (count) =>
+    count > 1
+      ? `${count.toLocaleString()} rows selected`
+      : `${count.toLocaleString()} row selected`,
 
   // Total rows footer text
   footerTotalRows: 'Total Rows:',

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -1,9 +1,67 @@
 import { LocaleText } from '../models/api/localeTextApi';
 
 export const DEFAULT_LOCALE_TEXT: LocaleText = {
+  // Root
+  rootGridLabel: 'grid',
+
+  // Density selector toolbar button text
   toolbarDensity: 'Density',
   toolbarDensityLabel: 'Density',
   toolbarDensityCompact: 'Compact',
   toolbarDensityStandard: 'Standard',
   toolbarDensityComfortable: 'Comfortable',
+
+  // Columns selector toolbar button text
+  toolbarColumns: 'Columns',
+  toolbarColumnsLabel: 'Show Column Selector',
+
+  // Filters toolbar button text
+  toolbarFilters: 'Filters',
+  toolbarFiltersLabel: 'Show Filters',
+  toolbarFiltersTooltipHide: 'Hide Filters',
+  toolbarFiltersTooltipShow: 'Show Filters',
+  toolbarFiltersTooltipActive: 'active filter(s)',
+
+  // Columns panel text
+  columnsPanelTextFieldLabel: 'Find column',
+  columnsPanelTextFieldPlaceholder: 'Column title',
+  columnsPanelDragIconTitle: 'Reorder Column',
+  columnsPanelDragIconLabel: 'Drag to reorder column',
+  columnsPanelShowAllButton: 'Show All',
+  columnsPanelHideAllButton: 'Hide All',
+
+  // Filter panel text
+  filterPanelAddFilter: 'Add Filter',
+  filterPanelDeleteIconTitle: 'Delete',
+  filterPanelDeleteIconLabel: 'Delete',
+  filterPanelOperators: 'Operators',
+  filterPanelOperatorAnd: 'And',
+  filterPanelOperatorOr: 'Or',
+  filterPanelColumns: 'Columns',
+
+  // Column menu text
+  columnMenuTitle: 'Menu',
+  columnMenuLabel: 'Menu',
+  columnMenuShowColumns: 'Show columns',
+  columnMenuFilter: 'Filter',
+  columnMenuHideColumn: 'Hide',
+  columnMenuUnsort: 'Unsort',
+  columnMenuSortAsc: 'Sort by Asc',
+  columnMenuSortDesc: 'Sort by Desc',
+
+  // Column header text
+  columnHeaderFiltersTooltipActive: 'active filter(s)',
+  columnHeaderFiltersLabel: 'Show Filters',
+  columnHeaderSortIconTitle: 'Sort',
+  columnHeaderSortIconLabel: 'Sort',
+
+  // Rows selected footer text
+  footerRowSelected: 'row selected',
+  footerRowSelectedPlural: 'rows selected',
+
+  // Total rows footer text
+  footerTotalRows: 'Total Rows:',
+
+  // Pagination footer text
+  footerPaginationRowsPerPage: 'Rows per page:',
 };

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -52,9 +52,8 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   columnHeaderSortIconLabel: 'Sort',
 
   // Rows selected footer text
-  footerRowSelected: 'row selected',
-  footerRowSelectedPlural: (count) =>
-    count > 1
+  footerRowSelected: (count) =>
+    count !== 1
       ? `${count.toLocaleString()} rows selected`
       : `${count.toLocaleString()} row selected`,
 

--- a/packages/grid/_modules_/grid/models/api/localeTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/localeTextApi.ts
@@ -21,7 +21,7 @@ export interface LocaleText {
   toolbarFiltersLabel: string;
   toolbarFiltersTooltipHide: React.ReactNode;
   toolbarFiltersTooltipShow: React.ReactNode;
-  toolbarFiltersTooltipActive: Function;
+  toolbarFiltersTooltipActive: (count: number) => React.ReactNode;
 
   // Columns panel text
   columnsPanelTextFieldLabel: string;
@@ -48,13 +48,12 @@ export interface LocaleText {
   columnMenuSortDesc: React.ReactNode;
 
   // Column header text
-  columnHeaderFiltersTooltipActive: Function;
+  columnHeaderFiltersTooltipActive: (count: number) => React.ReactNode;
   columnHeaderFiltersLabel: string;
   columnHeaderSortIconLabel: string;
 
   // Rows selected footer text
-  footerRowSelected: React.ReactNode;
-  footerRowSelectedPlural: Function;
+  footerRowSelected: (count: number) => React.ReactNode;
 
   // Total rows footer text
   footerTotalRows: React.ReactNode;

--- a/packages/grid/_modules_/grid/models/api/localeTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/localeTextApi.ts
@@ -2,12 +2,69 @@
  * Set the types of the texts in the grid.
  */
 export interface LocaleText {
+  // Root
+  rootGridLabel: string;
+
   // Density selector toolbar button text
   toolbarDensity: React.ReactNode;
   toolbarDensityLabel: string;
   toolbarDensityCompact: string;
   toolbarDensityStandard: string;
   toolbarDensityComfortable: string;
+
+  // Columns selector toolbar button text
+  toolbarColumns: React.ReactNode;
+  toolbarColumnsLabel: string;
+
+  // Filters toolbar button text
+  toolbarFilters: React.ReactNode;
+  toolbarFiltersLabel: string;
+  toolbarFiltersTooltipHide: React.ReactNode;
+  toolbarFiltersTooltipShow: React.ReactNode;
+  toolbarFiltersTooltipActive: React.ReactNode;
+
+  // Columns panel text
+  columnsPanelTextFieldLabel: string;
+  columnsPanelTextFieldPlaceholder: string;
+  columnsPanelDragIconTitle: string;
+  columnsPanelDragIconLabel: string;
+  columnsPanelShowAllButton: React.ReactNode;
+  columnsPanelHideAllButton: React.ReactNode;
+
+  // Filter panel text
+  filterPanelAddFilter: React.ReactNode;
+  filterPanelDeleteIconTitle: string;
+  filterPanelDeleteIconLabel: string;
+  filterPanelOperators: React.ReactNode;
+  filterPanelOperatorAnd: React.ReactNode;
+  filterPanelOperatorOr: React.ReactNode;
+  filterPanelColumns: React.ReactNode;
+
+  // Column menu text
+  columnMenuTitle: string;
+  columnMenuLabel: string;
+  columnMenuShowColumns: React.ReactNode;
+  columnMenuFilter: React.ReactNode;
+  columnMenuHideColumn: React.ReactNode;
+  columnMenuUnsort: React.ReactNode;
+  columnMenuSortAsc: React.ReactNode;
+  columnMenuSortDesc: React.ReactNode;
+
+  // Column header text
+  columnHeaderFiltersTooltipActive: React.ReactNode;
+  columnHeaderFiltersLabel: string;
+  columnHeaderSortIconTitle: string;
+  columnHeaderSortIconLabel: string;
+
+  // Rows selected footer text
+  footerRowSelected: React.ReactNode;
+  footerRowSelectedPlural: React.ReactNode;
+
+  // Total rows footer text
+  footerTotalRows: React.ReactNode;
+
+  // Pagination footer text
+  footerPaginationRowsPerPage: React.ReactNode;
 }
 
 export type LocaleTextValue = string | React.ReactNode | Function;

--- a/packages/grid/_modules_/grid/models/api/localeTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/localeTextApi.ts
@@ -21,19 +21,17 @@ export interface LocaleText {
   toolbarFiltersLabel: string;
   toolbarFiltersTooltipHide: React.ReactNode;
   toolbarFiltersTooltipShow: React.ReactNode;
-  toolbarFiltersTooltipActive: React.ReactNode;
+  toolbarFiltersTooltipActive: Function;
 
   // Columns panel text
   columnsPanelTextFieldLabel: string;
   columnsPanelTextFieldPlaceholder: string;
-  columnsPanelDragIconTitle: string;
   columnsPanelDragIconLabel: string;
   columnsPanelShowAllButton: React.ReactNode;
   columnsPanelHideAllButton: React.ReactNode;
 
   // Filter panel text
   filterPanelAddFilter: React.ReactNode;
-  filterPanelDeleteIconTitle: string;
   filterPanelDeleteIconLabel: string;
   filterPanelOperators: React.ReactNode;
   filterPanelOperatorAnd: React.ReactNode;
@@ -41,7 +39,6 @@ export interface LocaleText {
   filterPanelColumns: React.ReactNode;
 
   // Column menu text
-  columnMenuTitle: string;
   columnMenuLabel: string;
   columnMenuShowColumns: React.ReactNode;
   columnMenuFilter: React.ReactNode;
@@ -51,14 +48,13 @@ export interface LocaleText {
   columnMenuSortDesc: React.ReactNode;
 
   // Column header text
-  columnHeaderFiltersTooltipActive: React.ReactNode;
+  columnHeaderFiltersTooltipActive: Function;
   columnHeaderFiltersLabel: string;
-  columnHeaderSortIconTitle: string;
   columnHeaderSortIconLabel: string;
 
   // Rows selected footer text
   footerRowSelected: React.ReactNode;
-  footerRowSelectedPlural: React.ReactNode;
+  footerRowSelectedPlural: Function;
 
   // Total rows footer text
   footerTotalRows: React.ReactNode;


### PR DESCRIPTION
Fixes #196 

This is the follow up PR with the rest of the text now being converted to use the `getLocaleText` API