### PR TITLE
[docs] Catch leaks ahread of time

### DIFF
--- a/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.js
+++ b/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.js
@@ -12,11 +12,9 @@ function loadServerRows(sortModel, data) {
 
       const sortedColumn = sortModel[0];
 
-      let sortedRows = [
-        ...data.rows.sort((a, b) =>
-          String(a[sortedColumn.field]).localeCompare(String(b[sortedColumn.field])),
-        ),
-      ];
+      let sortedRows = [...data.rows].sort((a, b) =>
+        String(a[sortedColumn.field]).localeCompare(String(b[sortedColumn.field])),
+      );
 
       if (sortModel[0].sort === 'desc') {
         sortedRows = sortedRows.reverse();

--- a/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.tsx
+++ b/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.tsx
@@ -17,11 +17,9 @@ function loadServerRows(sortModel: SortModel, data: GridData): Promise<any> {
 
       const sortedColumn = sortModel[0];
 
-      let sortedRows = [
-        ...data.rows.sort((a, b) =>
-          String(a[sortedColumn.field]).localeCompare(String(b[sortedColumn.field])),
-        ),
-      ];
+      let sortedRows = [...data.rows].sort((a, b) =>
+        String(a[sortedColumn.field]).localeCompare(String(b[sortedColumn.field])),
+      );
 
       if (sortModel[0].sort === 'desc') {
         sortedRows = sortedRows.reverse();

--- a/packages/grid/_modules_/grid/hooks/features/filter/useFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useFilter.ts
@@ -65,11 +65,17 @@ export const useFilter = (apiRef: ApiRef, rowsProp: RowsProp): void => {
       const filterOperators = column.filterOperators;
 
       if (!filterOperators?.length) {
-        throw new Error(`No Filter operator found for column ${column.field}`);
+        throw new Error(`Material-UI: No filter operators found for column '${column.field}'.`);
       }
       const filterOperator = filterOperators.find(
         (operator) => operator.value === filterItem.operatorValue,
       )!;
+
+      if (!filterOperator) {
+        throw new Error(
+          `Material-UI: No filter operator found for column '${column.field}' and operator value '${filterItem.operatorValue}'.`,
+        );
+      }
 
       const applyFilterOnRow = filterOperator.getApplyFilterFn(filterItem, column)!;
 

--- a/packages/grid/x-grid-data-generator/src/useDemoData.ts
+++ b/packages/grid/x-grid-data-generator/src/useDemoData.ts
@@ -57,6 +57,24 @@ async function sleep(duration: number) {
   });
 }
 
+function deepFreeze(object) {
+  // Retrieve the property names defined on object
+  const propNames = Object.getOwnPropertyNames(object);
+
+  // Freeze properties before freezing self
+
+  // eslint-disable-next-line no-restricted-syntax
+  for (const name of propNames) {
+    const value = object[name];
+
+    if (value && typeof value === 'object') {
+      deepFreeze(value);
+    }
+  }
+
+  return Object.freeze(object);
+}
+
 export const useDemoData = (options: DemoDataOptions): DemoDataReturnType => {
   const [data, setData] = React.useState<GridData>({ columns: [], rows: [] });
   const [rowLength, setRowLength] = React.useState(options.rowLength);
@@ -96,6 +114,8 @@ export const useDemoData = (options: DemoDataOptions): DemoDataReturnType => {
       if (!active) {
         return;
       }
+
+      deepFreeze(newData);
 
       dataCache.set(cacheKey, newData);
       setData(newData);


### PR DESCRIPTION
Improve the DX when this error occurs, as well as throw **ahead of time** (it should throw when opening the page, without any interaction). The need for the changes was surfaced with #974. It's not OK to mutate the data returned by `useDemoData` as it's stored in a state. Modifications are shared between two renders as well as two different mounts (trough caching).

It works, see https://deploy-preview-979--material-ui-x.netlify.app/components/data-grid/filtering/ that throws with:

<img width="473" alt="Capture d’écran 2021-02-04 à 12 09 23" src="https://user-images.githubusercontent.com/3165635/106884621-d6104f80-66e1-11eb-99a8-89b032fa6eb8.png">

#975 should be merged first.