### PR TITLE
[docs] Improve docs of DataGrid about filter operators

### DIFF
--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.js
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.js
@@ -1,47 +1,31 @@
 import * as React from 'react';
-import {
-  DataGrid,
-  getNumericColumnOperators,
-  getDateOperators,
-} from '@material-ui/data-grid';
+import { DataGrid } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+const columns = [
+  { field: 'name', headerName: 'Name', width: 180 },
+  {
+    field: 'rating',
+    headerName: 'Rating',
+    type: 'number',
+  },
+  {
+    field: 'dateCreated',
+    headerName: 'Created on',
+    width: 180,
+    type: 'date',
+  },
+];
 
 export default function FilterOperators() {
   const { data } = useDemoData({
     dataSet: 'Employee',
-    rowLength: 100,
+    rowLength: 10,
   });
-
-  const rows = data.rows;
-
-  const columns = [
-    { field: 'name', headerName: 'Name', width: 180 },
-    { field: 'email', headerName: 'Email', width: 180 },
-    {
-      field: 'rating',
-      headerName: 'Rating',
-      width: 180,
-      type: 'number',
-      filterOperators: getNumericColumnOperators(),
-    },
-    {
-      field: 'dateCreated',
-      headerName: 'Created on',
-      width: 180,
-      type: 'date',
-      filterOperators: getDateOperators(),
-    },
-  ];
-
-  const dateFilterModel = {
-    items: [
-      { columnField: 'dateCreated', operatorValue: 'after', value: '2020-10-01' },
-    ],
-  };
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid rows={rows} columns={columns} filterModel={dateFilterModel} />
+      <DataGrid rows={data.rows} columns={columns} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.js
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.js
@@ -21,6 +21,7 @@ export default function FilterOperators() {
       field: 'rating',
       headerName: 'Rating',
       width: 180,
+      type: 'number',
       filterOperators: getNumericColumnOperators(),
     },
     {

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.js
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.js
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  getNumericColumnOperators,
+  getDateOperators,
+} from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function FilterOperators() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    rowLength: 100,
+  });
+
+  const rows = data.rows;
+
+  const columns = [
+    { field: 'name', headerName: 'Name', width: 180 },
+    { field: 'email', headerName: 'Email', width: 180 },
+    {
+      field: 'rating',
+      headerName: 'Rating',
+      width: 180,
+      filterOperators: getNumericColumnOperators(),
+    },
+    {
+      field: 'dateCreated',
+      headerName: 'Created on',
+      width: 180,
+      type: 'date',
+      filterOperators: getDateOperators(),
+    },
+  ];
+
+  const dateFilterModel = {
+    items: [
+      { columnField: 'dateCreated', operatorValue: 'after', value: '2020-10-01' },
+    ],
+  };
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid rows={rows} columns={columns} filterModel={dateFilterModel} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import {
+  DataGrid,
+  FilterModel,
+  getNumericColumnOperators,
+  getDateOperators,
+} from '@material-ui/data-grid';
+import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+export default function FilterOperators() {
+  const { data } = useDemoData({
+    dataSet: 'Employee',
+    rowLength: 100,
+  });
+
+  const rows = data.rows;
+
+  const columns = [
+    { field: 'name', headerName: 'Name', width: 180 },
+    { field: 'email', headerName: 'Email', width: 180 },
+    { field: 'rating', headerName: 'Rating', width: 180 },
+    {
+      field: 'dateCreated',
+      headerName: 'Created on',
+      width: 180,
+      type: 'date',
+      filterOperators: getDateOperators(),
+    },
+  ];
+
+  const dateFilterModel: FilterModel = {
+    items: [
+      { columnField: 'dateCreated', operatorValue: 'after', value: '2020-10-01' },
+    ],
+  };
+
+  return (
+    <div style={{ height: 400, width: '100%' }}>
+      <DataGrid rows={rows} columns={columns} filterModel={dateFilterModel} />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
@@ -1,48 +1,31 @@
 import * as React from 'react';
-import {
-  DataGrid,
-  FilterModel,
-  getNumericColumnOperators,
-  getDateOperators,
-} from '@material-ui/data-grid';
+import { DataGrid } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
+
+const columns = [
+  { field: 'name', headerName: 'Name', width: 180 },
+  {
+    field: 'rating',
+    headerName: 'Rating',
+    type: 'number',
+  },
+  {
+    field: 'dateCreated',
+    headerName: 'Created on',
+    width: 180,
+    type: 'date',
+  },
+];
 
 export default function FilterOperators() {
   const { data } = useDemoData({
     dataSet: 'Employee',
-    rowLength: 100,
+    rowLength: 10,
   });
-
-  const rows = data.rows;
-
-  const columns = [
-    { field: 'name', headerName: 'Name', width: 180 },
-    { field: 'email', headerName: 'Email', width: 180 },
-    {
-      field: 'rating',
-      headerName: 'Rating',
-      width: 180,
-      type: 'number',
-      filterOperators: getNumericColumnOperators(),
-    },
-    {
-      field: 'dateCreated',
-      headerName: 'Created on',
-      width: 180,
-      type: 'date',
-      filterOperators: getDateOperators(),
-    },
-  ];
-
-  const dateFilterModel: FilterModel = {
-    items: [
-      { columnField: 'dateCreated', operatorValue: 'after', value: '2020-10-01' },
-    ],
-  };
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid rows={rows} columns={columns} filterModel={dateFilterModel} />
+      <DataGrid rows={data.rows} columns={columns} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx
@@ -18,7 +18,13 @@ export default function FilterOperators() {
   const columns = [
     { field: 'name', headerName: 'Name', width: 180 },
     { field: 'email', headerName: 'Email', width: 180 },
-    { field: 'rating', headerName: 'Rating', width: 180 },
+    {
+      field: 'rating',
+      headerName: 'Rating',
+      width: 180,
+      type: 'number',
+      filterOperators: getNumericColumnOperators(),
+    },
     {
       field: 'dateCreated',
       headerName: 'Created on',

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -24,7 +24,7 @@ In addition to the column menu that allows users to apply a filter, you can also
 
 {{"demo": "pages/components/data-grid/filtering/BasicToolbarFilteringGrid.js", "bg": "inline"}}
 
-### Filter Operators
+### Column types
 
 The type of the column is used for adapting the filtering. You can find the different supported types in the [columns section](/components/data-grid/columns/#column-types).
 

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -26,7 +26,7 @@ In addition to the column menu that allows users to apply a filter, you can also
 
 ### Filter Operators
 
-By default the string operator is used for filtering. Additionally numerical and date operators are available:
+The type of the column is used for adapting the filtering. You can find the different supported types in the [columns section](/components/data-grid/columns/#column-types).
 
 {{"demo": "pages/components/data-grid/filtering/FilterOperators.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -24,6 +24,12 @@ In addition to the column menu that allows users to apply a filter, you can also
 
 {{"demo": "pages/components/data-grid/filtering/BasicToolbarFilteringGrid.js", "bg": "inline"}}
 
+### Filter Operators
+
+By default the string operator is used for filtering. Additionally numerical and date operators are available:
+
+{{"demo": "pages/components/data-grid/filtering/FilterOperators.js", "bg": "inline"}}
+
 ### Disable filter
 
 #### Globally

--- a/docs/src/pages/components/data-grid/filtering/filtering.md
+++ b/docs/src/pages/components/data-grid/filtering/filtering.md
@@ -28,7 +28,7 @@ In addition to the column menu that allows users to apply a filter, you can also
 
 The type of the column is used for adapting the filtering. You can find the different supported types in the [columns section](/components/data-grid/columns/#column-types).
 
-{{"demo": "pages/components/data-grid/filtering/FilterOperators.js", "bg": "inline"}}
+{{"demo": "pages/components/data-grid/filtering/FilterOperators.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ### Disable filter
 


### PR DESCRIPTION
[Fixing the failed checks right now]

While I started to use MaterialUI's DataGrid I struggled to figure out how to use non-string operators for filtering.
The example about custom filters touches this topic, but was a bit too advanced for my use case.

This is why I think it could be good to have an easy example in the docs to show the different filterOperators in action.

I'm not a born JS/TS developer, so please let me know if you see any issues with the demo :)