### PR TITLE
[docs] Add documentation for the column menu

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -22,7 +22,7 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">ColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridComponentOverridesProp</span> |   | Overrideable components. |
 | <span class="prop-name">density</span> | <span class="prop-type">Density</span> | standard | Sets the density of the grid. |
-| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu will be disabled. |
+| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu is disabled. |
 | <span class="prop-name">disableExtendRowFullWidth</span> | <span class="prop-type">boolean</span> | false | If `true`, rows will not be extended to fill the full width of the grid container. |
 | <span class="prop-name">disableSelectionOnClick</span> | <span class="prop-type">boolean</span> | false | If `true`, the selection on click on a row or cell is disabled. |
 | <span class="prop-name">error</span> | <span class="prop-type">any</span> |   | An error that will turn the grid into its error state and display the error component. |

--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -22,6 +22,7 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">ColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridComponentOverridesProp</span> |   | Overrideable components. |
 | <span class="prop-name">density</span> | <span class="prop-type">Density</span> | standard | Sets the density of the grid. |
+| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu will be disabled. |
 | <span class="prop-name">disableExtendRowFullWidth</span> | <span class="prop-type">boolean</span> | false | If `true`, rows will not be extended to fill the full width of the grid container. |
 | <span class="prop-name">disableSelectionOnClick</span> | <span class="prop-type">boolean</span> | false | If `true`, the selection on click on a row or cell is disabled. |
 | <span class="prop-name">error</span> | <span class="prop-type">any</span> |   | An error that will turn the grid into its error state and display the error component. |

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -23,6 +23,7 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">ColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridComponentOverridesProp</span> |   | Overrideable components. |
 | <span class="prop-name">density</span> | <span class="prop-type">Density</span> | standard | Sets the density of the grid. |
+| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu will be disabled. |
 | <span class="prop-name">disableColumnResize</span> | <span class="prop-type">boolean</span> | false | If `true`, resizing columns is disabled. |
 | <span class="prop-name">disableExtendRowFullWidth</span> | <span class="prop-type">boolean</span> | false | If `true`, rows will not be extended to fill the full width of the grid container. |
 | <span class="prop-name">disableMultipleColumnsSorting</span> | <span class="prop-type">boolean</span> | false | If `true`, sorting with multiple columns is disabled. |

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -23,7 +23,7 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">ColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridComponentOverridesProp</span> |   | Overrideable components. |
 | <span class="prop-name">density</span> | <span class="prop-type">Density</span> | standard | Sets the density of the grid. |
-| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu will be disabled. |
+| <span class="prop-name">disableColumnMenu</span> | <span class="prop-type">boolean</span> | false | If `true`, the column menu is disabled. |
 | <span class="prop-name">disableColumnResize</span> | <span class="prop-type">boolean</span> | false | If `true`, resizing columns is disabled. |
 | <span class="prop-name">disableExtendRowFullWidth</span> | <span class="prop-type">boolean</span> | false | If `true`, rows will not be extended to fill the full width of the grid container. |
 | <span class="prop-name">disableMultipleColumnsSorting</span> | <span class="prop-type">boolean</span> | false | If `true`, sorting with multiple columns is disabled. |

--- a/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.js
+++ b/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function ColumnMenuGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 20,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid {...data} disableColumnMenu />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.tsx
+++ b/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.tsx
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import { DataGrid } from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function ColumnMenuGrid() {
+  const { data } = useDemoData({
+    dataSet: 'Commodity',
+    rowLength: 20,
+    maxColumns: 5,
+  });
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid {...data} disableColumnMenu />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -43,7 +43,7 @@ For more advanced header configuration, go to the [rendering section](/component
 
 ## Column menu
 
-By default, for each column header a column menu is shown that allows filters to be set in the context of the target column. To disable it set the prop `disableColumnMenu={true}`.
+By default, each column header displays a column menu. The column menu allows actions to be performed in the context of the target column, e.g. filtering. To disable it set the prop `disableColumnMenu={true}`.
 
 {{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -47,8 +47,6 @@ By default, for each column header a column menu is shown that allows filters to
 
 {{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
 
-For more advanced filtering configuration, go to the [filtering section](/components/data-grid/filtering/#basic-filter).
-
 ## Column width
 
 By default, the columns have a width of 100 pixels.

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -121,7 +121,7 @@ const usdPrice: ColTypeDef = {
 
 ## Column menu
 
-By default, each column header displays a column menu. The column menu allows actions to be performed in the context of the target column, e.g. filtering. To disable it set the prop `disableColumnMenu={true}`.
+By default, each column header displays a column menu. The column menu allows actions to be performed in the context of the target column, e.g. filtering. To disable the column menu, set the prop `disableColumnMenu={true}`.
 
 {{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -41,12 +41,6 @@ You can configure the headers with:
 
 For more advanced header configuration, go to the [rendering section](/components/data-grid/rendering/#header-cell).
 
-## Column menu
-
-By default, each column header displays a column menu. The column menu allows actions to be performed in the context of the target column, e.g. filtering. To disable it set the prop `disableColumnMenu={true}`.
-
-{{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
-
 ## Column width
 
 By default, the columns have a width of 100 pixels.
@@ -124,6 +118,12 @@ const usdPrice: ColTypeDef = {
 ```
 
 {{"demo": "pages/components/data-grid/columns/CustomColumnTypesGrid.js", "bg": "inline"}}
+
+## Column menu
+
+By default, each column header displays a column menu. The column menu allows actions to be performed in the context of the target column, e.g. filtering. To disable it set the prop `disableColumnMenu={true}`.
+
+{{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
 
 ## Column reorder [<span role="img" title="Enterprise">⚡️</span>](https://material-ui.com/store/items/material-ui-x/)
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -41,6 +41,14 @@ You can configure the headers with:
 
 For more advanced header configuration, go to the [rendering section](/components/data-grid/rendering/#header-cell).
 
+## Column menu
+
+By default, for each column header a column menu is shown that allows filters to be set in the context of the target column. To disable it set the prop `disableColumnMenu={true}`.
+
+{{"demo": "pages/components/data-grid/columns/ColumnMenuGrid.js", "bg": "inline"}}
+
+For more advanced filtering configuration, go to the [filtering section](/components/data-grid/filtering/#basic-filter).
+
 ## Column width
 
 By default, the columns have a width of 100 pixels.

--- a/packages/grid/_modules_/grid/models/colDef/colDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/colDef.ts
@@ -118,7 +118,7 @@ export interface ColDef {
    */
   disableClickEventBubbling?: boolean;
   /**
-   * Allows to disable the column menu for this column.
+   * If `true`, the column menu is disabled for this column.
    */
   disableColumnMenu?: boolean;
   /**

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -145,7 +145,7 @@ export interface GridOptions {
    */
   disableColumnFilter?: boolean;
   /**
-   * If `true`, column Menu is disabled.
+   * If `true`, the column menu is disabled.
    * @default false
    */
   disableColumnMenu?: boolean;


### PR DESCRIPTION
Fixes #813 

Added docs and examples for the column menu. It turns out the menu is mentioned on the `Filtering` page but I added a menu specific explanation un the `Columns` page and added a link to the filtering specific usage of the menu.

Also updated the API docs with the new `disableColumnMenu` prop.