### PR TITLE
[docs] Fix typo

### DIFF
--- a/docs/src/pages/components/data-grid/rendering/rendering.md
+++ b/docs/src/pages/components/data-grid/rendering/rendering.md
@@ -271,7 +271,7 @@ The prop accepts an object of type [GridSlotsComponent](/api/data-grid/#slots) .
 ### Toolbar
 
 To enable the toolbar you need to add the `Toolbar: GridToolbar` to the grid `components` prop.
-This demo showcases how this can be achieve.
+This demo showcases how this can be achieved.
 
 {{"demo": "pages/components/data-grid/rendering/ToolbarGrid.js", "bg": "inline"}}
 


### PR DESCRIPTION
Should say achieved and not achieve.

Thanks for your great work with this library!