### PR TITLE
[DataGrid] Add bgBG locale

### DIFF
--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -17,7 +17,10 @@ In the following example, the labels of the density selector are customized.
 
 {{"demo": "pages/components/data-grid/localization/CustomLocaleTextGrid.js", "bg": "inline"}}
 
-The default locale of Material-UI is English (United States). You can find all the locales supported in [the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
+## Locale text
+
+The default locale of Material-UI is English (United States). 
+You can find all the locales supported in [the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
 
 ### Supported locales
 
@@ -25,9 +28,6 @@ The default locale of Material-UI is English (United States). You can find all t
 | :-------- | :------------------ | :---------- |
 | Bulgarian | bg-BG               | `bgBG`      |
 
-## 🚧 Locale text
-
-> ⚠️ This feature isn't implemented yet. It's coming.
 >
 > 👍 Upvote [issue #777](https://github.com/mui-org/material-ui-x/issues/777) if you want to see it land faster.
 

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -17,6 +17,14 @@ In the following example, the labels of the density selector are customized.
 
 {{"demo": "pages/components/data-grid/localization/CustomLocaleTextGrid.js", "bg": "inline"}}
 
+The default locale of Material-UI is English (United States). You can find all the locales supported in [the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
+
+### Supported locales
+
+| Locale    | BCP 47 language tag | Import name |
+| :-------- | :------------------ | :---------- |
+| Bulgarian | bg-BG               | `bgBG`      |
+
 ## 🚧 Locale text
 
 > ⚠️ This feature isn't implemented yet. It's coming.

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -19,7 +19,7 @@ In the following example, the labels of the density selector are customized.
 
 ## Locale text
 
-The default locale of Material-UI is English (United States). 
+The default locale of Material-UI is English (United States).
 You can find all the locales supported in [the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
 
 ### Supported locales
@@ -27,9 +27,6 @@ You can find all the locales supported in [the source](https://github.com/mui-or
 | Locale    | BCP 47 language tag | Import name |
 | :-------- | :------------------ | :---------- |
 | Bulgarian | bg-BG               | `bgBG`      |
-
->
-> 👍 Upvote [issue #777](https://github.com/mui-org/material-ui-x/issues/777) if you want to see it land faster.
 
 The data grid will support dozens of locales with a simple import that includes all the translated messages.
 You will be able to follow [this guide](/guides/localization/#locale-text) to use them.

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { capitalize } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
 import InputLabel from '@material-ui/core/InputLabel';
@@ -201,7 +202,9 @@ export function FilterForm(props: FilterFormProps) {
         >
           {currentColumn?.filterOperators?.map((operator) => (
             <option key={operator.value} value={operator.value}>
-              {apiRef!.current.getLocaleText(operator.value as TranslationKeys)}
+              {apiRef!.current.getLocaleText(
+                `filterOperator${capitalize(operator.value)}` as TranslationKeys,
+              )}
             </option>
           ))}
         </Select>

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -11,6 +11,7 @@ import { FilterItem, LinkOperator } from '../../../models/filterItem';
 import { FilterOperator } from '../../../models/filterOperator';
 import { ApiContext } from '../../api-context';
 import { CloseIcon } from '../../icons/index';
+import { TranslationKeys } from '../../../models/api/localeTextApi';
 
 export interface FilterFormProps {
   item: FilterItem;
@@ -200,7 +201,7 @@ export function FilterForm(props: FilterFormProps) {
         >
           {currentColumn?.filterOperators?.map((operator) => (
             <option key={operator.value} value={operator.value}>
-              {operator.label}
+              {apiRef!.current.getLocaleText(operator.value as TranslationKeys)}
             </option>
           ))}
         </Select>

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -40,15 +40,15 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   filterPanelColumns: 'Columns',
 
   // Filter operators text
-  contains: 'contains',
-  equals: 'equals',
-  startsWith: 'starts with',
-  endsWith: 'ends with',
-  is: 'is',
-  not: 'is not',
-  onOrAfter: 'is on or after',
-  before: 'is before',
-  onOrBefore: 'is on or before',
+  filterOperatorContains: 'contains',
+  filterOperatorEquals: 'equals',
+  filterOperatorStartsWith: 'starts with',
+  filterOperatorEndsWith: 'ends with',
+  filterOperatorIs: 'is',
+  filterOperatorNot: 'is not',
+  filterOperatorOnOrAfter: 'is on or after',
+  filterOperatorBefore: 'is before',
+  filterOperatorOnOrBefore: 'is on or before',
 
   // Column menu text
   columnMenuLabel: 'Menu',

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -39,6 +39,17 @@ export const DEFAULT_LOCALE_TEXT: LocaleText = {
   filterPanelOperatorOr: 'Or',
   filterPanelColumns: 'Columns',
 
+  // Filter operators text
+  contains: 'contains',
+  equals: 'equals',
+  startsWith: 'starts with',
+  endsWith: 'ends with',
+  is: 'is',
+  not: 'is not',
+  onOrAfter: 'is on or after',
+  before: 'is before',
+  onOrBefore: 'is on or before',
+
   // Column menu text
   columnMenuLabel: 'Menu',
   columnMenuShowColumns: 'Show columns',

--- a/packages/grid/_modules_/grid/index.ts
+++ b/packages/grid/_modules_/grid/index.ts
@@ -1,6 +1,7 @@
 export * from './components';
 export * from './constants';
 export * from './hooks';
+export * from './locales';
 export * from './models';
 export * from './utils';
 export * from './GridComponentProps';

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -1,84 +1,78 @@
-export const bgBG = {
-  components: {
-    MuiDataGrid: {
-      defaultProps: {
-        localeText: {
-          // Root
-          rootGridLabel: 'мрежа',
-          noRowsLabel: 'Няма редове',
-          errorOverlayDefaultLabel: 'Възникна грешка.',
+import { getLocalization, Localization } from '../utils';
 
-          // Density selector toolbar button text
-          toolbarDensity: 'Гъстота',
-          toolbarDensityLabel: 'Гъстота',
-          toolbarDensityCompact: 'Компактна',
-          toolbarDensityStandard: 'Стандартна',
-          toolbarDensityComfortable: 'Комфортна',
+export const bgBG: Localization = getLocalization({
+  // Root
+  rootGridLabel: 'мрежа',
+  noRowsLabel: 'Няма редове',
+  errorOverlayDefaultLabel: 'Възникна грешка.',
 
-          // Columns selector toolbar button text
-          toolbarColumns: 'Колони',
-          toolbarColumnsLabel: 'Покажи селектора на колони',
+  // Density selector toolbar button text
+  toolbarDensity: 'Гъстота',
+  toolbarDensityLabel: 'Гъстота',
+  toolbarDensityCompact: 'Компактна',
+  toolbarDensityStandard: 'Стандартна',
+  toolbarDensityComfortable: 'Комфортна',
 
-          // Filters toolbar button text
-          toolbarFilters: 'Филтри',
-          toolbarFiltersLabel: 'Покажи Филтрите',
-          toolbarFiltersTooltipHide: 'Скрий Филтрите',
-          toolbarFiltersTooltipShow: 'Покажи Филтрите',
-          toolbarFiltersTooltipActive: (count) => `${count} активни филтри`,
+  // Columns selector toolbar button text
+  toolbarColumns: 'Колони',
+  toolbarColumnsLabel: 'Покажи селектора на колони',
 
-          // Columns panel text
-          columnsPanelTextFieldLabel: 'Намери колона',
-          columnsPanelTextFieldPlaceholder: 'Заглавие на колона',
-          columnsPanelDragIconLabel: 'Пренареди на колона',
-          columnsPanelShowAllButton: 'Покажи Всички',
-          columnsPanelHideAllButton: 'Скрий Всички',
+  // Filters toolbar button text
+  toolbarFilters: 'Филтри',
+  toolbarFiltersLabel: 'Покажи Филтрите',
+  toolbarFiltersTooltipHide: 'Скрий Филтрите',
+  toolbarFiltersTooltipShow: 'Покажи Филтрите',
+  toolbarFiltersTooltipActive: (count) => `${count} активни филтри`,
 
-          // Filter panel text
-          filterPanelAddFilter: 'Добави Филтър',
-          filterPanelDeleteIconLabel: 'Изтрий',
-          filterPanelOperators: 'Оператори',
-          filterPanelOperatorAnd: 'И',
-          filterPanelOperatorOr: 'Или',
-          filterPanelColumns: 'Колони',
+  // Columns panel text
+  columnsPanelTextFieldLabel: 'Намери колона',
+  columnsPanelTextFieldPlaceholder: 'Заглавие на колона',
+  columnsPanelDragIconLabel: 'Пренареди на колона',
+  columnsPanelShowAllButton: 'Покажи Всички',
+  columnsPanelHideAllButton: 'Скрий Всички',
 
-          // Filter operators text
-          contains: 'съдържа',
-          equals: 'равно',
-          startsWith: 'започва с',
-          endsWith: 'завършва с',
-          is: 'е',
-          not: 'не е',
-          onOrAfter: 'е на или след',
-          before: 'е преди',
-          onOrBefore: 'е на или преди',
+  // Filter panel text
+  filterPanelAddFilter: 'Добави Филтър',
+  filterPanelDeleteIconLabel: 'Изтрий',
+  filterPanelOperators: 'Оператори',
+  filterPanelOperatorAnd: 'И',
+  filterPanelOperatorOr: 'Или',
+  filterPanelColumns: 'Колони',
 
-          // Column menu text
-          columnMenuLabel: 'Меню',
-          columnMenuShowColumns: 'Покажи колоните',
-          columnMenuFilter: 'Филтри',
-          columnMenuHideColumn: 'Скрий',
-          columnMenuUnsort: 'Отмени сортирането',
-          columnMenuSortAsc: 'Сортирай по възходящ ред',
-          columnMenuSortDesc: 'Сортирай по низходящ ред',
+  // Filter operators text
+  filterOperatorContains: 'съдържа',
+  filterOperatorEquals: 'равно',
+  filterOperatorStartsWith: 'започва с',
+  filterOperatorEndsWith: 'завършва с',
+  filterOperatorIs: 'е',
+  filterOperatorNot: 'не е',
+  filterOperatorOnOrAfter: 'е на или след',
+  filterOperatorBefore: 'е преди',
+  filterOperatorOnOrBefore: 'е на или преди',
 
-          // Column header text
-          columnHeaderFiltersTooltipActive: (count) => `${count} активни филтри`,
-          columnHeaderFiltersLabel: 'Покажи Филтрите',
-          columnHeaderSortIconLabel: 'Сортирай',
+  // Column menu text
+  columnMenuLabel: 'Меню',
+  columnMenuShowColumns: 'Покажи колоните',
+  columnMenuFilter: 'Филтри',
+  columnMenuHideColumn: 'Скрий',
+  columnMenuUnsort: 'Отмени сортирането',
+  columnMenuSortAsc: 'Сортирай по възходящ ред',
+  columnMenuSortDesc: 'Сортирай по низходящ ред',
 
-          // Rows selected footer text
-          footerRowSelected: (count) =>
-            count !== 1
-              ? `${count.toLocaleString()} избрани редове`
-              : `${count.toLocaleString()} избран ред`,
+  // Column header text
+  columnHeaderFiltersTooltipActive: (count) => `${count} активни филтри`,
+  columnHeaderFiltersLabel: 'Покажи Филтрите',
+  columnHeaderSortIconLabel: 'Сортирай',
 
-          // Total rows footer text
-          footerTotalRows: 'Общо Rедове:',
+  // Rows selected footer text
+  footerRowSelected: (count) =>
+    count !== 1
+      ? `${count.toLocaleString()} избрани редове`
+      : `${count.toLocaleString()} избран ред`,
 
-          // Pagination footer text
-          footerPaginationRowsPerPage: 'Редове на страница:',
-        },
-      },
-    },
-  },
-};
+  // Total rows footer text
+  footerTotalRows: 'Общо Rедове:',
+
+  // Pagination footer text
+  footerPaginationRowsPerPage: 'Редове на страница:',
+});

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -1,0 +1,84 @@
+export const bgBG = {
+  components: {
+    MuiDataGrid: {
+      defaultProps: {
+        localeText: {
+          // Root
+          rootGridLabel: 'мрежа',
+          noRowsLabel: 'Няма редове',
+          errorOverlayDefaultLabel: 'Възникна грешка.',
+
+          // Density selector toolbar button text
+          toolbarDensity: 'Гъстота',
+          toolbarDensityLabel: 'Гъстота',
+          toolbarDensityCompact: 'Компактна',
+          toolbarDensityStandard: 'Стандартна',
+          toolbarDensityComfortable: 'Комфортна',
+
+          // Columns selector toolbar button text
+          toolbarColumns: 'Колони',
+          toolbarColumnsLabel: 'Покажи селектора на колони',
+
+          // Filters toolbar button text
+          toolbarFilters: 'Филтри',
+          toolbarFiltersLabel: 'Покажи Филтрите',
+          toolbarFiltersTooltipHide: 'Скрий Филтрите',
+          toolbarFiltersTooltipShow: 'Покажи Филтрите',
+          toolbarFiltersTooltipActive: (count) => `${count} активни филтри`,
+
+          // Columns panel text
+          columnsPanelTextFieldLabel: 'Намери колона',
+          columnsPanelTextFieldPlaceholder: 'Заглавие на колона',
+          columnsPanelDragIconLabel: 'Пренареди на колона',
+          columnsPanelShowAllButton: 'Покажи Всички',
+          columnsPanelHideAllButton: 'Скрий Всички',
+
+          // Filter panel text
+          filterPanelAddFilter: 'Добави Филтър',
+          filterPanelDeleteIconLabel: 'Изтрий',
+          filterPanelOperators: 'Оператори',
+          filterPanelOperatorAnd: 'И',
+          filterPanelOperatorOr: 'Или',
+          filterPanelColumns: 'Колони',
+
+          // Filter operators text
+          contains: 'съдържа',
+          equals: 'равно',
+          startsWith: 'започва с',
+          endsWith: 'завършва с',
+          is: 'е',
+          not: 'не е',
+          onOrAfter: 'е на или след',
+          before: 'е преди',
+          onOrBefore: 'е на или преди',
+
+          // Column menu text
+          columnMenuLabel: 'Меню',
+          columnMenuShowColumns: 'Покажи колоните',
+          columnMenuFilter: 'Филтри',
+          columnMenuHideColumn: 'Скрий',
+          columnMenuUnsort: 'Отмени сортирането',
+          columnMenuSortAsc: 'Сортирай по възходящ ред',
+          columnMenuSortDesc: 'Сортирай по низходящ ред',
+
+          // Column header text
+          columnHeaderFiltersTooltipActive: (count) => `${count} активни филтри`,
+          columnHeaderFiltersLabel: 'Покажи Филтрите',
+          columnHeaderSortIconLabel: 'Сортирай',
+
+          // Rows selected footer text
+          footerRowSelected: (count) =>
+            count !== 1
+              ? `${count.toLocaleString()} избрани редове`
+              : `${count.toLocaleString()} избран ред`,
+
+          // Total rows footer text
+          footerTotalRows: 'Общо Rедове:',
+
+          // Pagination footer text
+          footerPaginationRowsPerPage: 'Редове на страница:',
+        },
+      },
+    },
+  },
+};

--- a/packages/grid/_modules_/grid/locales/index.ts
+++ b/packages/grid/_modules_/grid/locales/index.ts
@@ -1,0 +1,1 @@
+export * from './bgBG';

--- a/packages/grid/_modules_/grid/models/api/localeTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/localeTextApi.ts
@@ -41,15 +41,15 @@ export interface LocaleText {
   filterPanelColumns: React.ReactNode;
 
   // Filter operators text
-  contains: React.ReactNode;
-  equals: React.ReactNode;
-  startsWith: React.ReactNode;
-  endsWith: React.ReactNode;
-  is: React.ReactNode;
-  not: React.ReactNode;
-  onOrAfter: React.ReactNode;
-  before: React.ReactNode;
-  onOrBefore: React.ReactNode;
+  filterOperatorContains: string;
+  filterOperatorEquals: string;
+  filterOperatorStartsWith: string;
+  filterOperatorEndsWith: string;
+  filterOperatorIs: string;
+  filterOperatorNot: string;
+  filterOperatorOnOrAfter: string;
+  filterOperatorBefore: string;
+  filterOperatorOnOrBefore: string;
 
   // Column menu text
   columnMenuLabel: string;

--- a/packages/grid/_modules_/grid/models/api/localeTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/localeTextApi.ts
@@ -40,6 +40,17 @@ export interface LocaleText {
   filterPanelOperatorOr: React.ReactNode;
   filterPanelColumns: React.ReactNode;
 
+  // Filter operators text
+  contains: React.ReactNode;
+  equals: React.ReactNode;
+  startsWith: React.ReactNode;
+  endsWith: React.ReactNode;
+  is: React.ReactNode;
+  not: React.ReactNode;
+  onOrAfter: React.ReactNode;
+  before: React.ReactNode;
+  onOrBefore: React.ReactNode;
+
   // Column menu text
   columnMenuLabel: string;
   columnMenuShowColumns: React.ReactNode;

--- a/packages/grid/_modules_/grid/models/colDef/dateOperators.ts
+++ b/packages/grid/_modules_/grid/models/colDef/dateOperators.ts
@@ -5,7 +5,6 @@ import { ColDef } from './colDef';
 
 export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showTime) => [
   {
-    label: 'is',
     value: 'is',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -28,7 +27,6 @@ export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showT
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
   },
   {
-    label: 'is not',
     value: 'not',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -51,7 +49,6 @@ export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showT
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
   },
   {
-    label: 'is after',
     value: 'after',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -74,7 +71,6 @@ export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showT
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
   },
   {
-    label: 'is on or after',
     value: 'onOrAfter',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -97,7 +93,6 @@ export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showT
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
   },
   {
-    label: 'is before',
     value: 'before',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -120,7 +115,6 @@ export const getDateOperators: (showTime?: boolean) => FilterOperator[] = (showT
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
   },
   {
-    label: 'is on or before',
     value: 'onOrBefore',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {

--- a/packages/grid/_modules_/grid/models/colDef/stringOperators.ts
+++ b/packages/grid/_modules_/grid/models/colDef/stringOperators.ts
@@ -5,7 +5,6 @@ import { ColDef } from './colDef';
 
 export const getStringOperators: () => FilterOperator[] = () => [
   {
-    label: 'contains',
     value: 'contains',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -21,7 +20,6 @@ export const getStringOperators: () => FilterOperator[] = () => [
     InputComponent: FilterInputValue,
   },
   {
-    label: 'equals',
     value: 'equals',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -39,7 +37,6 @@ export const getStringOperators: () => FilterOperator[] = () => [
     InputComponent: FilterInputValue,
   },
   {
-    label: 'starts with',
     value: 'startsWith',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
@@ -55,7 +52,6 @@ export const getStringOperators: () => FilterOperator[] = () => [
     InputComponent: FilterInputValue,
   },
   {
-    label: 'ends with',
     value: 'endsWith',
     getApplyFilterFn: (filterItem: FilterItem, column: ColDef) => {
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {

--- a/packages/grid/_modules_/grid/models/filterOperator.ts
+++ b/packages/grid/_modules_/grid/models/filterOperator.ts
@@ -4,7 +4,6 @@ import { FilterItem } from './filterItem';
 import { CellParams } from './params/cellParams';
 
 export interface FilterOperator {
-  label: string;
   value: string;
   getApplyFilterFn: (
     filterItem: FilterItem,

--- a/packages/grid/_modules_/grid/utils/getLocalization.ts
+++ b/packages/grid/_modules_/grid/utils/getLocalization.ts
@@ -1,0 +1,41 @@
+import { LocaleText } from '../models/api/localeTextApi';
+import { GridOptions } from '../models/gridOptions';
+import { isMuiV5 } from './utils';
+
+export interface LocalizationV4 {
+  props: {
+    MuiDataGrid: Pick<GridOptions, 'localeText'>;
+  };
+}
+
+export interface LocalizationV5 {
+  components: {
+    MuiDataGrid: {
+      defaultProps: Pick<GridOptions, 'localeText'>;
+    };
+  };
+}
+
+export type Localization = LocalizationV4 | LocalizationV5;
+
+export const getLocalization = (translations: LocaleText): Localization => {
+  if (isMuiV5()) {
+    return {
+      components: {
+        MuiDataGrid: {
+          defaultProps: {
+            localeText: translations,
+          },
+        },
+      },
+    };
+  }
+
+  return {
+    props: {
+      MuiDataGrid: {
+        localeText: translations,
+      },
+    },
+  };
+};

--- a/packages/grid/_modules_/grid/utils/index.ts
+++ b/packages/grid/_modules_/grid/utils/index.ts
@@ -5,3 +5,4 @@ export * from './classnames';
 export * from './keyboardUtils';
 export * from './mergeUtils';
 export * from './paramsUtils';
+export * from './getLocalization';


### PR DESCRIPTION
Fixes #777 

This PR adds 'bgBG' locale OTB. Currently, if you want to use that locale you would need to provide it to the grid in the following way:

```jsx
import { DataGrid, bgBG } from '@material-ui/data-grid'

...

<DataGrid localeText={bgBG.components.MuiDataGrid.defaultProps.localeText} />
```

The reason is that we want to make it work with `createMuiTheme` and this is the v5 structure https://material-ui.com/guides/localization/#locale-text - #984

In a separate PR I'll add the ability to set the locale using `createMuiTheme` because currently, we are missing an identifier for the grid, a.k.a `MuiDataGrid`.

PS: I found that I missed a couple of labels so I added them as well.