### PR TITLE
[DataGrid] Add missing TablePagination localizations

### DIFF
--- a/packages/grid/_modules_/grid/components/GridPagination.tsx
+++ b/packages/grid/_modules_/grid/components/GridPagination.tsx
@@ -84,9 +84,6 @@ export function GridPagination() {
           : []
       }
       rowsPerPage={paginationState.pageSize}
-      labelRowsPerPage={apiRef!.current.getLocaleText('footerPaginationRowsPerPage')}
-      getItemAriaLabel={apiRef!.current.getLocaleText('footerPaginationGetItemAriaLabel')}
-      labelDisplayedRows={apiRef!.current.getLocaleText('footerPaginationLabelDisplayedRows')}
       {...getPaginationChangeHandlers()}
     />
   );

--- a/packages/grid/_modules_/grid/components/GridPagination.tsx
+++ b/packages/grid/_modules_/grid/components/GridPagination.tsx
@@ -85,6 +85,8 @@ export function GridPagination() {
       }
       rowsPerPage={paginationState.pageSize}
       labelRowsPerPage={apiRef!.current.getLocaleText('footerPaginationRowsPerPage')}
+      getItemAriaLabel={apiRef!.current.getLocaleText('footerPaginationGetItemAriaLabel')}
+      labelDisplayedRows={apiRef!.current.getLocaleText('footerPaginationLabelDisplayedRows')}
       {...getPaginationChangeHandlers()}
     />
   );

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -85,4 +85,19 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
 
   // Pagination footer text
   footerPaginationRowsPerPage: 'Rows per page:',
+  footerPaginationGetItemAriaLabel: (type) => {
+    if (type === 'first') {
+      return 'Go to first page';
+    }
+    if (type === 'last') {
+      return 'Go to last page';
+    }
+    if (type === 'next') {
+      return 'Go to next page';
+    }
+
+    return 'Go to previous page';
+  },
+  footerPaginationLabelDisplayedRows: ({ from, to, count }) =>
+    `${from}-${to} of ${count !== -1 ? count : `more than ${to}`}`,
 };

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -82,22 +82,4 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
 
   // Total rows footer text
   footerTotalRows: 'Total Rows:',
-
-  // Pagination footer text
-  footerPaginationRowsPerPage: 'Rows per page:',
-  footerPaginationGetItemAriaLabel: (type) => {
-    if (type === 'first') {
-      return 'Go to first page';
-    }
-    if (type === 'last') {
-      return 'Go to last page';
-    }
-    if (type === 'next') {
-      return 'Go to next page';
-    }
-
-    return 'Go to previous page';
-  },
-  footerPaginationLabelDisplayedRows: ({ from, to, count }) =>
-    `${from}-${to} of ${count !== -1 ? count : `more than ${to}`}`,
 };

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -1,6 +1,6 @@
 import { getGridLocalization, Localization } from '../utils';
 
-export const bgBG: Localization = getGridLocalization({
+export const bgBG: Localization = getGridLocalization('bgBG', {
   // Root
   rootGridLabel: 'мрежа',
   noRowsLabel: 'Няма редове',
@@ -75,7 +75,4 @@ export const bgBG: Localization = getGridLocalization({
 
   // Total rows footer text
   footerTotalRows: 'Общо Rедове:',
-
-  // Pagination footer text
-  footerPaginationRowsPerPage: 'Редове на страница:',
 });

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -1,6 +1,8 @@
+import { bgBG as bgBGCore } from '@material-ui/core/locale';
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { getGridLocalization, Localization } from '../utils';
 
-export const bgBG: Localization = getGridLocalization('bgBG', {
+const bgBGGrid: Partial<GridLocaleText> = {
   // Root
   rootGridLabel: 'мрежа',
   noRowsLabel: 'Няма редове',
@@ -75,4 +77,6 @@ export const bgBG: Localization = getGridLocalization('bgBG', {
 
   // Total rows footer text
   footerTotalRows: 'Общо Rедове:',
-});
+};
+
+export const bgBG: Localization = getGridLocalization(bgBGGrid, bgBGCore);

--- a/packages/grid/_modules_/grid/locales/enUS.ts
+++ b/packages/grid/_modules_/grid/locales/enUS.ts
@@ -1,4 +1,5 @@
+import { enUS as enUSCore } from '@material-ui/core/locale';
 import { getGridLocalization, Localization } from '../utils';
 import { GRID_DEFAULT_LOCALE_TEXT } from '../constants/localeTextConstants';
 
-export const enUS: Localization = getGridLocalization('enUS', GRID_DEFAULT_LOCALE_TEXT);
+export const enUS: Localization = getGridLocalization(GRID_DEFAULT_LOCALE_TEXT, enUSCore);

--- a/packages/grid/_modules_/grid/locales/enUS.ts
+++ b/packages/grid/_modules_/grid/locales/enUS.ts
@@ -1,4 +1,4 @@
 import { getGridLocalization, Localization } from '../utils';
 import { GRID_DEFAULT_LOCALE_TEXT } from '../constants/localeTextConstants';
 
-export const enUS: Localization = getGridLocalization(GRID_DEFAULT_LOCALE_TEXT);
+export const enUS: Localization = getGridLocalization('enUS', GRID_DEFAULT_LOCALE_TEXT);

--- a/packages/grid/_modules_/grid/locales/frFR.ts
+++ b/packages/grid/_modules_/grid/locales/frFR.ts
@@ -1,6 +1,6 @@
 import { getGridLocalization, Localization } from '../utils';
 
-export const frFR: Localization = getGridLocalization({
+export const frFR: Localization = getGridLocalization('frFR', {
   // Root
   rootGridLabel: 'grid',
   noRowsLabel: 'Pas de résultats',
@@ -77,7 +77,4 @@ export const frFR: Localization = getGridLocalization({
 
   // Total rows footer text
   footerTotalRows: 'Lignes totales :',
-
-  // Pagination footer text
-  footerPaginationRowsPerPage: 'Lignes par page :',
 });

--- a/packages/grid/_modules_/grid/locales/frFR.ts
+++ b/packages/grid/_modules_/grid/locales/frFR.ts
@@ -1,6 +1,8 @@
+import { frFR as frFRCore } from '@material-ui/core/locale';
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { getGridLocalization, Localization } from '../utils';
 
-export const frFR: Localization = getGridLocalization('frFR', {
+const frFRGrid: Partial<GridLocaleText> = {
   // Root
   rootGridLabel: 'grid',
   noRowsLabel: 'Pas de résultats',
@@ -77,4 +79,6 @@ export const frFR: Localization = getGridLocalization('frFR', {
 
   // Total rows footer text
   footerTotalRows: 'Lignes totales :',
-});
+};
+
+export const frFR: Localization = getGridLocalization(frFRGrid, frFRCore);

--- a/packages/grid/_modules_/grid/locales/ptBR.ts
+++ b/packages/grid/_modules_/grid/locales/ptBR.ts
@@ -1,6 +1,6 @@
 import { getGridLocalization, Localization } from '../utils';
 
-export const ptBR: Localization = getGridLocalization({
+export const ptBR: Localization = getGridLocalization('ptBR', {
   // Root
   rootGridLabel: 'Grade',
   noRowsLabel: 'Nenhuma linha',
@@ -77,7 +77,4 @@ export const ptBR: Localization = getGridLocalization({
 
   // Total rows footer text
   footerTotalRows: 'Total de linhas:',
-
-  // Pagination footer text
-  footerPaginationRowsPerPage: 'Linhas por página:',
 });

--- a/packages/grid/_modules_/grid/locales/ptBR.ts
+++ b/packages/grid/_modules_/grid/locales/ptBR.ts
@@ -1,6 +1,8 @@
+import { ptBR as ptBRCore } from '@material-ui/core/locale';
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { getGridLocalization, Localization } from '../utils';
 
-export const ptBR: Localization = getGridLocalization('ptBR', {
+const ptBRGrid: Partial<GridLocaleText> = {
   // Root
   rootGridLabel: 'Grade',
   noRowsLabel: 'Nenhuma linha',
@@ -77,4 +79,6 @@ export const ptBR: Localization = getGridLocalization('ptBR', {
 
   // Total rows footer text
   footerTotalRows: 'Total de linhas:',
-});
+};
+
+export const ptBR: Localization = getGridLocalization(ptBRGrid, ptBRCore);

--- a/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
@@ -81,6 +81,16 @@ export interface GridLocaleText {
 
   // Pagination footer text
   footerPaginationRowsPerPage: React.ReactNode;
+  footerPaginationGetItemAriaLabel: (type: string) => string;
+  footerPaginationLabelDisplayedRows: ({
+    from,
+    to,
+    count,
+  }: {
+    from: number;
+    to: number;
+    count: number;
+  }) => React.ReactNode;
 }
 
 export type LocaleTextValue = string | React.ReactNode | Function;

--- a/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
@@ -78,19 +78,6 @@ export interface GridLocaleText {
 
   // Total rows footer text
   footerTotalRows: React.ReactNode;
-
-  // Pagination footer text
-  footerPaginationRowsPerPage: React.ReactNode;
-  footerPaginationGetItemAriaLabel: (type: string) => string;
-  footerPaginationLabelDisplayedRows: ({
-    from,
-    to,
-    count,
-  }: {
-    from: number;
-    to: number;
-    count: number;
-  }) => React.ReactNode;
 }
 
 export type LocaleTextValue = string | React.ReactNode | Function;

--- a/packages/grid/_modules_/grid/utils/getGridLocalization.ts
+++ b/packages/grid/_modules_/grid/utils/getGridLocalization.ts
@@ -1,3 +1,4 @@
+import * as locales from '@material-ui/core/locale';
 import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { GridOptions } from '../models/gridOptions';
 import { isMuiV5 } from './utils';
@@ -18,7 +19,10 @@ export interface LocalizationV5 {
 
 export type Localization = LocalizationV4 | LocalizationV5;
 
-export const getGridLocalization = (translations: Partial<GridLocaleText>): Localization => {
+export const getGridLocalization = (
+  locale: string,
+  translations: Partial<GridLocaleText>,
+): Localization => {
   if (isMuiV5()) {
     return {
       components: {
@@ -27,6 +31,7 @@ export const getGridLocalization = (translations: Partial<GridLocaleText>): Loca
             localeText: translations,
           },
         },
+        ...locales[locale].components,
       },
     };
   }
@@ -36,6 +41,7 @@ export const getGridLocalization = (translations: Partial<GridLocaleText>): Loca
       MuiDataGrid: {
         localeText: translations,
       },
+      ...locales[locale].props,
     },
   };
 };

--- a/packages/grid/_modules_/grid/utils/getGridLocalization.ts
+++ b/packages/grid/_modules_/grid/utils/getGridLocalization.ts
@@ -1,4 +1,3 @@
-import * as locales from '@material-ui/core/locale';
 import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { GridOptions } from '../models/gridOptions';
 import { isMuiV5 } from './utils';
@@ -20,18 +19,18 @@ export interface LocalizationV5 {
 export type Localization = LocalizationV4 | LocalizationV5;
 
 export const getGridLocalization = (
-  locale: string,
-  translations: Partial<GridLocaleText>,
+  gridTranslations: Partial<GridLocaleText>,
+  coreTranslations,
 ): Localization => {
   if (isMuiV5()) {
     return {
       components: {
         MuiDataGrid: {
           defaultProps: {
-            localeText: translations,
+            localeText: gridTranslations,
           },
         },
-        ...locales[locale].components,
+        ...coreTranslations.components,
       },
     };
   }
@@ -39,9 +38,9 @@ export const getGridLocalization = (
   return {
     props: {
       MuiDataGrid: {
-        localeText: translations,
+        localeText: gridTranslations,
       },
-      ...locales[locale].props,
+      ...coreTranslations.props,
     },
   };
 };

--- a/packages/storybook/src/stories/grid-toolbar.stories.tsx
+++ b/packages/storybook/src/stories/grid-toolbar.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
-import { XGrid, GridToolbar, bgBG } from '@material-ui/x-grid';
+import { XGrid, GridToolbar } from '@material-ui/x-grid';
 import '../style/grid-stories.css';
 import { useData } from '../hooks/useData';
 

--- a/packages/storybook/src/stories/grid-toolbar.stories.tsx
+++ b/packages/storybook/src/stories/grid-toolbar.stories.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { XGrid, GridToolbar } from '@material-ui/x-grid';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
+import { XGrid, GridToolbar, bgBG } from '@material-ui/x-grid';
 import '../style/grid-stories.css';
 import { useData } from '../hooks/useData';
 


### PR DESCRIPTION
Fixes #1107 

Some context about the discussion:

> The points I wonder about:
> 1. Do we need to duplicate the translation keys for the components? Do developers need to translate a <TablePagination> differently in the context of a data grid? (DataGrid.localeText.footerPaginationRowsPerPage vs. TablePagination.labelRowsPerPage)
> 2. Should we duplicate (seems we need the same translations) the maintenance of the translated locales between the two components?
> 3. Should the data grid ignore the translation of the core components and ask developers to configure them independently? Basically, asking to do https://material-ui.com/guides/localization/#locale-text. And in the future, if we support importing individual translations, to cherry-pick what they need.
> 4. Should the data grid work in isolation, importing its translation from the core package, avoiding the need for 3?