### PR TITLE
[DataGrid] Remove duplicate aria-label

### DIFF
--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderTitle.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderTitle.tsx
@@ -8,14 +8,7 @@ const ColumnHeaderInnerTitle = React.forwardRef<
 >(function ColumnHeaderInnerTitle(props, ref) {
   const { className, ...other } = props;
 
-  return (
-    <div
-      ref={ref}
-      className={classnames('MuiDataGrid-colCellTitle', className)}
-      aria-label={String(other.children)}
-      {...other}
-    />
-  );
+  return <div ref={ref} className={classnames('MuiDataGrid-colCellTitle', className)} {...other} />;
 });
 
 export interface ColumnHeaderTitleProps {


### PR DESCRIPTION
The text is already available as a child. AFAIK, the aria-label adds nothing, it's noise. I had a look at https://accessible360.com/accessible360-blog/use-aria-label-screen-reader-text/ regarding the pros & cons of aria-label vs. sr-only text while it doesn't concern us here, it's interesting.