### PR TITLE
[DataGrid] Fix unstable footer height

### DIFF
--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -259,9 +259,11 @@ export const useStyles = makeStyles(
           '& .MuiDataGrid-selectedRowCount': {
             visibility: 'hidden',
             width: 0,
+            height: 0,
             [theme.breakpoints.up('sm')]: {
               visibility: 'visible',
               width: 'auto',
+              height: 'auto',
             },
           },
         },


### PR DESCRIPTION
Noticed in https://github.com/mui-org/material-ui-x/issues/936.

A reproduction:

- Open: https://codesandbox.io/s/material-demo-forked-4sexv?file=/demo.js
- Make sure the iframe is small enough
- Notice the footer:

<img width="206" alt="Capture d’écran 2021-01-27 à 16 32 16" src="https://user-images.githubusercontent.com/3165635/106013985-4bb26500-60bd-11eb-997f-9a1ebf366352.png">

- Select all the checkboxes, different height

<img width="194" alt="Capture d’écran 2021-01-27 à 16 32 22" src="https://user-images.githubusercontent.com/3165635/106014000-50771900-60bd-11eb-93b1-3ff1fc127d04.png">

