### PR TITLE
[test] Speed-up rebuild in karma

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const webpack = require('webpack');
 
+const CI = Boolean(process.env.CI);
+
 let build = `material-ui-x local ${new Date().toISOString()}`;
 
 if (process.env.CIRCLE_BUILD_URL) {
@@ -57,7 +59,7 @@ module.exports = function setKarmaConfig(config) {
     reporters: ['dots'],
     webpack: {
       mode: 'development',
-      devtool: 'inline-source-map',
+      devtool: CI ? 'inline-source-map' : 'eval-source-map',
       plugins: [
         new webpack.DefinePlugin({
           'process.env': {
@@ -101,7 +103,7 @@ module.exports = function setKarmaConfig(config) {
     },
     webpackMiddleware: {
       noInfo: true,
-      writeToDisk: Boolean(process.env.CI),
+      writeToDisk: CI,
     },
     customLaunchers: {
       ChromeHeadlessNoSandbox: {
@@ -109,7 +111,7 @@ module.exports = function setKarmaConfig(config) {
         flags: ['--no-sandbox'],
       },
     },
-    singleRun: Boolean(process.env.CI),
+    singleRun: CI,
   };
 
   let newConfig = baseConfig;


### PR DESCRIPTION
Leverage https://github.com/mui-org/material-ui/pull/24967

**Before**

- Build: ~18s
- Re-builds: ~2.5s

**After**

- Build: ~18s
- Re-builds: ~500ms

@eps1lon I have tested the changes in this repo, definitely works 😍. We save 2s for each iteration.