### PR TITLE
[DataGrid] Fix warning with v5

### DIFF
--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -9,6 +9,12 @@ import { isMuiV5 } from '../utils';
 
 // Used to hide the Rows per page selector on small devices
 const useStyles = makeStyles((theme: Theme) => ({
+  selectLabel: {
+    display: 'none',
+    [theme.breakpoints.up('md')]: {
+      display: 'block',
+    },
+  },
   caption: {
     // input label
     '&[id]': {
@@ -64,7 +70,16 @@ export function Pagination() {
   return (
     // @ts-ignore TODO remove once upgraded v4 support is dropped
     <TablePagination
-      classes={classes}
+      classes={{
+        ...(isMuiV5()
+          ? {
+              selectLabel: classes.selectLabel,
+            }
+          : {
+              caption: classes.caption,
+            }),
+        input: classes.input,
+      }}
       component="div"
       count={paginationState.rowCount}
       page={paginationState.page}

--- a/packages/grid/_modules_/grid/components/Pagination.tsx
+++ b/packages/grid/_modules_/grid/components/Pagination.tsx
@@ -71,13 +71,7 @@ export function Pagination() {
     // @ts-ignore TODO remove once upgraded v4 support is dropped
     <TablePagination
       classes={{
-        ...(isMuiV5()
-          ? {
-              selectLabel: classes.selectLabel,
-            }
-          : {
-              caption: classes.caption,
-            }),
+        ...(isMuiV5() ? { selectLabel: classes.selectLabel } : { caption: classes.caption }),
         input: classes.input,
       }}
       component="div"


### PR DESCRIPTION
Solve:

<img width="509" alt="Capture d’écran 2021-02-12 à 22 06 59" src="https://user-images.githubusercontent.com/3165635/107822590-a666e480-6d7e-11eb-9e40-b37b8b96381d.png">

Reproduction: https://codesandbox.io/s/material-demo-forked-ozptd?file=/package.json

We have made a change in the core not too long ago. I have found the issue working on https://github.com/mui-org/material-ui/pull/24663.