### PR TITLE
[DataGrid] Use the disableDensitySelector to disable the DensitySelector

### DIFF
--- a/packages/grid/_modules_/grid/components/toolbar/DensitySelector.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/DensitySelector.tsx
@@ -65,7 +65,7 @@ export function DensitySelector() {
   };
 
   // Disable the button if the corresponding is disabled
-  if (options.disableColumnFilter) {
+  if (options.disableDensitySelector) {
     return null;
   }
 


### PR DESCRIPTION
I must have added the wrong option to check whether to disable the `DensitySelector` component. This PR fixes that and uses the correct one -> `disableDensitySelector`.