### PR TITLE
[DataGrid] Change page index base, from 1 to 0

### DIFF
--- a/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.js
@@ -11,7 +11,7 @@ export default function ApiRefPaginationGrid() {
   });
 
   React.useEffect(() => {
-    apiRef.current.setPage(2);
+    apiRef.current.setPage(1);
   }, [apiRef]);
 
   return (

--- a/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx
@@ -11,7 +11,7 @@ export default function ApiRefPaginationGrid() {
   });
 
   React.useEffect(() => {
-    apiRef.current.setPage(2);
+    apiRef.current.setPage(1);
   }, [apiRef]);
 
   return (

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
@@ -9,7 +9,7 @@ export default function ControlledPaginationGrid() {
     maxColumns: 6,
   });
 
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(0);
 
   return (
     <div style={{ height: 400, width: '100%' }}>

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
@@ -8,7 +8,7 @@ export default function ControlledPaginationGrid() {
     rowLength: 100,
     maxColumns: 6,
   });
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(0);
 
   return (
     <div style={{ height: 400, width: '100%' }}>

--- a/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.js
@@ -5,7 +5,7 @@ import { useDemoData } from '@material-ui/x-grid-data-generator';
 function loadServerRows(page, data) {
   return new Promise((resolve) => {
     setTimeout(() => {
-      resolve(data.rows.slice((page - 1) * 5, page * 5));
+      resolve(data.rows.slice(page * 5, (page + 1) * 5));
     }, Math.random() * 500 + 100); // simulate network latency
   });
 }
@@ -17,7 +17,7 @@ export default function ServerPaginationGrid() {
     maxColumns: 6,
   });
 
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(0);
   const [rows, setRows] = React.useState([]);
   const [loading, setLoading] = React.useState(false);
 

--- a/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx
@@ -5,7 +5,7 @@ import { useDemoData, GridData } from '@material-ui/x-grid-data-generator';
 function loadServerRows(page: number, data: GridData): Promise<any> {
   return new Promise<any>((resolve) => {
     setTimeout(() => {
-      resolve(data.rows.slice((page - 1) * 5, page * 5));
+      resolve(data.rows.slice(page * 5, (page + 1) * 5));
     }, Math.random() * 500 + 100); // simulate network latency
   });
 }
@@ -16,7 +16,7 @@ export default function ServerPaginationGrid() {
     rowLength: 100,
     maxColumns: 6,
   });
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(0);
   const [rows, setRows] = React.useState<RowsProp>([]);
   const [loading, setLoading] = React.useState<boolean>(false);
 

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -42,7 +42,7 @@ export function Pagination() {
 
   const onPageChange = React.useCallback(
     (event: any, page: number) => {
-      apiRef!.current!.setPage(page + 1);
+      apiRef!.current!.setPage(page);
     },
     [apiRef],
   );
@@ -67,7 +67,7 @@ export function Pagination() {
       classes={classes}
       component="div"
       count={paginationState.rowCount}
-      page={paginationState.page - 1}
+      page={paginationState.page}
       rowsPerPageOptions={
         options.rowsPerPageOptions &&
         options.rowsPerPageOptions.indexOf(paginationState.pageSize) > -1

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useKeyboard.ts
@@ -86,7 +86,7 @@ export const useKeyboard = (gridRootRef: React.RefObject<HTMLDivElement>, apiRef
       const currentColIndex = Number(cellEl.getAttribute('aria-colindex'));
       const currentRowIndex = Number(cellEl.getAttribute('data-rowindex'));
       const rowCount = options.pagination
-        ? paginationState.pageSize * paginationState.page
+        ? paginationState.pageSize * (paginationState.page + 1)
         : totalRowCount;
 
       let nextCellIndexes: CellIndexCoordinates;

--- a/packages/grid/_modules_/grid/hooks/features/pagination/paginationReducer.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/paginationReducer.ts
@@ -93,7 +93,7 @@ export const setRowCountStateUpdate = (state, payload): PaginationState => {
 };
 
 export const INITIAL_PAGINATION_STATE: PaginationState = {
-  page: 1,
+  page: 0,
   pageCount: 0,
   pageSize: 0,
   paginationMode: 'client',

--- a/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
@@ -83,7 +83,7 @@ export const usePagination = (apiRef: ApiRef): void => {
   }, [apiRef, dispatch, options.paginationMode]);
 
   React.useEffect(() => {
-    setPage(options.page != null ? options.page : 1);
+    setPage(options.page != null ? options.page : 0);
   }, [apiRef, options.page, setPage]);
 
   React.useEffect(() => {

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useVirtualRows.ts
@@ -69,8 +69,7 @@ export const useVirtualRows = (
         paginationState.pageSize != null &&
         paginationState.paginationMode === 'client'
       ) {
-        minRowIdx =
-          paginationState.pageSize * (paginationState.page - 1 > 0 ? paginationState.page - 1 : 0);
+        minRowIdx = paginationState.pageSize * paginationState.page;
       }
 
       const firstRowIdx = page * apiRef.current.state.containerSizes.viewportPageSize + minRowIdx;
@@ -210,7 +209,7 @@ export const useVirtualRows = (
       let scrollTop;
 
       const currentRowPage =
-        (params.rowIndex - (gridState.pagination.page - 1) * gridState.pagination.pageSize) /
+        (params.rowIndex - gridState.pagination.page * gridState.pagination.pageSize) /
         gridState.containerSizes!.viewportPageSize;
       const scrollPosition = currentRowPage * gridState!.viewportSizes.height;
       const viewportHeight = gridState.viewportSizes.height;

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -41,7 +41,7 @@ describe('<DataGrid /> - Pagination', () => {
       }
     });
 
-    it('should apply the page prop correctly', (done) => {
+    it('should apply the page prop correctly', () => {
       const rows = [
         {
           id: 0,
@@ -58,14 +58,11 @@ describe('<DataGrid /> - Pagination', () => {
       ];
       render(
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid {...baselineProps} rows={rows} page={2} pageSize={1} />
+          <DataGrid {...baselineProps} rows={rows} page={1} pageSize={1} />
         </div>,
       );
-      setTimeout(() => {
-        const cell = document.querySelector('[role="cell"][aria-colindex="0"]')!;
-        expect(cell).to.have.text('Addidas');
-        done();
-      }, 50);
+      const cell = document.querySelector('[role="cell"][aria-colindex="0"]')!;
+      expect(cell).to.have.text('Addidas');
     });
 
     it('should trigger onPageChange once if page prop is set', () => {
@@ -126,7 +123,7 @@ describe('<DataGrid /> - Pagination', () => {
 
     it('should support server side pagination', () => {
       const ServerPaginationGrid = () => {
-        const [page, setPage] = React.useState(1);
+        const [page, setPage] = React.useState(0);
         const [rows, setRows] = React.useState<RowsProp>([]);
 
         const handlePageChange = (params) => {
@@ -172,9 +169,9 @@ describe('<DataGrid /> - Pagination', () => {
       };
 
       render(<ServerPaginationGrid />);
-      expect(getColumnValues()).to.deep.equal(['Nike 1']);
+      expect(getColumnValues()).to.deep.equal(['Nike 0']);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      expect(getColumnValues()).to.deep.equal(['Nike 2']);
+      expect(getColumnValues()).to.deep.equal(['Nike 1']);
     });
   });
 });

--- a/packages/grid/x-grid/src/tests/pagination.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/pagination.XGrid.test.tsx
@@ -53,7 +53,7 @@ describe('<XGrid /> - Pagination', () => {
     let cell = document.querySelector('[role="cell"][aria-colindex="0"]')!;
     expect(cell).to.have.text('Nike');
     act(() => {
-      apiRef.current.setPage(2);
+      apiRef.current.setPage(1);
     });
 
     cell = document.querySelector('[role="cell"][aria-colindex="0"]')!;

--- a/packages/storybook/src/stories/grid-pagination.stories.tsx
+++ b/packages/storybook/src/stories/grid-pagination.stories.tsx
@@ -45,7 +45,7 @@ export const PaginationArgs: Story = (args) => {
 PaginationArgs.args = {
   pagination: true,
   pageSize: 100,
-  page: 1,
+  page: 0,
   rowCount: 2000,
   autoPageSize: false,
   rowsPerPageOptions: [10, 20, 50, 100, 200],
@@ -130,9 +130,9 @@ export function PaginationApiTests() {
             Pagination: ({ state }) => (
               <Pagination
                 className="my-custom-pagination"
-                page={state.pagination.page}
+                page={state.pagination.page + 1}
                 count={state.pagination.pageCount}
-                onChange={(e, value) => apiRef.current.setPage(value)}
+                onChange={(e, value) => apiRef.current.setPage(value - 1)}
               />
             ),
           }}
@@ -347,7 +347,7 @@ export const GridTest = () => {
 function loadDocsDemoServerRows(page: number, data: any): Promise<any> {
   return new Promise<any>((resolve) => {
     setTimeout(() => {
-      resolve(data.rows.slice((page - 1) * 5, page * 5));
+      resolve(data.rows.slice(page * 5, (page + 1) * 5));
     }, Math.random() * 500 + 100); // simulate network latency
   });
 }
@@ -358,7 +358,7 @@ export function ServerPaginationDocsDemo() {
     rowLength: 100,
     maxColumns: 6,
   });
-  const [page, setPage] = React.useState(1);
+  const [page, setPage] = React.useState(0);
   const [rows, setRows] = React.useState<RowsProp>([]);
   const [loading, setLoading] = React.useState<boolean>(false);
 


### PR DESCRIPTION
### Breaking changes

- [DataGrid] Change page index base, from 1 to 0. This change is done for consistency with `TablePagination` and JavaScript arrays that are 0-based. Material-UI still uses a 1-base page for the `Pagination` component that matches the URL's query.

  ```diff
  -const [page, setPage] = React.useState(1);
  +const [page, setPage] = React.useState(0);
  
  return (
    <div className="grid-container">
     <DataGrid rows={rows} columns={columns} page={page} />
    </div>
  ```

---

fix #852 