### PR TITLE
[DataGrid] Fix footer visual regression

### DIFF
--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   input: {
     display: 'none',
     [theme.breakpoints.up('md')]: {
-      display: 'flex',
+      display: 'inline-flex',
     },
   },
 }));

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -21,7 +21,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   input: {
     display: 'none',
     [theme.breakpoints.up('md')]: {
-      display: 'block',
+      display: 'flex',
     },
   },
 }));


### PR DESCRIPTION
Fix input display: 
![image](https://user-images.githubusercontent.com/936978/105868216-3c1c1900-5ff6-11eb-8edb-c7edae089dca.png)

Visible on grid with width higher than 960px, ie.
https://material-ui-x.netlify.app/storybook/?path=/story/x-grid-tests-pagination--pagination-default
