### PR TITLE
[test] Make the test actually test what we need

### DIFF
--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -29,7 +29,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('should be able to type in an child input', () => {
-    const handleInputKeyDown = spy();
+    const handleInputKeyDown = spy((event) => event.defaultPrevented);
 
     const columns = [
       {
@@ -60,7 +60,7 @@ describe('<DataGrid /> - Keyboard', () => {
       key: 'a',
     });
     fireEvent(input, keydownEvent);
-    expect(handleInputKeyDown.callCount).to.equal(1);
+    expect(handleInputKeyDown.returnValues).to.deep.equal([false]);
   });
 
   /* eslint-disable material-ui/disallow-active-element-as-key-event-target */


### PR DESCRIPTION
The test that we have added in #673 is unrelated to the issue and solves no problems (we could remove the test it wouldn't make a difference). We were relying on the fact that `stopPropagation()` is no longer call. But that's not what we need to assert. We need to make sure the event doesn't prevent default. The updated test should be correct and prevent regressions now.

### Context

I have started looking at #794, then, I realized that the whole section inside https://github.com/mui-org/material-ui-x/pull/673/files#diff-2cb5cd44894a9bd734c47410669a07af73de0e7ff1b69f5488453ee1159da470R235 is a dead code. So I kept exploring. Yes, it creates regressions. I'm opening new issues.