### PR TITLE
[core] Improve prop-types handling

### DIFF
--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -56,7 +56,7 @@ const DataGrid2 = React.forwardRef<HTMLDivElement, DataGridProps>(function DataG
   );
 });
 
-(DataGrid2 as any).propTypes = {
+DataGrid2.propTypes = {
   apiRef: chainPropTypes(PropTypes.any, (props: any) => {
     if (props.apiRef != null) {
       return new Error(
@@ -174,7 +174,7 @@ const DataGrid2 = React.forwardRef<HTMLDivElement, DataGridProps>(function DataG
     }
     return null;
   },
-};
+} as any;
 
 export const DataGrid = React.memo(DataGrid2);
 


### PR DESCRIPTION
Apply the same fix as @eps1lon did in the main repo: https://github.com/mui-org/material-ui/pull/24747. It will allow to automatic generation of the documentation and stripping the prop-types from the production bundle once we use [the babel plugin](https://www.npmjs.com/package/babel-plugin-transform-react-remove-prop-types) dedicated to it (-0.3kB gzipped now and a lot more saving once we generate the docs automatically)