### PR TITLE
[DataGrid] Resolve the api ref at the same time as any other ref

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
+++ b/packages/grid/_modules_/grid/hooks/features/useApiRef.ts
@@ -10,14 +10,17 @@ function createGridApi(): GridApi {
   return new EventEmitter() as GridApi;
 }
 
-export function useApiRef(apiRefProp?: ApiRef): ApiRef {
-  const apiRef = React.useRef<GridApi>(createGridApi());
+// Public developers facing overload
+export function useApiRef(): ApiRef;
 
-  React.useEffect(() => {
-    if (apiRefProp?.current) {
-      apiRefProp.current = apiRef.current;
-    }
-  });
+// Internal grid facing overload
+export function useApiRef(apiRefProp: ApiRef | undefined): ApiRef;
+
+export function useApiRef(...args): any {
+  const apiRefProp = args[0];
+  const apiRef = React.useRef<GridApi>(args.length === 0 ? null : createGridApi());
+
+  React.useImperativeHandle(apiRefProp, () => apiRef.current, [apiRef]);
 
   return apiRef;
 }


### PR DESCRIPTION
Effectively, it means that we can stop documenting `useApiRef`, and replace it completely in the public API with:

```jsx
function MyApp() {
  const apiRef = React.useRef();

  return <DataGrid apiRef={apiRef} />
}
```

It's a logical follow-up with the direction taken in #933. More details in https://github.com/mui-org/material-ui-x/pull/939#discussion_r567235523. I like the approach, at least, it's sounds and consistent with the rest of the codebase. You can find the same API on, the Tabs for instance (`action` prop).