### PR TITLE
[docs] Clarify align is separate from headerAlign

### DIFF
--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -155,7 +155,7 @@ const columns: Columns = [
 The `ColDef` type has properties to apply class names and custom CSS on the cells.
 
 - `cellClassName`: to apply class names on every cell. It can also be a function.
-- `align`: to align the content of the cells. It must be 'left' | 'right' | 'center'.
+- `align`: to align the content of the cells. It must be 'left' | 'right' | 'center'. (Note you must use `headerAlign` to align the content of the header.)
 
 ```tsx
 const columns: Columns = [


### PR DESCRIPTION
docs: Clarify align is separate from headerAlign

Update DataGrid rendering.md docs to clarify that align is separate from headerAlign. 

Resolves https://github.com/mui-org/material-ui-x/issues/1073