### PR TITLE
[DataGrid] fix autoheight header footer issue

### DIFF
--- a/packages/grid/_modules_/grid/GridComponent.tsx
+++ b/packages/grid/_modules_/grid/GridComponent.tsx
@@ -4,7 +4,6 @@
  */
 import * as React from 'react';
 import { useForkRef } from '@material-ui/core/utils';
-import NoSsr from '@material-ui/core/NoSsr';
 import { AutoSizer } from './components/AutoSizer';
 import { ColumnsHeader } from './components/columnHeaders/ColumnHeaders';
 import { ErrorBoundary } from './components/ErrorBoundary';
@@ -95,66 +94,70 @@ export const GridComponent = React.forwardRef<HTMLDivElement, GridComponentProps
     const showNoRowsOverlay = !props.loading && gridState.rows.totalRowCount === 0;
     return (
       <ApiContext.Provider value={apiRef}>
-        <NoSsr>
-          <GridRoot ref={handleRef} className={props.className}>
-            <ErrorBoundary
-              hasError={errorState != null}
-              componentProps={errorState}
-              api={apiRef!}
-              logger={logger}
-              render={(errorProps) => (
-                <GridMainContainer>
-                  <components.ErrorOverlay
-                    {...errorProps}
-                    {...componentBaseProps}
-                    {...props.componentsProps?.errorOverlay}
-                  />
-                </GridMainContainer>
-              )}
+        <AutoSizer onResize={onResize} nonce={props.nonce} disableHeight={props.autoHeight}>
+          {(size: any) => (
+            <GridRoot
+              ref={handleRef}
+              className={props.className}
+              size={size}
+              header={headerRef}
+              footer={footerRef}
             >
-              <div ref={headerRef}>
-                <components.Header {...componentBaseProps} {...props.componentsProps?.header} />
-              </div>
-              <GridMainContainer>
-                <GridColumnHeaderMenu
-                  ContentComponent={components.ColumnMenu}
-                  contentComponentProps={{
-                    ...componentBaseProps,
-                    ...props.componentsProps?.columnMenu,
-                  }}
-                />
-                <Watermark licenseStatus={props.licenseStatus} />
-                <GridColumnsContainer ref={columnsContainerRef}>
-                  <ColumnsHeader ref={columnsHeaderRef} />
-                </GridColumnsContainer>
-                {showNoRowsOverlay && (
-                  <components.NoRowsOverlay
-                    {...componentBaseProps}
-                    {...props.componentsProps?.noRowsOverlay}
-                  />
+              <ErrorBoundary
+                hasError={errorState != null}
+                componentProps={errorState}
+                api={apiRef!}
+                logger={logger}
+                render={(errorProps) => (
+                  <GridMainContainer>
+                    <components.ErrorOverlay
+                      {...errorProps}
+                      {...componentBaseProps}
+                      {...props.componentsProps?.errorOverlay}
+                    />
+                  </GridMainContainer>
                 )}
-                {props.loading && (
-                  <components.LoadingOverlay
-                    {...componentBaseProps}
-                    {...props.componentsProps?.loadingOverlay}
-                  />
-                )}
-                <AutoSizer onResize={onResize} nonce={props.nonce} disableHeight={props.autoHeight}>
-                  {(size: any) => (
-                    <GridWindow ref={windowRef} size={size}>
-                      <Viewport ref={renderingZoneRef} />
-                    </GridWindow>
-                  )}
-                </AutoSizer>
-              </GridMainContainer>
-              {!gridState.options.hideFooter && (
-                <div ref={footerRef}>
-                  <components.Footer {...componentBaseProps} {...props.componentsProps?.footer} />
+              >
+                <div ref={headerRef}>
+                  <components.Header {...componentBaseProps} {...props.componentsProps?.header} />
                 </div>
-              )}
-            </ErrorBoundary>
-          </GridRoot>
-        </NoSsr>
+                <GridMainContainer>
+                  <GridColumnHeaderMenu
+                    ContentComponent={components.ColumnMenu}
+                    contentComponentProps={{
+                      ...componentBaseProps,
+                      ...props.componentsProps?.columnMenu,
+                    }}
+                  />
+                  <Watermark licenseStatus={props.licenseStatus} />
+                  <GridColumnsContainer ref={columnsContainerRef}>
+                    <ColumnsHeader ref={columnsHeaderRef} />
+                  </GridColumnsContainer>
+                  {showNoRowsOverlay && (
+                    <components.NoRowsOverlay
+                      {...componentBaseProps}
+                      {...props.componentsProps?.noRowsOverlay}
+                    />
+                  )}
+                  {props.loading && (
+                    <components.LoadingOverlay
+                      {...componentBaseProps}
+                      {...props.componentsProps?.loadingOverlay}
+                    />
+                  )}
+                  <GridWindow ref={windowRef}>
+                    <Viewport ref={renderingZoneRef} />
+                  </GridWindow>
+                </GridMainContainer>
+                {!gridState.options.hideFooter && (
+                  <div ref={footerRef}>
+                    <components.Footer {...componentBaseProps} {...props.componentsProps?.footer} />
+                  </div>
+                )}
+              </ErrorBoundary>
+            </GridRoot>
+          )}
+        </AutoSizer>
       </ApiContext.Provider>
     );
   },

--- a/packages/grid/_modules_/grid/components/AutoSizer.tsx
+++ b/packages/grid/_modules_/grid/components/AutoSizer.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import { useForkRef, ownerWindow } from '@material-ui/core/utils';
+import { useGridState } from '../hooks/features/core/useGridState';
 import { useEventCallback, useEnhancedEffect } from '../utils/material-ui-utils';
 import createDetectElementResize from '../lib/createDetectElementResize';
+import { ApiContext } from './api-context';
 // TODO replace with https://caniuse.com/resizeobserver.
 
 export interface AutoSizerSize {
@@ -68,6 +70,8 @@ export const AutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>(functi
     width: defaultWidth,
   });
 
+  const apiRef = React.useContext(ApiContext);
+
   const rootRef = React.useRef<HTMLDivElement | null>(null);
   const parentElement = React.useRef<HTMLElement | null>(null);
 
@@ -93,10 +97,11 @@ export const AutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>(functi
         (!disableHeight && state.height !== newHeight) ||
         (!disableWidth && state.width !== newWidth)
       ) {
-        setState({
+        const size = {
           height: newHeight,
           width: newWidth,
-        });
+        };
+        setState(size);
 
         if (onResize) {
           onResize({ height: newHeight, width: newWidth });
@@ -141,15 +146,19 @@ export const AutoSizer = React.forwardRef<HTMLDivElement, AutoSizerProps>(functi
 
   const handleRef = useForkRef(rootRef, ref);
   return (
-    <div
-      ref={handleRef}
-      style={{
-        ...outerStyle,
-        ...style,
-      }}
-      {...other}
-    >
-      {state.height === null && state.width === null ? null : children(childParams)}
+    <div style={{ display: 'flex', flexGrow: 1 }}>
+      <div
+        className="autosizer-container"
+        ref={handleRef}
+        style={{
+          ...outerStyle,
+          ...style,
+        }}
+        {...other}
+      >
+        {state.height === null && state.width === null ? null : children(childParams)}
+      </div>
     </div>
   );
 });
+

--- a/packages/grid/_modules_/grid/components/containers/GridRoot.tsx
+++ b/packages/grid/_modules_/grid/components/containers/GridRoot.tsx
@@ -4,19 +4,35 @@ import { visibleColumnsLengthSelector } from '../../hooks/features/columns/colum
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { useGridState } from '../../hooks/features/core/useGridState';
 import { classnames } from '../../utils';
+import { getCurryTotalHeight } from '../../utils/getTotalHeight';
 import { ApiContext } from '../api-context';
 
-export type GridRootProps = React.HTMLAttributes<HTMLDivElement>;
+export interface GridRootProps extends React.HTMLAttributes<HTMLDivElement> {
+  size: { width: number; height: number };
+  header: React.RefObject<HTMLDivElement>;
+  footer: React.RefObject<HTMLDivElement>;
+}
 
 export const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function GridRoot(
   props,
   ref,
 ) {
-  const { className, ...other } = props;
+  const { className, style, ...other } = props;
   const classes = useStyles();
   const apiRef = React.useContext(ApiContext);
   const visibleColumnsLength = useGridSelector(apiRef, visibleColumnsLengthSelector);
   const [gridState] = useGridState(apiRef!);
+
+  const getTotalHeight = React.useCallback(
+    (size) =>
+      getCurryTotalHeight(
+        gridState.options,
+        gridState.containerSizes,
+        props.header,
+        props.footer,
+      )(size),
+    [gridState.options, gridState.containerSizes, props.header, props.footer],
+  );
 
   return (
     <div
@@ -30,6 +46,7 @@ export const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function
       tabIndex={0}
       aria-label={apiRef!.current.getLocaleText('rootGridLabel')}
       aria-multiselectable={!gridState.options.disableMultipleSelection}
+      style={{ width: props.size.width, height: getTotalHeight(props.size), ...style }}
       {...other}
     />
   );

--- a/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
+++ b/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
@@ -2,38 +2,25 @@ import * as React from 'react';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { densityHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
 import { optionsSelector } from '../../hooks/utils/optionsSelector';
-import { useGridState } from '../../hooks/features/core/useGridState';
-import { getCurryTotalHeight } from '../../utils/getTotalHeight';
 import { classnames } from '../../utils';
 import { ApiContext } from '../api-context';
 
-export interface GridWindowProps extends React.HTMLAttributes<HTMLDivElement> {
-  size: { width: number; height: number };
-}
+type GridWindowProps = React.HTMLAttributes<HTMLDivElement>;
 
 export const GridWindow = React.forwardRef<HTMLDivElement, GridWindowProps>(function GridWindow(
   props,
   ref,
 ) {
-  const { className, size, ...other } = props;
+  const { className, ...other } = props;
   const apiRef = React.useContext(ApiContext);
   const { autoHeight } = useGridSelector(apiRef, optionsSelector);
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
-  const [gridState] = useGridState(apiRef!);
-
   return (
     <div
-      style={{
-        width: props.size.width,
-        height: getCurryTotalHeight(gridState.options, gridState.containerSizes)(size),
-      }}
-    >
-      <div
-        ref={ref}
-        className={classnames('MuiDataGrid-window', className)}
-        {...other}
-        style={{ top: headerHeight, overflowY: autoHeight ? 'hidden' : 'auto' }}
-      />
-    </div>
+      ref={ref}
+      className={classnames('MuiDataGrid-window', className)}
+      {...other}
+      style={{ top: headerHeight, overflowY: autoHeight ? 'hidden' : 'auto' }}
+    />
   );
 });

--- a/packages/grid/_modules_/grid/hooks/features/core/gridState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/core/gridState.ts
@@ -58,3 +58,4 @@ export const getInitialState: () => GridState = () => ({
   visibleRows: getInitialVisibleRowsState(),
   density: getInitialDensityState(),
 });
+

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -1,18 +1,23 @@
+import * as React from 'react';
 import { ContainerProps, GridOptions } from '../models';
 
 // TODO Move that to renderContext and delete this
 export const getCurryTotalHeight = (
   internalOptions: GridOptions,
   containerSizes: ContainerProps | null,
+  headerRef: React.RefObject<HTMLDivElement>,
+  footerRef: React.RefObject<HTMLDivElement>,
 ) => (size: any) => {
   const dataContainerHeight = (containerSizes && containerSizes.dataContainerSizes!.height) || 0;
   if (!internalOptions.autoHeight) {
     return size.height;
   }
+  const footerHeight = (footerRef.current && footerRef.current.getBoundingClientRect().height) || 0;
+  const headerHeight = (headerRef.current && headerRef.current.getBoundingClientRect().height) || 0;
   let dataHeight = dataContainerHeight;
   if (dataHeight < internalOptions.rowHeight) {
     dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
   }
 
-  return dataHeight + internalOptions.headerHeight;
+  return headerHeight + footerHeight + dataHeight + internalOptions.headerHeight;
 };

--- a/packages/storybook/src/stories/grid-columns.stories.tsx
+++ b/packages/storybook/src/stories/grid-columns.stories.tsx
@@ -138,6 +138,7 @@ export function UpdateColumnsBtn() {
       </div>
       <div className="grid-container">
         <XGrid rows={rows} columns={cols} />
+        <p style={{ backgroundColor: 'red' }}>after DataGrid</p>
       </div>
     </React.Fragment>
   );

--- a/packages/storybook/src/stories/grid-options.stories.tsx
+++ b/packages/storybook/src/stories/grid-options.stories.tsx
@@ -92,8 +92,10 @@ export const ColumnRightBorder = () => {
 export const AutoHeightSmall = () => {
   const data = useData(8, 12);
   return (
-    <div>
+    <div className="grid-container">
+      <p style={{ backgroundColor: 'red', height: 50 }}>before DataGrid</p>
       <XGrid rows={data.rows} columns={data.columns} autoHeight />
+      <p style={{ backgroundColor: 'red' }}>after DataGrid</p>
     </div>
   );
 };
@@ -101,8 +103,10 @@ export const AutoHeightSmall = () => {
 export const AutoHeightLarge = () => {
   const data = useData(75, 20);
   return (
-    <div>
+    <div className="grid-container">
+      <p style={{ backgroundColor: 'red', height: 50 }}>before DataGrid</p>
       <XGrid rows={data.rows} columns={data.columns} autoHeight />
+      <p style={{ backgroundColor: 'red' }}>after DataGrid</p>
     </div>
   );
 };

--- a/packages/storybook/src/style/grid-stories.css
+++ b/packages/storybook/src/style/grid-stories.css
@@ -18,7 +18,7 @@
  #root {
      top:0;
      left: 0;
-     min-width: 100%;
+     width: 100%;
      height: 100%;
      display: flex;
      position: absolute;
@@ -56,4 +56,5 @@
     padding: 10px;
     display: flex;
     flex-grow: 1;
+    flex-direction: column;
  }


### PR DESCRIPTION
revert #940, fix #604 without moving autoSizer as autosizer initialise the size of the grid, which then calculates all container sizes, and then according to those sizes render rows and columns.
