### PR TITLE
[DataGrid] Fix timing guarentee

### DIFF
--- a/docs/src/pages/components/data-grid/rendering/AutoHeightGrid.js
+++ b/docs/src/pages/components/data-grid/rendering/AutoHeightGrid.js
@@ -12,6 +12,7 @@ export default function AutoHeightGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid autoHeight {...data} />
+      <p>more content</p>
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/rendering/AutoHeightGrid.tsx
+++ b/docs/src/pages/components/data-grid/rendering/AutoHeightGrid.tsx
@@ -12,6 +12,7 @@ export default function AutoHeightGrid() {
   return (
     <div style={{ height: 400, width: '100%' }}>
       <DataGrid autoHeight {...data} />
+      <p>more content</p>
     </div>
   );
 }

--- a/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
+++ b/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
@@ -3,7 +3,7 @@ import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { densityHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
 import { optionsSelector } from '../../hooks/utils/optionsSelector';
 import { useGridState } from '../../hooks/features/core/useGridState';
-import { getCurryTotalHeight } from '../../utils/getTotalHeight';
+import { getTotalHeight } from '../../utils/getTotalHeight';
 import { classnames } from '../../utils';
 import { ApiContext } from '../api-context';
 
@@ -31,8 +31,8 @@ export const GridWindow = React.forwardRef<HTMLDivElement, GridWindowProps>(func
   return (
     <div
       style={{
-        width: props.size.width,
-        height: getCurryTotalHeight(gridState.options, gridState.containerSizes)(size),
+        width: size.width,
+        height: getTotalHeight(gridState.options, gridState.containerSizes, size.height),
       }}
     >
       <div

--- a/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
+++ b/packages/grid/_modules_/grid/components/containers/GridWindow.tsx
@@ -21,6 +21,13 @@ export const GridWindow = React.forwardRef<HTMLDivElement, GridWindowProps>(func
   const headerHeight = useGridSelector(apiRef, densityHeaderHeightSelector);
   const [gridState] = useGridState(apiRef!);
 
+  React.useEffect(() => {
+    // refs are run before effect. Waiting for an effect guarentees that
+    // windowRef is resolved first.
+    // Once windowRef is resolved, we can update the size of the container.
+    apiRef!.current.resize();
+  }, [apiRef]);
+
   return (
     <div
       style={{

--- a/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
@@ -47,9 +47,7 @@ export function useResizeContainer(apiRef): (size: ElementSize) => void {
       }
 
       gridLogger.info('resized...', size);
-      if (apiRef!.current.resize) {
-        apiRef!.current.resize();
-      }
+      apiRef!.current.resize();
     },
     [gridLogger, apiRef, autoHeight],
   );

--- a/packages/grid/_modules_/grid/utils/getTotalHeight.ts
+++ b/packages/grid/_modules_/grid/utils/getTotalHeight.ts
@@ -1,18 +1,20 @@
 import { ContainerProps, GridOptions } from '../models';
 
 // TODO Move that to renderContext and delete this
-export const getCurryTotalHeight = (
-  internalOptions: GridOptions,
+export const getTotalHeight = (
+  options: GridOptions,
   containerSizes: ContainerProps | null,
-) => (size: any) => {
-  const dataContainerHeight = (containerSizes && containerSizes.dataContainerSizes!.height) || 0;
-  if (!internalOptions.autoHeight) {
-    return size.height;
-  }
-  let dataHeight = dataContainerHeight;
-  if (dataHeight < internalOptions.rowHeight) {
-    dataHeight = internalOptions.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
+  height: number,
+) => {
+  if (!options.autoHeight) {
+    return height;
   }
 
-  return dataHeight + internalOptions.headerHeight;
+  const dataContainerHeight = (containerSizes && containerSizes.dataContainerSizes!.height) || 0;
+  let dataHeight = dataContainerHeight;
+  if (dataHeight < options.rowHeight) {
+    dataHeight = options.rowHeight * 2; // If we have no rows, we give the size of 2 rows to display the no rows overlay
+  }
+
+  return options.headerHeight + dataHeight;
 };


### PR DESCRIPTION
Sorry, I got more stuff to attent to before I could have a look at the problem:

<img width="136" alt="Capture d’écran 2021-02-05 à 00 38 59" src="https://user-images.githubusercontent.com/3165635/106969155-9a5da000-674a-11eb-90c8-49b2e941d04b.png">


Closes #977.

I have tried to explain what's going on in the comment. Previously, we had no timing guarantee, we were lucky (no matter where the AutoSizer is in the React tree). After 64ba484c094c3fe728fbfbcbf3ac7c772a728da9 was merged, we lost a rerender which made the last render happen before the ref of the container is resolved. The fix is the first commit, the rest is cleanup.