### PR TITLE
[DataGrid] Fix onPageChange and onPageSizeChange event trigger

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
@@ -83,20 +83,21 @@ export const usePagination = (apiRef: ApiRef): void => {
   }, [apiRef, dispatch, options.paginationMode]);
 
   React.useEffect(() => {
-    setPage(options.page != null ? options.page : 0);
-  }, [apiRef, options.page, setPage]);
+    const newPage = options.page != null ? options.page : 0;
+    dispatch(setPageActionCreator(newPage));
+  }, [ dispatch, options.page]);
 
   React.useEffect(() => {
     if (!options.autoPageSize && options.pageSize) {
-      setPageSize(options.pageSize);
+      dispatch(setPageSizeActionCreator(options.pageSize));
     }
-  }, [options.autoPageSize, options.pageSize, logger, setPageSize]);
+  }, [options.autoPageSize, options.pageSize, logger, dispatch]);
 
   React.useEffect(() => {
     if (options.autoPageSize && containerSizes && containerSizes?.viewportPageSize > 0) {
-      setPageSize(containerSizes?.viewportPageSize);
+      dispatch(setPageSizeActionCreator(containerSizes?.viewportPageSize));
     }
-  }, [containerSizes, options.autoPageSize, setPageSize]);
+  }, [containerSizes, dispatch, options.autoPageSize]);
 
   React.useEffect(() => {
     dispatch(setRowCountActionCreator({ totalRowCount: visibleRowCount }));

--- a/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/usePagination.ts
@@ -85,7 +85,7 @@ export const usePagination = (apiRef: ApiRef): void => {
   React.useEffect(() => {
     const newPage = options.page != null ? options.page : 0;
     dispatch(setPageActionCreator(newPage));
-  }, [ dispatch, options.page]);
+  }, [dispatch, options.page]);
 
   React.useEffect(() => {
     if (!options.autoPageSize && options.pageSize) {

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -10,8 +10,6 @@ import { expect } from 'chai';
 import {
   DataGrid,
   DataGridProps,
-  DataGridProps,
-  GridComponentProps,
   RowsProp,
 } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -65,17 +65,6 @@ describe('<DataGrid /> - Pagination', () => {
       expect(cell).to.have.text('Addidas');
     });
 
-    it('should trigger onPageChange once if page prop is set', () => {
-      const onPageChange = spy();
-
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid {...baselineProps} page={1} onPageChange={onPageChange} pageSize={1} />
-        </div>,
-      );
-      expect(onPageChange.callCount).to.equal(1);
-    });
-
     it('should trigger onPageChange when clicking on next page', () => {
       const onPageChange = spy();
 
@@ -110,15 +99,38 @@ describe('<DataGrid /> - Pagination', () => {
       expect(onPageChange.callCount).to.equal(2);
     });
 
-    it('should not trigger onPageChange on initialisation and rendering of the first and default page', () => {
+    it('should not trigger onPageChange on initialisation or on page prop change', () => {
       const onPageChange = spy();
 
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid {...baselineProps} onPageChange={onPageChange} pageSize={1} />
-        </div>,
-      );
+      function Test({page, pageSize}) {
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid {...baselineProps} onPageChange={onPageChange} pageSize={pageSize} page={page} />
+          </div>
+        );
+      }
+
+      const {setProps} = render(<Test page={1} pageSize={1} />);
       expect(onPageChange.callCount).to.equal(0);
+      setProps({page: 2})
+      expect(onPageChange.callCount).to.equal(0);
+    });
+
+    it('should not trigger onPageSizeChange on initialisation or on pageSize prop change', () => {
+      const onPageSizeChange = spy();
+
+      function Test({page, pageSize}) {
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid {...baselineProps} onPageSizeChange={onPageSizeChange} pageSize={pageSize} page={page} />
+          </div>
+        );
+      }
+
+      const {setProps} = render(<Test page={1} pageSize={1} />);
+      expect(onPageSizeChange.callCount).to.equal(0);
+      setProps({pageSize: 2})
+      expect(onPageSizeChange.callCount).to.equal(0);
     });
 
     it('should support server side pagination', () => {
@@ -174,4 +186,5 @@ describe('<DataGrid /> - Pagination', () => {
       expect(getColumnValues()).to.deep.equal(['Nike 1']);
     });
   });
+
 });

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -7,11 +7,7 @@ import {
   screen,
 } from 'test/utils';
 import { expect } from 'chai';
-import {
-  DataGrid,
-  DataGridProps,
-  RowsProp,
-} from '@material-ui/data-grid';
+import { DataGrid, DataGridProps, RowsProp } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
 

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -7,7 +7,13 @@ import {
   screen,
 } from 'test/utils';
 import { expect } from 'chai';
-import { DataGrid, DataGridProps, DataGridProps, GridComponentProps, RowsProp } from '@material-ui/data-grid';
+import {
+  DataGrid,
+  DataGridProps,
+  DataGridProps,
+  GridComponentProps,
+  RowsProp,
+} from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
 
@@ -110,9 +116,9 @@ describe('<DataGrid /> - Pagination', () => {
         );
       }
 
-      const {setProps} = render(<Test page={1} pageSize={1} onPageChange={onPageChange}  />);
+      const { setProps } = render(<Test page={1} pageSize={1} onPageChange={onPageChange} />);
       expect(onPageChange.callCount).to.equal(0);
-      setProps({page: 2})
+      setProps({ page: 2 });
       expect(onPageChange.callCount).to.equal(0);
     });
 
@@ -127,9 +133,11 @@ describe('<DataGrid /> - Pagination', () => {
         );
       }
 
-      const {setProps} = render(<Test onPageSizeChange={onPageSizeChange} pageSize={1} page={1} />);
+      const { setProps } = render(
+        <Test onPageSizeChange={onPageSizeChange} pageSize={1} page={1} />,
+      );
       expect(onPageSizeChange.callCount).to.equal(0);
-      setProps({pageSize: 2})
+      setProps({ pageSize: 2 });
       expect(onPageSizeChange.callCount).to.equal(0);
     });
 
@@ -186,5 +194,4 @@ describe('<DataGrid /> - Pagination', () => {
       expect(getColumnValues()).to.deep.equal(['Nike 1']);
     });
   });
-
 });

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -7,7 +7,7 @@ import {
   screen,
 } from 'test/utils';
 import { expect } from 'chai';
-import { DataGrid, RowsProp } from '@material-ui/data-grid';
+import { DataGrid, DataGridProps, DataGridProps, GridComponentProps, RowsProp } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
 
@@ -102,15 +102,15 @@ describe('<DataGrid /> - Pagination', () => {
     it('should not trigger onPageChange on initialisation or on page prop change', () => {
       const onPageChange = spy();
 
-      function Test({page, pageSize}) {
+      function Test(props: Partial<DataGridProps>) {
         return (
           <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...baselineProps} onPageChange={onPageChange} pageSize={pageSize} page={page} />
+            <DataGrid {...baselineProps} {...props} />
           </div>
         );
       }
 
-      const {setProps} = render(<Test page={1} pageSize={1} />);
+      const {setProps} = render(<Test page={1} pageSize={1} onPageChange={onPageChange}  />);
       expect(onPageChange.callCount).to.equal(0);
       setProps({page: 2})
       expect(onPageChange.callCount).to.equal(0);
@@ -119,15 +119,15 @@ describe('<DataGrid /> - Pagination', () => {
     it('should not trigger onPageSizeChange on initialisation or on pageSize prop change', () => {
       const onPageSizeChange = spy();
 
-      function Test({page, pageSize}) {
+      function Test(props: Partial<DataGridProps>) {
         return (
           <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...baselineProps} onPageSizeChange={onPageSizeChange} pageSize={pageSize} page={page} />
+            <DataGrid {...baselineProps} {...props} />
           </div>
         );
       }
 
-      const {setProps} = render(<Test page={1} pageSize={1} />);
+      const {setProps} = render(<Test onPageSizeChange={onPageSizeChange} pageSize={1} page={1} />);
       expect(onPageSizeChange.callCount).to.equal(0);
       setProps({pageSize: 2})
       expect(onPageSizeChange.callCount).to.equal(0);

--- a/packages/storybook/src/stories/grid-pagination.stories.tsx
+++ b/packages/storybook/src/stories/grid-pagination.stories.tsx
@@ -76,7 +76,7 @@ export function PaginationApiTests() {
   const [autosize, setAutoSize] = React.useState(false);
 
   React.useEffect(() => {
-    return apiRef.current.onPageChange(action('pageChange'));
+    return apiRef.current.onPageChange(action('apiRef: onPageChange'));
   }, [apiRef, data]);
 
   const backToFirstPage = () => {
@@ -126,6 +126,8 @@ export function PaginationApiTests() {
           pagination
           pageSize={myPageSize}
           autoPageSize={autosize}
+          onPageChange={action('prop: onPageChange')}
+          onPageSizeChange={action('prop: onPageSizeChange')}
           components={{
             Pagination: ({ state }) => (
               <Pagination


### PR DESCRIPTION
Fix #885 
- onPageChange should only fire when the underlying state change, it doesn't change when the component mount.

Fix #848 
