### PR TITLE
[XGrid] Support column reordering inside the whole grid

### DIFF
--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -150,11 +150,10 @@ To disable column reordering, set the prop `disableColumnReorder={true}`.
 
 In addition, column reordering emits the following events that can be imported:
 
-- `columnReordering:dragStart`: emitted when dragging of a header cell starts.
-- `columnReordering:dragEnter`: emitted when the cursor enters another header cell while dragging.
-- `columnReordering:dragOver`: emitted when dragging a header cell over another header cell.
-- `columnReordering:dragOverHeader`: emitted when dragging a header cell over the `ColumnsHeader` component.
-- `columnReordering:dragEnd`: emitted when dragging of a header cell stops.
+- `columnHeaderDragStart`: emitted when dragging of a header cell starts.
+- `columnHeaderDragEnter`: emitted when the cursor enters another header cell while dragging.
+- `columnHeaderDragOver`: emitted when dragging a header cell over another header cell.
+- `columnHeaderDragEnd`: emitted when dragging of a header cell stops.
 
 {{"demo": "pages/components/data-grid/columns/ColumnOrderingGrid.js", "disableAd": true, "bg": "inline"}}
 

--- a/packages/grid/_modules_/grid/components/GridScrollArea.tsx
+++ b/packages/grid/_modules_/grid/components/GridScrollArea.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import {
-  GRID_COLUMN_REORDER_START,
-  GRID_COLUMN_REORDER_DRAG_END,
+  GRID_COLUMN_HEADER_DRAG_START,
+  GRID_COLUMN_HEADER_DRAG_END,
   GRID_ROWS_SCROLL,
 } from '../constants/eventsConstants';
 import { useGridApiEventHandler } from '../hooks/root/useGridApiEventHandler';
@@ -69,8 +69,8 @@ export const GridScrollArea = React.memo(function GridScrollArea(props: ScrollAr
   }, []);
 
   useGridApiEventHandler(api as GridApiRef, GRID_ROWS_SCROLL, handleScrolling);
-  useGridApiEventHandler(api as GridApiRef, GRID_COLUMN_REORDER_START, toggleDragging);
-  useGridApiEventHandler(api as GridApiRef, GRID_COLUMN_REORDER_DRAG_END, toggleDragging);
+  useGridApiEventHandler(api as GridApiRef, GRID_COLUMN_HEADER_DRAG_START, toggleDragging);
+  useGridApiEventHandler(api as GridApiRef, GRID_COLUMN_HEADER_DRAG_END, toggleDragging);
 
   return dragging ? (
     <div

--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -12,6 +12,9 @@ import {
   GRID_CELL_MOUSE_DOWN,
   GRID_CELL_OUT,
   GRID_CELL_OVER,
+  GRID_CELL_DRAG_START,
+  GRID_CELL_DRAG_ENTER,
+  GRID_CELL_DRAG_OVER,
 } from '../../constants/eventsConstants';
 import { GridAlignment, GridCellMode, GridCellValue, GridRowId } from '../../models/index';
 import { classnames } from '../../utils/index';
@@ -115,6 +118,9 @@ export const GridCell: React.FC<GridCellProps> = React.memo((props) => {
       onKeyDown: publish(GRID_CELL_KEYDOWN),
       onBlur: publishBlur(GRID_CELL_BLUR),
       onFocus: publish(GRID_CELL_FOCUS),
+      onDragStart: publish(GRID_CELL_DRAG_START),
+      onDragEnter: publish(GRID_CELL_DRAG_ENTER),
+      onDragOver: publish(GRID_CELL_DRAG_OVER),
     }),
     [publish, publishBlur, publishClick],
   );

--- a/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -6,10 +6,10 @@ import {
   GRID_COLUMN_HEADER_LEAVE,
   GRID_COLUMN_HEADER_OUT,
   GRID_COLUMN_HEADER_OVER,
-  GRID_COLUMN_REORDER_DRAG_ENTER,
-  GRID_COLUMN_REORDER_DRAG_OVER,
-  GRID_COLUMN_REORDER_START,
-  GRID_COLUMN_REORDER_DRAG_END,
+  GRID_COLUMN_HEADER_DRAG_ENTER,
+  GRID_COLUMN_HEADER_DRAG_OVER,
+  GRID_COLUMN_HEADER_DRAG_START,
+  GRID_COLUMN_HEADER_DRAG_END,
 } from '../../constants/eventsConstants';
 import { GridColDef, GRID_NUMBER_COLUMN_TYPE } from '../../models/colDef/index';
 import { GridOptions } from '../../models/gridOptions';
@@ -69,7 +69,7 @@ export const GridColumnHeaderItem = ({
   }
 
   const publish = React.useCallback(
-    (eventName: string) => (event: React.MouseEvent) =>
+    (eventName: string) => (event: React.MouseEvent | React.DragEvent) =>
       apiRef!.current.publishEvent(
         eventName,
         apiRef!.current.getColumnHeaderParams(column.field),
@@ -92,10 +92,10 @@ export const GridColumnHeaderItem = ({
 
   const draggableEventHandlers = React.useMemo(
     () => ({
-      onDragStart: publish(GRID_COLUMN_REORDER_START),
-      onDragEnter: publish(GRID_COLUMN_REORDER_DRAG_ENTER),
-      onDragOver: publish(GRID_COLUMN_REORDER_DRAG_OVER),
-      onDragEnd: publish(GRID_COLUMN_REORDER_DRAG_END),
+      onDragStart: publish(GRID_COLUMN_HEADER_DRAG_START),
+      onDragEnter: publish(GRID_COLUMN_HEADER_DRAG_ENTER),
+      onDragOver: publish(GRID_COLUMN_HEADER_DRAG_OVER),
+      onDragEnd: publish(GRID_COLUMN_HEADER_DRAG_END),
     }),
     [publish],
   );

--- a/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaders.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaders.tsx
@@ -3,7 +3,6 @@ import { visibleGridColumnsSelector } from '../../hooks/features/columns/gridCol
 import { GridState } from '../../hooks/features/core/gridState';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { renderStateSelector } from '../../hooks/features/virtualization/renderingStateSelector';
-import { optionsSelector } from '../../hooks/utils/optionsSelector';
 import { GridApiContext } from '../GridApiContext';
 import { GridEmptyCell } from '../cell/GridEmptyCell';
 import { GridScrollArea } from '../GridScrollArea';
@@ -11,7 +10,8 @@ import { GridColumnHeadersItemCollection } from './GridColumnHeadersItemCollecti
 import { gridDensityHeaderHeightSelector } from '../../hooks/features/density/densitySelector';
 import { gridColumnReorderDragColSelector } from '../../hooks/features/columnReorder/columnReorderSelector';
 import { gridContainerSizesSelector } from '../../hooks/root/gridContainerSizesSelector';
-import { GRID_COLUMN_REORDER_DRAG_OVER_HEADER } from '../../constants/eventsConstants';
+import { GRID_HEADER_CELL_DROP_ZONE_CSS_CLASS } from '../../constants/cssClassesConstants';
+import { classnames } from '../../utils/classnames';
 
 export const gridScrollbarStateSelector = (state: GridState) => state.scrollBar;
 
@@ -21,13 +21,16 @@ export const GridColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function G
 ) {
   const apiRef = React.useContext(GridApiContext);
   const columns = useGridSelector(apiRef, visibleGridColumnsSelector);
-  const { disableColumnReorder } = useGridSelector(apiRef, optionsSelector);
   const containerSizes = useGridSelector(apiRef, gridContainerSizesSelector);
   const headerHeight = useGridSelector(apiRef, gridDensityHeaderHeightSelector);
   const renderCtx = useGridSelector(apiRef, renderStateSelector).renderContext;
   const { hasScrollX } = useGridSelector(apiRef, gridScrollbarStateSelector);
   const dragCol = useGridSelector(apiRef, gridColumnReorderDragColSelector);
-  const wrapperCssClasses = `MuiDataGrid-colCellWrapper ${hasScrollX ? 'scroll' : ''}`;
+
+  const wrapperCssClasses = classnames('MuiDataGrid-colCellWrapper', {
+    scroll: hasScrollX,
+    [GRID_HEADER_CELL_DROP_ZONE_CSS_CLASS]: dragCol,
+  });
 
   const renderedCols = React.useMemo(() => {
     if (renderCtx == null) {
@@ -36,28 +39,15 @@ export const GridColumnsHeader = React.forwardRef<HTMLDivElement, {}>(function G
     return columns.slice(renderCtx.firstColIdx, renderCtx.lastColIdx! + 1);
   }, [columns, renderCtx]);
 
-  const handleDragOver =
-    !disableColumnReorder && apiRef
-      ? (event) =>
-          apiRef.current.publishEvent(
-            GRID_COLUMN_REORDER_DRAG_OVER_HEADER,
-            apiRef.current.getColumnHeaderParams(dragCol),
-            event,
-          )
-      : undefined;
-
   return (
     <React.Fragment>
       <GridScrollArea scrollDirection="left" />
-      {/* Header row isn't interactive, cells are, event delegation */}
-      {/* eslint-disable-next-line jsx-a11y/interactive-supports-focus */}
       <div
         ref={ref}
         className={wrapperCssClasses}
         aria-rowindex={1}
         role="row"
         style={{ minWidth: containerSizes?.totalSizes?.width }}
-        onDragOver={handleDragOver}
       >
         <GridEmptyCell width={renderCtx?.leftEmptyWidth} height={headerHeight} />
         <GridColumnHeadersItemCollection columns={renderedCols} />

--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -29,6 +29,10 @@ export const GRID_CELL_EDIT_ENTER = 'cellEditEnter';
 export const GRID_CELL_EDIT_EXIT = 'cellEditExit';
 export const GRID_CELL_NAVIGATION_KEYDOWN = 'cellNavigationKeyDown';
 export const GRID_CELL_FOCUS = 'cellCellFocus';
+export const GRID_CELL_DRAG_START = 'cellDragStart';
+export const GRID_CELL_DRAG_ENTER = 'cellDragEnter';
+export const GRID_CELL_DRAG_OVER = 'cellDragOver';
+export const GRID_CELL_DRAG_END = 'cellDragEnd';
 
 export const GRID_ROW_CLICK = 'rowClick';
 export const GRID_ROW_DOUBLE_CLICK = 'rowDoubleClick';
@@ -45,6 +49,10 @@ export const GRID_COLUMN_HEADER_OVER = 'columnHeaderOver';
 export const GRID_COLUMN_HEADER_OUT = 'columnHeaderOut';
 export const GRID_COLUMN_HEADER_ENTER = 'columnHeaderEnter';
 export const GRID_COLUMN_HEADER_LEAVE = 'columnHeaderLeave';
+export const GRID_COLUMN_HEADER_DRAG_START = 'columnHeaderDragStart';
+export const GRID_COLUMN_HEADER_DRAG_OVER = 'columnHeaderDragOver';
+export const GRID_COLUMN_HEADER_DRAG_ENTER = 'columnHeaderDragEnter';
+export const GRID_COLUMN_HEADER_DRAG_END = 'columnHeaderDragEnd';
 
 export const GRID_SELECTION_CHANGED = 'selectionChange';
 
@@ -58,12 +66,6 @@ export const GRID_COL_RESIZE_START = 'colResizing:start';
 export const GRID_COL_RESIZE_STOP = 'colResizing:stop';
 
 export const GRID_COLUMN_ORDER_CHANGE = 'columnOrderChange';
-
-export const GRID_COLUMN_REORDER_START = 'columnReordering:dragStart';
-export const GRID_COLUMN_REORDER_DRAG_OVER_HEADER = 'columnReordering:dragOverHeader';
-export const GRID_COLUMN_REORDER_DRAG_OVER = 'columnReordering:dragOver';
-export const GRID_COLUMN_REORDER_DRAG_ENTER = 'columnReordering:dragEnter';
-export const GRID_COLUMN_REORDER_DRAG_END = 'columnReordering:dragEnd';
 
 export const GRID_ROWS_UPDATED = 'rowsUpdated';
 export const GRID_ROWS_SET = 'rowsSet';

--- a/packages/grid/x-grid/src/tests/reorder.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/reorder.XGrid.test.tsx
@@ -110,13 +110,18 @@ describe('<XGrid /> - Reorder', () => {
     expect(getColumnHeadersTextContent()).to.deep.equal(['brand', 'desc', 'type']);
     const dragCol = getColumnHeaderCell(1).firstChild;
 
+    const targetCell = getCell(0, 2);
     fireEvent.dragStart(dragCol);
-    fireEvent.dragEnter(getCell(0, 2));
-    fireEvent.dragOver(getCell(0, 2), { clientX: 1, clientY: 1 });
+    fireEvent.dragEnter(targetCell);
+    const dragOverEvent = createEvent.dragOver(targetCell);
+    // Safari 13 doesn't have DragEvent.
+    // RTL fallbacks to Event which doesn't allow to set these fields during initialization.
+    Object.defineProperty(dragOverEvent, 'clientX', { value: 1 });
+    Object.defineProperty(dragOverEvent, 'clientY', { value: 1 });
+    fireEvent(targetCell, dragOverEvent);
     expect(getColumnHeadersTextContent()).to.deep.equal(['desc', 'type', 'brand']);
 
     const dragEndEvent = createEvent.dragEnd(dragCol);
-    // Safari doesn't support DataTransfer constructor
     Object.defineProperty(dragEndEvent, 'dataTransfer', { value: { dropEffect: 'copy' } });
     fireEvent(dragCol, dragEndEvent);
     expect(getColumnHeadersTextContent()).to.deep.equal(['desc', 'type', 'brand']);
@@ -142,12 +147,17 @@ describe('<XGrid /> - Reorder', () => {
     const dragCol = getColumnHeaderCell(1).firstChild;
 
     fireEvent.dragStart(dragCol);
-    fireEvent.dragEnter(getCell(0, 2));
-    fireEvent.dragOver(getCell(0, 2), { clientX: 1, clientY: 1 });
+    const targetCell = getCell(0, 2);
+    fireEvent.dragEnter(targetCell);
+    const dragOverEvent = createEvent.dragOver(targetCell);
+    // Safari 13 doesn't have DragEvent.
+    // RTL fallbacks to Event which doesn't allow to set these fields during initialization.
+    Object.defineProperty(dragOverEvent, 'clientX', { value: 1 });
+    Object.defineProperty(dragOverEvent, 'clientY', { value: 1 });
+    fireEvent(targetCell, dragOverEvent);
     expect(getColumnHeadersTextContent()).to.deep.equal(['desc', 'type', 'brand']);
 
     const dragEndEvent = createEvent.dragEnd(dragCol);
-    // Safari doesn't support DataTransfer constructor
     Object.defineProperty(dragEndEvent, 'dataTransfer', { value: { dropEffect: 'none' } });
     fireEvent(dragCol, dragEndEvent);
     expect(getColumnHeadersTextContent()).to.deep.equal(['brand', 'desc', 'type']);


### PR DESCRIPTION
Fixes #445.
Preview https://deploy-preview-1250--material-ui-x.netlify.app/components/data-grid/demo/

### Breaking changes

- [XGrid] Event `GRID_COLUMN_REORDER_DRAG_OVER_HEADER` is no longer emitted

---

My approach here was to turn every cell into a droppable target. If https://github.com/mui-org/material-ui-x/issues/206 gets implemented an additional check may be needed to determine if a column cell or a row cell was dropped. I'm using the value of [`dropEffect`](https://developer.mozilla.org/en-US/docs/Web/API/DataTransfer/dropEffect) to determine if the user canceled the reordering (dropping outside or pressing Escape).

Result:

![Peek 2021-03-18 00-07](https://user-images.githubusercontent.com/42154031/111567713-287f6a00-877e-11eb-868e-2911a07f18a6.gif)
