### PR TITLE
[core] Add 'Order id 💳' section in issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -65,3 +65,10 @@ Steps:
   Output from `npx @material-ui/envinfo` goes here.
 ```
 </details>
+
+## Order id 💳
+
+<!--
+  The Pro plan comes with priority over the Community/MIT plan.
+  Leaving your order id will help us give the attention your problem deserves.
+-->

--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -70,5 +70,5 @@ Steps:
 
 <!--
   The Pro plan comes with priority over the Community/MIT plan.
-  Leaving your order id will help us give the attention your problem deserves.
+  Providing your order id will help us give your problem the attention it deserves.
 -->

--- a/.github/ISSUE_TEMPLATE/2.feature.md
+++ b/.github/ISSUE_TEMPLATE/2.feature.md
@@ -32,3 +32,10 @@ labels: 'status: needs triage'
   What are you trying to accomplish? How has the lack of this feature affected you?
   Providing context helps us come up with a solution that is most useful in the real world.
 -->
+
+## Order id 💳
+
+<!--
+  The Pro plan comes with priority over the Community/MIT plan.
+  Leaving your order id will help us give the attention your problem deserves.
+-->

--- a/.github/ISSUE_TEMPLATE/2.feature.md
+++ b/.github/ISSUE_TEMPLATE/2.feature.md
@@ -37,5 +37,5 @@ labels: 'status: needs triage'
 
 <!--
   The Pro plan comes with priority over the Community/MIT plan.
-  Leaving your order id will help us give the attention your problem deserves.
+  Providing your order id will help us give your problem the attention it deserves.
 -->


### PR DESCRIPTION
An idea, then, we can write a bot to add the right label on the issue based on the plan the customer has purchased. The main flaw I see is, how do we guarantee that the order id is legit? Not copied from another issue.