### PR TITLE
[core] No top-level imports

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Unstable_TrapFocus as TrapFocus } from '@material-ui/core';
+import TrapFocus from '@material-ui/core/Unstable_TrapFocus';
 import { makeStyles } from '@material-ui/core/styles';
 import { classnames } from '../../utils/classnames';
 

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { capitalize } from '@material-ui/core';
 import FormControl from '@material-ui/core/FormControl';
 import IconButton from '@material-ui/core/IconButton';
 import InputLabel from '@material-ui/core/InputLabel';
 import Select from '@material-ui/core/Select';
+import { capitalize } from '@material-ui/core/utils';
 import { makeStyles } from '@material-ui/core/styles';
 import { filterableGridColumnsSelector } from '../../../hooks/features/columns/gridColumnsSelector';
 import { useGridSelector } from '../../../hooks/features/core/useGridSelector';


### PR DESCRIPTION
@DanailH see why https://github.com/mui-org/material-ui/pull/24147

I have tried to enable the eslint rule to have the CI fail upfront, but it needed to make a change in the main repo, I was too lazy for doing it:

https://github.com/mui-org/material-ui-x/blob/a46e2a13c5f63adc08e44fa2dc1d51e64275e4ac/.eslintrc.js#L26