### PR TITLE
[DataGrid] Add elGR locale

### DIFF
--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -53,6 +53,7 @@ The same import works with `XGrid` as it's an extension of `DataGrid`.
 | English (United States) | en-US               | `enUS`      |
 | French                  | fr-FR               | `frFR`      |
 | German                  | de-DE               | `deDE`      |
+| Greek                   | el-GR               | `elGR`      |
 | Portuguese (Brazil)     | pt-BR               | `ptBR`      |
 
 You can [find the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.

--- a/packages/grid/_modules_/grid/locales/elGR.ts
+++ b/packages/grid/_modules_/grid/locales/elGR.ts
@@ -1,0 +1,89 @@
+import { elGR as elGRCore } from '@material-ui/core/locale';
+import { GridLocaleText } from '../models/api/gridLocaleTextApi';
+import { getGridLocalization, Localization } from '../utils';
+
+const elGRGrid: Partial<GridLocaleText> = {
+  // Root
+  rootGridLabel: 'πλέγμα',
+  noRowsLabel: 'Δεν υπάρχουν καταχωρήσεις',
+  errorOverlayDefaultLabel: 'Παρουσιάστηκε απρόβλεπτο σφάλμα.',
+
+  // Density selector toolbar button text
+  toolbarDensity: 'Ύψος σειράς',
+  toolbarDensityLabel: 'Ύψος σειράς',
+  toolbarDensityCompact: 'Συμπαγής',
+  toolbarDensityStandard: 'Προκαθορισμένο',
+  toolbarDensityComfortable: 'Πλατύ',
+
+  // Columns selector toolbar button text
+  toolbarColumns: 'Στήλες',
+  toolbarColumnsLabel: 'Επιλέξτε στήλες',
+
+  // Filters toolbar button text
+  toolbarFilters: 'Φίλτρα',
+  toolbarFiltersLabel: 'Εμφάνιση φίλτρων',
+  toolbarFiltersTooltipHide: 'Απόκρυψη φίλτρων',
+  toolbarFiltersTooltipShow: 'Εμφάνιση φίλτρων',
+  toolbarFiltersTooltipActive: (count) =>
+    count !== 1 ? `${count} ενεργά φίλτρα` : `${count} ενεργό φίλτρο`,
+
+  // Export selector toolbar button text
+  toolbarExport: 'Εξαγωγή',
+  toolbarExportLabel: 'Εξαγωγή',
+  toolbarExportCSV: 'Λήψη ως CSV',
+
+  // Columns panel text
+  columnsPanelTextFieldLabel: 'Εύρεση στήλης',
+  columnsPanelTextFieldPlaceholder: 'Επικεφαλίδα στήλης',
+  columnsPanelDragIconLabel: 'Αναδιάταξη στήλης',
+  columnsPanelShowAllButton: 'Προβολή όλων',
+  columnsPanelHideAllButton: 'Απόκρυψη όλων',
+
+  // Filter panel text
+  filterPanelAddFilter: 'Προσθήκη φίλτρου',
+  filterPanelDeleteIconLabel: 'Διαγραφή',
+  filterPanelOperators: 'Τελεστές',
+  filterPanelOperatorAnd: 'Καί',
+  filterPanelOperatorOr: 'Ή',
+  filterPanelColumns: 'Στήλες',
+  filterPanelInputLabel: 'Τιμή',
+  filterPanelInputPlaceholder: 'Τιμή φίλτρου',
+
+  // Filter operators text
+  filterOperatorContains: 'περιέχει',
+  filterOperatorEquals: 'ισούται',
+  filterOperatorStartsWith: 'ξεκινάει με',
+  filterOperatorEndsWith: 'τελειώνει με',
+  filterOperatorIs: 'είναι',
+  filterOperatorNot: 'δεν είναι',
+  filterOperatorAfter: 'είναι μετά',
+  filterOperatorOnOrAfter: 'είναι ίσο ή μετά',
+  filterOperatorBefore: 'είναι πριν',
+  filterOperatorOnOrBefore: 'είναι ίσο ή πριν',
+
+  // Column menu text
+  columnMenuLabel: 'Μενού',
+  columnMenuShowColumns: 'Εμφάνιση στηλών',
+  columnMenuFilter: 'Φίλτρο',
+  columnMenuHideColumn: 'Απόκρυψη',
+  columnMenuUnsort: 'Απενεργοποίηση ταξινόμησης',
+  columnMenuSortAsc: 'Ταξινόμηση σε αύξουσα σειρά',
+  columnMenuSortDesc: 'Ταξινόμηση σε φθίνουσα σειρά',
+
+  // Column header text
+  columnHeaderFiltersTooltipActive: (count) =>
+    count !== 1 ? `${count} ενεργά φίλτρα` : `${count} ενεργό φίλτρο`,
+  columnHeaderFiltersLabel: 'Εμφάνιση φίλτρων',
+  columnHeaderSortIconLabel: 'Ταξινόμηση',
+
+  // Rows selected footer text
+  footerRowSelected: (count) =>
+    count !== 1
+      ? `${count.toLocaleString()} επιλεγμένες γραμμές`
+      : `${count.toLocaleString()} επιλεγμένη γραμμή`,
+
+  // Total rows footer text
+  footerTotalRows: 'Σύνολο Γραμμών:',
+};
+
+export const elGR: Localization = getGridLocalization(elGRGrid, elGRCore);

--- a/packages/grid/_modules_/grid/locales/elGR.ts
+++ b/packages/grid/_modules_/grid/locales/elGR.ts
@@ -1,4 +1,3 @@
-import { elGR as elGRCore } from '@material-ui/core/locale';
 import { GridLocaleText } from '../models/api/gridLocaleTextApi';
 import { getGridLocalization, Localization } from '../utils';
 
@@ -86,4 +85,4 @@ const elGRGrid: Partial<GridLocaleText> = {
   footerTotalRows: 'Σύνολο Γραμμών:',
 };
 
-export const elGR: Localization = getGridLocalization(elGRGrid, elGRCore);
+export const elGR: Localization = getGridLocalization(elGRGrid);

--- a/packages/grid/_modules_/grid/locales/index.ts
+++ b/packages/grid/_modules_/grid/locales/index.ts
@@ -1,6 +1,7 @@
 // Keys are translated from enUS
 export * from './bgBG';
 export * from './deDE';
+export * from './elGR';
 export * from './enUS';
 export * from './frFR';
 export * from './ptBR';

--- a/packages/grid/_modules_/grid/utils/getGridLocalization.ts
+++ b/packages/grid/_modules_/grid/utils/getGridLocalization.ts
@@ -20,7 +20,7 @@ export type Localization = LocalizationV4 | LocalizationV5;
 
 export const getGridLocalization = (
   gridTranslations: Partial<GridLocaleText>,
-  coreTranslations,
+  coreTranslations?,
 ): Localization => {
   if (isMuiV5()) {
     return {
@@ -30,7 +30,7 @@ export const getGridLocalization = (
             localeText: gridTranslations,
           },
         },
-        ...coreTranslations.components,
+        ...coreTranslations?.components,
       },
     };
   }
@@ -40,7 +40,7 @@ export const getGridLocalization = (
       MuiDataGrid: {
         localeText: gridTranslations,
       },
-      ...coreTranslations.props,
+      ...coreTranslations?.props,
     },
   };
 };


### PR DESCRIPTION
Add Greek language locale for Grid.

**WARNING**

```js
import { elGR as elGRCore } from '@material-ui/core/locale';
```

Locale `elGR` does not exist inside the current published `@material-ui/core` version `4.11.3` which this depends on (`"@material-ui/core": "^4.9.12"`), but of course it does exist inside master https://github.com/mui-org/material-ui/pull/21988.
