### PR TITLE
[DataGrid] Update docs to reflect v5 support

### DIFF
--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The Data Grid has complete accessibility support. For instance, every cell is accessible using the keyboard.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The Data Grid has complete accessibility support. For instance, every cell is accessible using the keyboard.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">This section goes in details on the aspects of the columns you need to know.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">This section goes in details on the aspects of the columns you need to know.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Data Grid will provide full support to create, read, update, and delete operations (CRUD).</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Data Grid will provide full support to create, read, update, and delete operations (CRUD).</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/export/export.md
+++ b/docs/src/pages/components/data-grid/export/export.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/export/export.md
+++ b/docs/src/pages/components/data-grid/export/export.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Easily export the rows in various file formats such as CSV, Excel, or PDF.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Filtering helps view particular or related records in the Data Grid.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Filtering helps view particular or related records in the Data Grid.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Get started with the last React data grid you will need. Install the package, configure the columns, provide rows and you are set.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Get started with the last React data grid you will need. Install the package, configure the columns, provide rows and you are set.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Use grouping, pivoting and more to analyse the data in depth.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Use grouping, pivoting and more to analyse the data in depth.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The Date Grid will support users from different locale, with formating, RTL, and localized strings.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The Date Grid will support users from different locale, with formating, RTL, and localized strings.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">A fast and extendable data table and data grid for React. It's a feature-rich component available in MIT or Commercial versions.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">A fast and extendable data table and data grid for React. It's a feature-rich component available in MIT or Commercial versions.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Through paging, a segment of data can be viewed from the assigned data source.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Through paging, a segment of data can be viewed from the assigned data source.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The grid is highly customizable. Take advantage of a React-first implementation.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">The grid is highly customizable. Take advantage of a React-first implementation.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">This section goes in details on the aspects of the rows you need to know.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">This section goes in details on the aspects of the rows you need to know.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -7,4 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Selection allows the user to select and highlight a number of rows that they can then take action on.</p>
 
-> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
+> ⚠️ The data grid components are supporting v5 and v4. However, no documentation is available for v5 yet. You can use the [documentation of v4](https://material-ui.com/components/data-grid/) instead.

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -7,6 +7,4 @@ components: DataGrid, XGrid
 
 <p class="description">Selection allows the user to select and highlight a number of rows that they can then take action on.</p>
 
-> ⚠️ This feature is only available in v4, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.
->
-> You can follow [issue #441](https://github.com/mui-org/material-ui-x/issues/441) to be notified once we migrate the data grid from v4 to v5.
+> ⚠️ This feature is now available in v5, head to the [v4 documentation page](https://material-ui.com/components/data-grid/) for more details.


### PR DESCRIPTION
To wrap up #441 

I tried applying the changes mentioned in step 2 from [this comment](https://github.com/mui-org/material-ui-x/pull/855#pullrequestreview-569244937) but there were issues with building the docs that I didn't manage to resolve quickly. Eventually, we would need to spend some more time to make it work and have all the examples in v5.