### PR TITLE
[DataGrid] Remove sortDirection from column definitions

### DIFF
--- a/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/ColumnHeaderItem.tsx
@@ -44,7 +44,7 @@ export const ColumnHeaderItem = ({
     disableColumnResize,
     disableColumnMenu,
   } = options;
-  const isColumnSorted = column.sortDirection != null;
+  const isColumnSorted = sortDirection != null;
   // todo refactor to a prop on col isNumeric or ?? ie: coltype===price wont work
   const isColumnNumeric = column.type === NUMBER_COLUMN_TYPE;
 

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -29,7 +29,6 @@ import { allColumnsSelector, visibleColumnsSelector } from '../columns/columnsSe
 import { useGridSelector } from '../core/useGridSelector';
 import { useGridState } from '../core/useGridState';
 import { rowCountSelector } from '../rows/rowsSelector';
-import { SortingState } from './sortingState';
 
 export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
   const logger = useLogger('useSorting');

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useSorting.ts
@@ -292,29 +292,6 @@ export const useSorting = (apiRef: ApiRef, rowsProp: RowsProp) => {
     }
   }, [rowCount, apiRef, logger]);
 
-  // TODO Remove if we deprecate column.sortDirection
-  React.useEffect(() => {
-    if (visibleColumns.length > 0) {
-      const sortedColumns = apiRef.current
-        .getAllColumns()
-        .filter((column) => column.sortDirection != null)
-        .sort((a, b) => a.sortIndex! - b.sortIndex!);
-
-      const sortModel = sortedColumns.map((column) => ({
-        field: column.field,
-        sort: column.sortDirection,
-      }));
-
-      if (
-        sortModel.length > 0 &&
-        !isDeepEqual(apiRef.current.getState<SortingState>('sorting').sortModel, sortModel)
-      ) {
-        // we use apiRef to avoid watching setSortModel as it will trigger an infinite loop
-        apiRef.current.setSortModel(sortModel);
-      }
-    }
-  }, [apiRef, visibleColumns]);
-
   React.useEffect(() => {
     const sortModel = options.sortModel || [];
     const oldSortModel = apiRef.current.state.sorting.sortModel;

--- a/packages/grid/_modules_/grid/models/colDef/colDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/colDef.ts
@@ -57,14 +57,6 @@ export interface ColDef {
    */
   sortComparator?: ComparatorFn;
   /**
-   * Sort the rows in a specific direction.
-   */
-  sortDirection?: SortDirection;
-  /**
-   * If multiple columns are sorted, this setting allows to order the columns sorting sequence.
-   */
-  sortIndex?: number;
-  /**
    * Type allows to merge this object with a default definition [[ColDef]].
    * @default string
    */

--- a/packages/grid/_modules_/grid/models/colDef/colDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/colDef.ts
@@ -4,7 +4,7 @@ import { CellClassNamePropType, CellClassRules } from '../cellClass';
 import { FilterOperator } from '../filterOperator';
 import { CellParams, ValueFormatterParams, ValueGetterParams } from '../params/cellParams';
 import { ColParams } from '../params/colParams';
-import { ComparatorFn, SortDirection } from '../sortModel';
+import { ComparatorFn } from '../sortModel';
 import { ColType, NativeColTypes } from './colType';
 
 /**

--- a/packages/grid/_modules_/grid/models/colDef/stringColDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/stringColDef.ts
@@ -8,7 +8,6 @@ export const STRING_COL_DEF: ColTypeDef = {
   sortable: true,
   resizable: true,
   filterable: true,
-  sortDirection: null,
   sortComparator: stringNumberComparer,
   type: 'string',
   align: 'left',

--- a/packages/storybook/src/stories/grid-filter.stories.tsx
+++ b/packages/storybook/src/stories/grid-filter.stories.tsx
@@ -511,7 +511,6 @@ export function ColumnsAlign() {
           col.align = 'left';
         }
         col.width = 180;
-        col.sortDirection = 'asc';
       });
     }
     return cols;

--- a/packages/storybook/src/stories/grid-options.stories.tsx
+++ b/packages/storybook/src/stories/grid-options.stories.tsx
@@ -10,11 +10,7 @@ export default {
   },
 };
 
-const columns: ColDef[] = [
-  { field: 'id' },
-  { field: 'name' },
-  { field: 'age' },
-];
+const columns: ColDef[] = [{ field: 'id' }, { field: 'name' }, { field: 'age' }];
 
 const rows = [
   { id: 1, name: 'alice', age: 40 },

--- a/packages/storybook/src/stories/grid-options.stories.tsx
+++ b/packages/storybook/src/stories/grid-options.stories.tsx
@@ -12,8 +12,8 @@ export default {
 
 const columns: ColDef[] = [
   { field: 'id' },
-  { field: 'name', sortDirection: 'asc' },
-  { field: 'age', sortDirection: 'desc' },
+  { field: 'name' },
+  { field: 'age' },
 ];
 
 const rows = [

--- a/packages/storybook/src/stories/grid-sorting.stories.tsx
+++ b/packages/storybook/src/stories/grid-sorting.stories.tsx
@@ -94,105 +94,90 @@ export const SortingOrderOverrideOption = () => {
 
 export const StringSortingAsc = () => {
   const columns = getColumns();
-  columns[1] = { ...columns[1], sortDirection: 'asc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'asc'}]} />
     </div>
   );
 };
 export const StringSortingDesc = () => {
   const columns = getColumns();
-  columns[1] = { ...columns[1], sortDirection: 'desc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'desc'}]} />
     </div>
   );
 };
 export const NumberSortingAsc = () => {
   const columns = getColumns();
-  columns[2] = { ...columns[2], sortDirection: 'asc' };
-
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'asc'}]}  />
     </div>
   );
 };
 export const NumberSortingDesc = () => {
   const columns = getColumns();
-  columns[2] = { ...columns[2], sortDirection: 'desc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'desc'}]}  />
     </div>
   );
 };
 export const DateSortingAsc = () => {
   const columns = getColumns();
-  columns[3] = { ...columns[3], sortDirection: 'asc' };
-
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[3].field, sort: 'asc'}]}  />
     </div>
   );
 };
 export const DateSortingDesc = () => {
   const columns = getColumns();
-  columns[3] = { ...columns[3], sortDirection: 'desc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[3].field, sort: 'desc'}]} />
     </div>
   );
 };
 export const DateTimeSortingAsc = () => {
   const columns = getColumns();
-  columns[4] = { ...columns[4], sortDirection: 'asc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[4].field, sort: 'asc'}]}  />
     </div>
   );
 };
 export const DateTimeSortingDesc = () => {
   const columns = getColumns();
-  columns[4] = { ...columns[4], sortDirection: 'desc' };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[4].field, sort: 'desc'}]} />
     </div>
   );
 };
 
 export const MultipleSorting = () => {
   const columns = getColumns();
-  columns[1] = { ...columns[1], sortDirection: 'asc' };
-  columns[2] = { ...columns[2], sortDirection: 'desc' };
-
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'asc'}, {field: columns[2].field, sort: 'desc'} ]}  />
     </div>
   );
 };
 
 export const MultipleAndSortIndex = () => {
   const columns = getColumns();
-  columns[1] = { ...columns[1], sortDirection: 'asc', sortIndex: 2 };
-  columns[2] = { ...columns[2], sortDirection: 'desc', sortIndex: 1 };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'desc'}, {field: columns[1].field, sort: 'asc'} ]}  />
     </div>
   );
 };
@@ -221,13 +206,12 @@ export const CustomComparator = () => {
     valueGetter: (params) =>
       `${params.getValue('name') || 'unknown'}_${params.getValue('age') || 'x'}`,
     sortComparator: (v1, v2, cellParams1, cellParams2) => cellParams1.row.age - cellParams2.row.age,
-    sortDirection: 'asc',
     width: 150,
   };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[columns.length - 1].field, sort: 'asc'}]}  />
     </div>
   );
 };
@@ -236,13 +220,12 @@ export const SortingWithFormatter = () => {
   const columns = getColumns();
   columns[2] = {
     ...columns[2],
-    sortDirection: 'desc',
     valueFormatter: (params) => (params.value ? `${params.value} years ` : 'unknown'),
   };
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} />
+      <XGrid rows={getRows()} columns={columns}  sortModel={[{field: columns[2].field, sort: 'desc'}]}   />
     </div>
   );
 };

--- a/packages/storybook/src/stories/grid-sorting.stories.tsx
+++ b/packages/storybook/src/stories/grid-sorting.stories.tsx
@@ -97,7 +97,11 @@ export const StringSortingAsc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'asc'}]} />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[1].field, sort: 'asc' }]}
+      />
     </div>
   );
 };
@@ -106,7 +110,11 @@ export const StringSortingDesc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'desc'}]} />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[1].field, sort: 'desc' }]}
+      />
     </div>
   );
 };
@@ -114,7 +122,11 @@ export const NumberSortingAsc = () => {
   const columns = getColumns();
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'asc'}]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[2].field, sort: 'asc' }]}
+      />
     </div>
   );
 };
@@ -123,7 +135,11 @@ export const NumberSortingDesc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'desc'}]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[2].field, sort: 'desc' }]}
+      />
     </div>
   );
 };
@@ -131,7 +147,11 @@ export const DateSortingAsc = () => {
   const columns = getColumns();
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[3].field, sort: 'asc'}]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[3].field, sort: 'asc' }]}
+      />
     </div>
   );
 };
@@ -140,7 +160,11 @@ export const DateSortingDesc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[3].field, sort: 'desc'}]} />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[3].field, sort: 'desc' }]}
+      />
     </div>
   );
 };
@@ -149,7 +173,11 @@ export const DateTimeSortingAsc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[4].field, sort: 'asc'}]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[4].field, sort: 'asc' }]}
+      />
     </div>
   );
 };
@@ -158,7 +186,11 @@ export const DateTimeSortingDesc = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[4].field, sort: 'desc'}]} />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[4].field, sort: 'desc' }]}
+      />
     </div>
   );
 };
@@ -167,7 +199,14 @@ export const MultipleSorting = () => {
   const columns = getColumns();
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[1].field, sort: 'asc'}, {field: columns[2].field, sort: 'desc'} ]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[
+          { field: columns[1].field, sort: 'asc' },
+          { field: columns[2].field, sort: 'desc' },
+        ]}
+      />
     </div>
   );
 };
@@ -177,7 +216,14 @@ export const MultipleAndSortIndex = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[2].field, sort: 'desc'}, {field: columns[1].field, sort: 'asc'} ]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[
+          { field: columns[2].field, sort: 'desc' },
+          { field: columns[1].field, sort: 'asc' },
+        ]}
+      />
     </div>
   );
 };
@@ -211,7 +257,11 @@ export const CustomComparator = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns} sortModel={[{field: columns[columns.length - 1].field, sort: 'asc'}]}  />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[columns.length - 1].field, sort: 'asc' }]}
+      />
     </div>
   );
 };
@@ -225,7 +275,11 @@ export const SortingWithFormatter = () => {
 
   return (
     <div className="grid-container">
-      <XGrid rows={getRows()} columns={columns}  sortModel={[{field: columns[2].field, sort: 'desc'}]}   />
+      <XGrid
+        rows={getRows()}
+        columns={columns}
+        sortModel={[{ field: columns[2].field, sort: 'desc' }]}
+      />
     </div>
   );
 };

--- a/packages/storybook/src/stories/playground/customize-components.stories.tsx
+++ b/packages/storybook/src/stories/playground/customize-components.stories.tsx
@@ -37,11 +37,7 @@ export default {
   decorators: [(StoryFn) => <StoryFn />],
 } as Meta;
 
-const columns: ColDef[] = [
-  { field: 'id' },
-  { field: 'name', sortDirection: 'asc' },
-  { field: 'age', sortDirection: 'desc' },
-];
+const columns: ColDef[] = [{ field: 'id' }, { field: 'name' }, { field: 'age' }];
 
 const rows = [
   { id: 1, name: 'alice', age: 40 },
@@ -53,7 +49,14 @@ const rows = [
   { id: 7, name: '', age: 42 },
 ];
 
-const defaultData = { columns, rows };
+const defaultData = {
+  columns,
+  rows,
+  sortModel: [
+    { field: 'name', sort: 'asc' as 'asc' },
+    { field: 'age', sort: 'desc' as 'desc' },
+  ],
+};
 
 const Template: Story<XGridProps> = (args) => {
   const data = useData(500, 50);
@@ -222,7 +225,6 @@ StyledColumns.args = {
       cellClassName: ['age', 'shine'],
       headerClassName: ['age', 'shine'],
       type: 'number',
-      sortDirection: 'desc',
     },
     {
       field: 'fullName',
@@ -247,7 +249,6 @@ StyledColumns.args = {
     {
       field: 'registerDate',
       headerName: 'Registered on',
-      sortDirection: 'asc',
       type: 'date',
     },
     {
@@ -256,6 +257,10 @@ StyledColumns.args = {
       type: 'dateTime',
       width: 200,
     },
+  ],
+  sortModel: [
+    { field: 'age', sort: 'desc' },
+    { field: 'registerDate', sort: 'asc' },
   ],
   rows: [
     { id: 1, firstName: 'alice', age: 40 },


### PR DESCRIPTION
- [DataGrid] Remove `sortDirection` from column definitions. Consolidate around fewer ways of doing the same thing.

  ```diff
  -columns[1] = { ...columns[1], sortDirection: 'asc' };

  return (
    <div className="grid-container">
  -   <DataGrid rows={rows} columns={columns} />
  +   <DataGrid rows={rows} columns={columns} sortModel={[{field: columns[1].field, sort: 'asc'}]} />
    </div>
  ```

---

fix #244 