### PR TITLE
[DataGrid] Fix footer count not showing on small screens

### DIFF
--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -16,7 +16,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       [theme.breakpoints.up('md')]: {
         display: 'block',
       },
-    }
+    },
   },
   input: {
     display: 'none',

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -10,13 +10,13 @@ import { isMuiV5 } from '../utils';
 // Used to hide the drop down select from the TablePaginagion
 const useStyles = makeStyles((theme: Theme) => ({
   caption: {
-    display: 'none',
-    [theme.breakpoints.up('md')]: {
-      display: 'block',
-    },
-    '& ~ &': {
-      display: 'block',
-    },
+    // input label
+    ['&[id]']: {
+      display: 'none',
+      [theme.breakpoints.up('md')]: {
+        display: 'block',
+      },
+    }
   },
   input: {
     display: 'none',

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -11,7 +11,7 @@ import { isMuiV5 } from '../utils';
 const useStyles = makeStyles((theme: Theme) => ({
   caption: {
     // input label
-    ['&[id]']: {
+    '&[id]': {
       display: 'none',
       [theme.breakpoints.up('md')]: {
         display: 'block',

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -7,7 +7,7 @@ import { optionsSelector } from '../hooks/utils/optionsSelector';
 import { ApiContext } from './api-context';
 import { isMuiV5 } from '../utils';
 
-// Used to hide the drop down select from the TablePaginagion
+// Used to hide the Rows per page selector on small devices
 const useStyles = makeStyles((theme: Theme) => ({
   caption: {
     // input label


### PR DESCRIPTION
Closes https://github.com/mui-org/material-ui-x/issues/847 

I've tried the silution proposed in https://github.com/mui-org/material-ui-x/issues/847#issuecomment-759410424 but there was a problem (when **there is no select** for rows per page, the caption which we want to show is immediately after the `$spacer` and it was hidden).

The only viable difference I could find between the two captions, was that the one which is used as label have `id`, so I used that information. Honestly, it would have been much easier, if the `TablePagination` had different classes for these two elements.

Not sure if this is the best fix, but I am open to other ideas. I was trying to come up with some sibling selector, but I couldn't do it, as the same class is used on both places.

Not sure what's the best way for adding test for this, so please let me know.
