### PR TITLE
[test] Increase timeout for XGrid demo

### DIFF
--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -61,7 +61,7 @@ async function main() {
 
       it(`creates screenshots of ${pathURL}`, async function test() {
         if (pathURL === '/docs-components-data-grid-overview/XGridDemo') {
-          this.timeout(5000);
+          this.timeout(6000);
         }
 
         // Use client-side routing which is much faster than full page navigation via page.goto().


### PR DESCRIPTION
For this fail: https://app.circleci.com/pipelines/github/mui-org/material-ui-x/3390/workflows/1f1b746f-64b3-42b1-a046-7ba4a479ecb7/jobs/14840.

I have rerun the build to make sure it wasn't a regression with #1025. The second build ran in a reasonable time, so unlikely a regression, but flakiness: https://app.circleci.com/pipelines/github/mui-org/material-ui-x/3390/workflows/d50285d1-f7f6-4bdd-bda8-8303711f0603/jobs/14843.