### PR TITLE
[docs] Add code snippet for localization docs in the data grid

### DIFF
--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -42,6 +42,9 @@ const theme = createMuiTheme(
 </ThemeProvider>;
 ```
 
+Note that `createMuiTheme` accepts any number of arguments.
+If you are already using the translations of the core components, you can add `bgBG` as a new argument.
+The same import works with `XGrid` as it's an extension of `DataGrid`.
 ### Supported locales
 
 | Locale    | BCP 47 language tag | Import name |

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -22,6 +22,26 @@ In the following example, the labels of the density selector are customized.
 The default locale of Material-UI is English (United States).
 You can find all the locales supported in [the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
 
+You can use the theme to configure the locale text:
+
+```jsx
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { DataGrid, bgBG } from '@material-ui/data-grid';
+
+const theme = createMuiTheme(
+  {
+    palette: {
+      primary: { main: '#1976d2' },
+    },
+  },
+  bgBG,
+);
+
+<ThemeProvider theme={theme}>
+  <DataGrid />
+</ThemeProvider>;
+```
+
 ### Supported locales
 
 | Locale    | BCP 47 language tag | Import name |

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -45,6 +45,7 @@ const theme = createMuiTheme(
 Note that `createMuiTheme` accepts any number of arguments.
 If you are already using the translations of the core components, you can add `bgBG` as a new argument.
 The same import works with `XGrid` as it's an extension of `DataGrid`.
+
 ### Supported locales
 
 | Locale    | BCP 47 language tag | Import name |

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/FilterForm.tsx
@@ -202,9 +202,10 @@ export function FilterForm(props: FilterFormProps) {
         >
           {currentColumn?.filterOperators?.map((operator) => (
             <option key={operator.value} value={operator.value}>
-              {apiRef!.current.getLocaleText(
-                `filterOperator${capitalize(operator.value)}` as TranslationKeys,
-              )}
+              {operator.label ||
+                apiRef!.current.getLocaleText(
+                  `filterOperator${capitalize(operator.value)}` as TranslationKeys,
+                )}
             </option>
           ))}
         </Select>

--- a/packages/grid/_modules_/grid/models/filterOperator.ts
+++ b/packages/grid/_modules_/grid/models/filterOperator.ts
@@ -4,6 +4,7 @@ import { FilterItem } from './filterItem';
 import { CellParams } from './params/cellParams';
 
 export interface FilterOperator {
+  label?: string;
   value: string;
   getApplyFilterFn: (
     filterItem: FilterItem,


### PR DESCRIPTION
Fixes #777 

The missing docs as mentioned in the last comment.