### PR TITLE
[test] Run more tests in jsdom

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,6 +1,7 @@
 module.exports = {
   recursive: true,
   reporter: 'dot',
+  slow: 300,
   require: [require.resolve('./test/utils/setup')],
   extension: ['js', 'tsx', 'ts'],
 };

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -276,7 +276,8 @@ export const useGridVirtualRows = (
     setRenderingState({ virtualPage: 0 });
 
     if (windowRef && windowRef.current) {
-      windowRef.current.scrollTo(0, 0);
+      windowRef.current.scrollTop = 0;
+      windowRef.current.scrollLeft = 0;
     }
     setRenderingState({ renderingZoneScroll: { left: 0, top: 0 } });
   }, [scrollTo, setRenderingState, windowRef]);

--- a/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
@@ -6,44 +6,36 @@ import { optionsSelector } from './optionsSelector';
 
 export function useResizeContainer(apiRef): (size: ElementSize) => void {
   const gridLogger = useLogger('useResizeContainer');
-  const widthTimeout = React.useRef<any>();
-  const heightTimeout = React.useRef<any>();
   const { autoHeight } = useGridSelector(apiRef, optionsSelector);
 
   const onResize = React.useCallback(
     (size: ElementSize) => {
-      clearTimeout(widthTimeout.current);
-      clearTimeout(heightTimeout.current);
+      // jsdom has no layout capabilities
+      const jsdom = /jsdom/.test(window.navigator.userAgent);
 
-      if (size.height === 0 && !autoHeight) {
-        // Use timeout to allow simpler tests in JSDOM.
-        widthTimeout.current = setTimeout(() => {
-          gridLogger.warn(
-            [
-              'The parent of the grid has an empty height.',
-              'You need to make sure the container has an intrinsic height.',
-              'The grid displays with a height of 0px.',
-              '',
-              'You can find a solution in the docs:',
-              'https://material-ui.com/components/data-grid/rendering/#layout',
-            ].join('\n'),
-          );
-        });
+      if (size.height === 0 && !autoHeight && !jsdom) {
+        gridLogger.warn(
+          [
+            'The parent of the grid has an empty height.',
+            'You need to make sure the container has an intrinsic height.',
+            'The grid displays with a height of 0px.',
+            '',
+            'You can find a solution in the docs:',
+            'https://material-ui.com/components/data-grid/rendering/#layout',
+          ].join('\n'),
+        );
       }
-      if (size.width === 0) {
-        // Use timeout to allow simpler tests in JSDOM.
-        heightTimeout.current = setTimeout(() => {
-          gridLogger.warn(
-            [
-              'The parent of the grid has an empty width.',
-              'You need to make sure the container has an intrinsic width.',
-              'The grid displays with a width of 0px.',
-              '',
-              'You can find a solution in the docs:',
-              'https://material-ui.com/components/data-grid/rendering/#layout',
-            ].join('\n'),
-          );
-        });
+      if (size.width === 0 && !jsdom) {
+        gridLogger.warn(
+          [
+            'The parent of the grid has an empty width.',
+            'You need to make sure the container has an intrinsic width.',
+            'The grid displays with a width of 0px.',
+            '',
+            'You can find a solution in the docs:',
+            'https://material-ui.com/components/data-grid/rendering/#layout',
+          ].join('\n'),
+        );
       }
 
       gridLogger.info('resized...', size);
@@ -51,13 +43,6 @@ export function useResizeContainer(apiRef): (size: ElementSize) => void {
     },
     [gridLogger, apiRef, autoHeight],
   );
-
-  React.useEffect(() => {
-    return () => {
-      clearTimeout(widthTimeout.current);
-      clearTimeout(heightTimeout.current);
-    };
-  }, []);
 
   return onResize;
 }

--- a/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useResizeContainer.ts
@@ -11,9 +11,9 @@ export function useResizeContainer(apiRef): (size: ElementSize) => void {
   const onResize = React.useCallback(
     (size: ElementSize) => {
       // jsdom has no layout capabilities
-      const jsdom = /jsdom/.test(window.navigator.userAgent);
+      const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
-      if (size.height === 0 && !autoHeight && !jsdom) {
+      if (size.height === 0 && !autoHeight && !isJSDOM) {
         gridLogger.warn(
           [
             'The parent of the grid has an empty height.',
@@ -25,7 +25,7 @@ export function useResizeContainer(apiRef): (size: ElementSize) => void {
           ].join('\n'),
         );
       }
-      if (size.width === 0 && !jsdom) {
+      if (size.width === 0 && !isJSDOM) {
         gridLogger.warn(
           [
             'The parent of the grid has an empty width.',

--- a/packages/grid/data-grid/src/tests/components.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/components.DataGrid.test.tsx
@@ -26,13 +26,6 @@ describe('<DataGrid /> - Components', () => {
   };
 
   describe('footer', () => {
-    before(function beforeHook() {
-      if (/jsdom/.test(window.navigator.userAgent)) {
-        // Need layouting
-        this.skip();
-      }
-    });
-
     it('should hide footer if prop hideFooter is set', () => {
       render(
         <div style={{ width: 300, height: 500 }}>

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -9,6 +9,7 @@ describe('<DataGrid /> - Filter', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: true,
     rows: [
       {
         id: 0,
@@ -29,13 +30,6 @@ describe('<DataGrid /> - Filter', () => {
     columns: [{ field: 'brand' }, { field: 'isPublished', type: 'boolean' }],
   };
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   const TestCase = (props: {
     rows?: any[];
     columns?: any[];
@@ -47,6 +41,7 @@ describe('<DataGrid /> - Filter', () => {
     return (
       <div style={{ width: 300, height: 300 }}>
         <DataGrid
+          autoHeight
           columns={columns || baselineProps.columns}
           rows={rows || baselineProps.rows}
           filterModel={{

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -9,7 +9,7 @@ describe('<DataGrid /> - Filter', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: true,
+    autoHeight: /jsdom/.test(window.navigator.userAgent),
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Filter', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: NO_LAYOUT,
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,
@@ -43,7 +43,7 @@ describe('<DataGrid /> - Filter', () => {
     return (
       <div style={{ width: 300, height: 300 }}>
         <DataGrid
-          autoHeight={NO_LAYOUT}
+          autoHeight={isJSDOM}
           columns={columns || baselineProps.columns}
           rows={rows || baselineProps.rows}
           filterModel={{

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -4,12 +4,14 @@ import { expect } from 'chai';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Filter', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: /jsdom/.test(window.navigator.userAgent),
+    autoHeight: NO_LAYOUT,
     rows: [
       {
         id: 0,
@@ -41,7 +43,7 @@ describe('<DataGrid /> - Filter', () => {
     return (
       <div style={{ width: 300, height: 300 }}>
         <DataGrid
-          autoHeight
+          autoHeight={NO_LAYOUT}
           columns={columns || baselineProps.columns}
           rows={rows || baselineProps.rows}
           filterModel={{

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -175,7 +175,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('Space only should go to the bottom of the page', function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
+    if (NO_LAYOUT) {
       // Need layouting for row virtualization
       this.skip();
     }
@@ -196,7 +196,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('Home / End navigation', async function test() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
+    if (NO_LAYOUT) {
       // Need layouting for column virtualization
       this.skip();
     }

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -26,6 +26,7 @@ import { GridColumns } from 'packages/grid/_modules_/grid/models/colDef/gridColD
 
 const SPACE_KEY = { key: ' ' };
 const SHIFT_SPACE_KEY = { ...SPACE_KEY, shiftKey: true };
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Keyboard', () => {
   // TODO v5: replace with createClientRender
@@ -133,7 +134,11 @@ describe('<DataGrid /> - Keyboard', () => {
 
     return (
       <div style={{ width: 300, height: 360 }}>
-        <DataGrid autoHeight rows={data.rows} columns={transformColSizes(data.columns)} />
+        <DataGrid
+          autoHeight={NO_LAYOUT}
+          rows={data.rows}
+          columns={transformColSizes(data.columns)}
+        />
       </div>
     );
   };
@@ -222,7 +227,11 @@ describe('<DataGrid /> - Keyboard', () => {
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid autoHeight rows={baselineProps.rows} columns={baselineProps.columns} />
+        <DataGrid
+          autoHeight={NO_LAYOUT}
+          rows={baselineProps.rows}
+          columns={baselineProps.columns}
+        />
       </div>,
     );
 

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -26,7 +26,7 @@ import { GridColumns } from 'packages/grid/_modules_/grid/models/colDef/gridColD
 
 const SPACE_KEY = { key: ' ' };
 const SHIFT_SPACE_KEY = { ...SPACE_KEY, shiftKey: true };
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Keyboard', () => {
   // TODO v5: replace with createClientRender
@@ -134,11 +134,7 @@ describe('<DataGrid /> - Keyboard', () => {
 
     return (
       <div style={{ width: 300, height: 360 }}>
-        <DataGrid
-          autoHeight={NO_LAYOUT}
-          rows={data.rows}
-          columns={transformColSizes(data.columns)}
-        />
+        <DataGrid autoHeight={isJSDOM} rows={data.rows} columns={transformColSizes(data.columns)} />
       </div>
     );
   };
@@ -175,7 +171,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('Space only should go to the bottom of the page', function test() {
-    if (NO_LAYOUT) {
+    if (isJSDOM) {
       // Need layouting for row virtualization
       this.skip();
     }
@@ -196,7 +192,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   it('Home / End navigation', async function test() {
-    if (NO_LAYOUT) {
+    if (isJSDOM) {
       // Need layouting for column virtualization
       this.skip();
     }
@@ -232,11 +228,7 @@ describe('<DataGrid /> - Keyboard', () => {
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid
-          autoHeight={NO_LAYOUT}
-          rows={baselineProps.rows}
-          columns={baselineProps.columns}
-        />
+        <DataGrid autoHeight={isJSDOM} rows={baselineProps.rows} columns={baselineProps.columns} />
       </div>,
     );
 

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -222,7 +222,7 @@ describe('<DataGrid /> - Keyboard', () => {
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid rows={baselineProps.rows} columns={baselineProps.columns} />
+        <DataGrid autoHeight rows={baselineProps.rows} columns={baselineProps.columns} />
       </div>,
     );
 

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -174,12 +174,17 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(isSelected).to.equal(true);
   });
 
-  it('Space only should go to the bottom of the page', () => {
+  it('Space only should go to the bottom of the page', function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting for row virtualization
+      this.skip();
+    }
+
     render(<KeyboardTest />);
     getCell(0, 0).focus();
     expect(getActiveCell()).to.equal('0-0');
-    fireEvent.keyDown(document.activeElement!, SPACE_KEY);
-    expect(getActiveCell()).to.equal('19-0');
+    fireEvent.keyDown(document.activeElement!, { key: ' ' });
+    expect(getActiveCell()).to.equal('4-0');
   });
 
   it('Space only should go to the bottom of the page even with small number of rows', () => {

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -127,7 +127,7 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   const KeyboardTest = (props: { nbRows?: number }) => {
-    const data = useData(props.nbRows || 20, 20);
+    const data = useData(props.nbRows || 100, 20);
     const transformColSizes = (columns: GridColumns) =>
       columns.map((column) => ({ ...column, width: 60 }));
 
@@ -140,7 +140,7 @@ describe('<DataGrid /> - Keyboard', () => {
 
   /* eslint-disable material-ui/disallow-active-element-as-key-event-target */
   it('cell navigation with arrows', () => {
-    render(<KeyboardTest />);
+    render(<KeyboardTest nbRows={10} />);
     getCell(0, 0).focus();
     expect(getActiveCell()).to.equal('0-0');
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -31,13 +31,6 @@ describe('<DataGrid /> - Keyboard', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   it('should be able to type in an child input', () => {
     const handleInputKeyDown = spy((event) => event.defaultPrevented);
 
@@ -134,13 +127,13 @@ describe('<DataGrid /> - Keyboard', () => {
   });
 
   const KeyboardTest = (props: { nbRows?: number }) => {
-    const data = useData(props.nbRows || 100, 20);
+    const data = useData(props.nbRows || 20, 20);
     const transformColSizes = (columns: GridColumns) =>
       columns.map((column) => ({ ...column, width: 60 }));
 
     return (
       <div style={{ width: 300, height: 360 }}>
-        <DataGrid rows={data.rows} columns={transformColSizes(data.columns)} />
+        <DataGrid autoHeight rows={data.rows} columns={transformColSizes(data.columns)} />
       </div>
     );
   };
@@ -181,7 +174,7 @@ describe('<DataGrid /> - Keyboard', () => {
     getCell(0, 0).focus();
     expect(getActiveCell()).to.equal('0-0');
     fireEvent.keyDown(document.activeElement!, SPACE_KEY);
-    expect(getActiveCell()).to.equal('4-0');
+    expect(getActiveCell()).to.equal('19-0');
   });
 
   it('Space only should go to the bottom of the page even with small number of rows', () => {
@@ -192,7 +185,12 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(getActiveCell()).to.equal('3-0');
   });
 
-  it('Home / End navigation', async () => {
+  it('Home / End navigation', async function test() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting for column virtualization
+      this.skip();
+    }
+
     render(<KeyboardTest />);
     getCell(1, 1).focus();
     expect(getActiveCell()).to.equal('1-1');

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -464,13 +464,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
   });
 
   describe('localeText', () => {
-    before(function beforeHook() {
-      if (/jsdom/.test(window.navigator.userAgent)) {
-        // Need layouting
-        this.skip();
-      }
-    });
-
     it('should replace the density selector button label text to "Size"', () => {
       const { getByText } = render(
         <div style={{ width: 300, height: 300 }}>
@@ -489,13 +482,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
   });
 
   describe('Error', () => {
-    before(function beforeHook() {
-      if (/jsdom/.test(window.navigator.userAgent)) {
-        // Need layouting
-        this.skip();
-      }
-    });
-
     it('should display error message when error prop set', () => {
       const message = 'Error can also be set in props!';
       render(

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -40,6 +40,13 @@ describe('<DataGrid /> - Pagination', () => {
   };
 
   describe('pagination', () => {
+    before(function beforeHook() {
+      if (/jsdom/.test(window.navigator.userAgent)) {
+        // Need layouting
+        this.skip();
+      }
+    });
+
     it('should apply the page prop correctly', () => {
       const rows = [
         {

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -40,13 +40,6 @@ describe('<DataGrid /> - Pagination', () => {
   };
 
   describe('pagination', () => {
-    before(function beforeHook() {
-      if (/jsdom/.test(window.navigator.userAgent)) {
-        // Need layouting
-        this.skip();
-      }
-    });
-
     it('should apply the page prop correctly', () => {
       const rows = [
         {

--- a/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
@@ -10,14 +10,14 @@ import Portal from '@material-ui/core/Portal';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Rows', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: NO_LAYOUT,
+    autoHeight: isJSDOM,
     rows: [
       {
         clientId: 'c1',

--- a/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
@@ -15,6 +15,7 @@ describe('<DataGrid /> - Rows', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: true,
     rows: [
       {
         clientId: 'c1',
@@ -34,13 +35,6 @@ describe('<DataGrid /> - Rows', () => {
     ],
     columns: [{ field: 'clientId' }, { field: 'first' }, { field: 'age' }],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   describe('getRowId', () => {
     it('should allow to select a field as id', () => {

--- a/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
@@ -10,12 +10,14 @@ import Portal from '@material-ui/core/Portal';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Rows', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: /jsdom/.test(window.navigator.userAgent),
+    autoHeight: NO_LAYOUT,
     rows: [
       {
         clientId: 'c1',

--- a/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
@@ -15,7 +15,7 @@ describe('<DataGrid /> - Rows', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: true,
+    autoHeight: /jsdom/.test(window.navigator.userAgent),
     rows: [
       {
         clientId: 'c1',

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -10,18 +10,12 @@ describe('<DataGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   describe('prop: checkboxSelection', () => {
     it('should check and uncheck when double clicking the row', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
+            autoHeight
             rows={[
               {
                 id: 0,
@@ -51,7 +45,12 @@ describe('<DataGrid /> - Selection', () => {
     it('with no rows, the checkbox should not be checked', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid rows={[]} checkboxSelection columns={[{ field: 'brand', width: 100 }]} />
+          <DataGrid
+            autoHeight
+            rows={[]}
+            checkboxSelection
+            columns={[{ field: 'brand', width: 100 }]}
+          />
         </div>,
       );
       const selectAll = screen.getByRole('checkbox', {
@@ -66,6 +65,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
+            autoHeight
             rows={[
               {
                 id: 0,
@@ -102,7 +102,7 @@ describe('<DataGrid /> - Selection', () => {
       function Demo(props) {
         return (
           <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...data} selectionModel={props.selectionModel} />
+            <DataGrid autoHeight {...data} selectionModel={props.selectionModel} />
           </div>
         );
       }

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -6,7 +6,7 @@ import { spy } from 'sinon';
 import { DataGrid } from '@material-ui/data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
@@ -17,7 +17,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight={NO_LAYOUT}
+            autoHeight={isJSDOM}
             rows={[
               {
                 id: 0,
@@ -48,7 +48,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight={NO_LAYOUT}
+            autoHeight={isJSDOM}
             rows={[]}
             checkboxSelection
             columns={[{ field: 'brand', width: 100 }]}
@@ -67,7 +67,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight={NO_LAYOUT}
+            autoHeight={isJSDOM}
             rows={[
               {
                 id: 0,
@@ -104,7 +104,7 @@ describe('<DataGrid /> - Selection', () => {
       function Demo(props) {
         return (
           <div style={{ width: 300, height: 300 }}>
-            <DataGrid autoHeight={NO_LAYOUT} {...data} selectionModel={props.selectionModel} />
+            <DataGrid autoHeight={isJSDOM} {...data} selectionModel={props.selectionModel} />
           </div>
         );
       }

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -6,6 +6,8 @@ import { spy } from 'sinon';
 import { DataGrid } from '@material-ui/data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
@@ -15,7 +17,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight
+            autoHeight={NO_LAYOUT}
             rows={[
               {
                 id: 0,
@@ -46,7 +48,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight
+            autoHeight={NO_LAYOUT}
             rows={[]}
             checkboxSelection
             columns={[{ field: 'brand', width: 100 }]}
@@ -65,7 +67,7 @@ describe('<DataGrid /> - Selection', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
           <DataGrid
-            autoHeight
+            autoHeight={NO_LAYOUT}
             rows={[
               {
                 id: 0,
@@ -102,7 +104,7 @@ describe('<DataGrid /> - Selection', () => {
       function Demo(props) {
         return (
           <div style={{ width: 300, height: 300 }}>
-            <DataGrid autoHeight {...data} selectionModel={props.selectionModel} />
+            <DataGrid autoHeight={NO_LAYOUT} {...data} selectionModel={props.selectionModel} />
           </div>
         );
       }

--- a/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -10,12 +10,14 @@ import { expect } from 'chai';
 import { DataGrid, DataGridProps } from '@material-ui/data-grid';
 import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Sorting', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: true,
+    autoHeight: NO_LAYOUT,
     rows: [
       {
         id: 0,
@@ -42,7 +44,7 @@ describe('<DataGrid /> - Sorting', () => {
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid autoHeight columns={cols} rows={rows} />
+        <DataGrid autoHeight={NO_LAYOUT} columns={cols} rows={rows} />
       </div>,
     );
     expect(getColumnValues()).to.deep.equal(['10', '0', '5']);
@@ -55,7 +57,7 @@ describe('<DataGrid /> - Sorting', () => {
     function Demo(props) {
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid autoHeight columns={cols} sortingMode="server" {...props} />
+          <DataGrid autoHeight={NO_LAYOUT} columns={cols} sortingMode="server" {...props} />
         </div>
       );
     }
@@ -191,7 +193,7 @@ describe('<DataGrid /> - Sorting', () => {
       const { rows, columns } = props;
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid autoHeight rows={rows} columns={columns} />
+          <DataGrid autoHeight={NO_LAYOUT} rows={rows} columns={columns} />
         </div>
       );
     };

--- a/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -8,13 +8,14 @@ import {
 } from 'test/utils';
 import { expect } from 'chai';
 import { DataGrid, DataGridProps } from '@material-ui/data-grid';
-import { getColumnValues } from 'test/utils/helperFn';
+import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
 
 describe('<DataGrid /> - Sorting', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: true,
     rows: [
       {
         id: 0,
@@ -35,20 +36,13 @@ describe('<DataGrid /> - Sorting', () => {
     columns: [{ field: 'brand' }, { field: 'isPublished', type: 'boolean' }],
   };
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   it('should keep the initial order', () => {
     const cols = [{ field: 'id' }];
     const rows = [{ id: 10 }, { id: 0 }, { id: 5 }];
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid columns={cols} rows={rows} />
+        <DataGrid autoHeight columns={cols} rows={rows} />
       </div>,
     );
     expect(getColumnValues()).to.deep.equal(['10', '0', '5']);
@@ -61,7 +55,7 @@ describe('<DataGrid /> - Sorting', () => {
     function Demo(props) {
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid columns={cols} sortingMode="server" {...props} />
+          <DataGrid autoHeight columns={cols} sortingMode="server" {...props} />
         </div>
       );
     }
@@ -78,9 +72,7 @@ describe('<DataGrid /> - Sorting', () => {
         <DataGrid {...baselineProps} />
       </div>,
     );
-    const header = screen
-      .getByRole('columnheader', { name: 'brand' })
-      .querySelector('.MuiDataGrid-colCellTitleContainer');
+    const header = getColumnHeaderCell(1);
     expect(getColumnValues()).to.deep.equal(['Nike', 'Adidas', 'Puma']);
     fireEvent.click(header);
     expect(getColumnValues()).to.deep.equal(['Adidas', 'Nike', 'Puma']);
@@ -199,7 +191,7 @@ describe('<DataGrid /> - Sorting', () => {
       const { rows, columns } = props;
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid rows={rows} columns={columns} />
+          <DataGrid autoHeight rows={rows} columns={columns} />
         </div>
       );
     };

--- a/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -10,14 +10,14 @@ import { expect } from 'chai';
 import { DataGrid, DataGridProps } from '@material-ui/data-grid';
 import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Sorting', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: NO_LAYOUT,
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,
@@ -44,7 +44,7 @@ describe('<DataGrid /> - Sorting', () => {
 
     render(
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid autoHeight={NO_LAYOUT} columns={cols} rows={rows} />
+        <DataGrid autoHeight={isJSDOM} columns={cols} rows={rows} />
       </div>,
     );
     expect(getColumnValues()).to.deep.equal(['10', '0', '5']);
@@ -57,7 +57,7 @@ describe('<DataGrid /> - Sorting', () => {
     function Demo(props) {
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid autoHeight={NO_LAYOUT} columns={cols} sortingMode="server" {...props} />
+          <DataGrid autoHeight={isJSDOM} columns={cols} sortingMode="server" {...props} />
         </div>
       );
     }
@@ -193,7 +193,7 @@ describe('<DataGrid /> - Sorting', () => {
       const { rows, columns } = props;
       return (
         <div style={{ width: 300, height: 300 }}>
-          <DataGrid autoHeight={NO_LAYOUT} rows={rows} columns={columns} />
+          <DataGrid autoHeight={isJSDOM} rows={rows} columns={columns} />
         </div>
       );
     };

--- a/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
@@ -9,7 +9,7 @@ describe('<DataGrid /> - State', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: true,
+    autoHeight: /jsdom/.test(window.navigator.userAgent),
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
@@ -4,12 +4,14 @@ import { expect } from 'chai';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - State', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: /jsdom/.test(window.navigator.userAgent),
+    autoHeight: NO_LAYOUT,
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
@@ -4,14 +4,14 @@ import { expect } from 'chai';
 import { DataGrid } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - State', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: NO_LAYOUT,
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
@@ -9,6 +9,7 @@ describe('<DataGrid /> - State', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: true,
     rows: [
       {
         id: 0,
@@ -25,13 +26,6 @@ describe('<DataGrid /> - State', () => {
     ],
     columns: [{ field: 'brand' }],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   it('should allow to control the state using useState', async () => {
     function GridStateTest({ direction, sortedRows }) {

--- a/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/state.DataGrid.test.tsx
@@ -27,7 +27,7 @@ describe('<DataGrid /> - State', () => {
     columns: [{ field: 'brand' }],
   };
 
-  it('should allow to control the state using useState', async () => {
+  it('should allow to control the state using useState', () => {
     function GridStateTest({ direction, sortedRows }) {
       const gridState = {
         sorting: { sortModel: [{ field: 'brand', sort: direction }], sortedRows },

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -44,7 +44,7 @@ describe('<DataGrid /> - Toolbar', () => {
     ],
   };
 
-  describe('Density selector', () => {
+  describe('density selector', () => {
     it('should increase grid density when selecting compact density', () => {
       const rowHeight = 30;
       const { getByText } = render(
@@ -120,7 +120,7 @@ describe('<DataGrid /> - Toolbar', () => {
     });
   });
 
-  describe('Column selector', () => {
+  describe('column selector', () => {
     it('should hide "id" column when hiding it from the column selector', () => {
       const { getByText } = render(
         <div style={{ width: 300, height: 300 }}>

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -14,12 +14,14 @@ import {
   COMPACT_DENSITY_FACTOR,
 } from 'packages/grid/_modules_/grid/hooks/features/density/useGridDensity';
 
+const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Toolbar', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: /jsdom/.test(window.navigator.userAgent),
+    autoHeight: NO_LAYOUT,
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -19,7 +19,7 @@ describe('<DataGrid /> - Toolbar', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: true,
+    autoHeight: /jsdom/.test(window.navigator.userAgent),
     rows: [
       {
         id: 0,

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -19,6 +19,7 @@ describe('<DataGrid /> - Toolbar', () => {
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: true,
     rows: [
       {
         id: 0,
@@ -42,13 +43,6 @@ describe('<DataGrid /> - Toolbar', () => {
       },
     ],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   describe('Density selector', () => {
     it('should increase grid density when selecting compact density', () => {

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -14,14 +14,14 @@ import {
   COMPACT_DENSITY_FACTOR,
 } from 'packages/grid/_modules_/grid/hooks/features/density/useGridDensity';
 
-const NO_LAYOUT = /jsdom/.test(window.navigator.userAgent);
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<DataGrid /> - Toolbar', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
-    autoHeight: NO_LAYOUT,
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -14,20 +14,16 @@ import {
   fireEvent,
 } from 'test/utils';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Edit Rows', () => {
   let baselineProps;
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
   beforeEach(() => {
     baselineProps = {
+      autoHeight: isJSDOM,
       rows: [
         {
           id: 0,
@@ -58,12 +54,7 @@ describe('<XGrid /> - Edit Rows', () => {
     apiRef = useGridApiRef();
     return (
       <div style={{ width: 300, height: 300 }}>
-        <XGrid
-          apiRef={apiRef}
-          columns={baselineProps.columns}
-          rows={baselineProps.rows}
-          {...props}
-        />
+        <XGrid {...baselineProps} apiRef={apiRef} {...props} />
       </div>
     );
   };

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -54,11 +54,7 @@ describe('<XGrid /> - Edit Rows', () => {
     apiRef = useGridApiRef();
     return (
       <div style={{ width: 300, height: 300 }}>
-        <XGrid
-          {...baselineProps}
-          apiRef={apiRef}
-          {...props}
-        />
+        <XGrid {...baselineProps} apiRef={apiRef} {...props} />
       </div>
     );
   };

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -54,7 +54,11 @@ describe('<XGrid /> - Edit Rows', () => {
     apiRef = useGridApiRef();
     return (
       <div style={{ width: 300, height: 300 }}>
-        <XGrid {...baselineProps} apiRef={apiRef} {...props} />
+        <XGrid
+          {...baselineProps}
+          apiRef={apiRef}
+          {...props}
+        />
       </div>
     );
   };

--- a/packages/grid/x-grid/src/tests/events.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/events.XGrid.test.tsx
@@ -120,14 +120,11 @@ describe('<XGrid /> - Events Params', () => {
     let eventArgs: { params: GridCellParams; event: React.MouseEvent } | null = null;
     let cell11;
 
-    beforeEach(() => {
+    it('should include the correct params', () => {
       const handleClick = (params, event) => {
         eventArgs = { params, event };
       };
       render(<TestEvents onCellClick={handleClick} />);
-    });
-
-    it('should include the correct params', () => {
       cell11 = getCell(1, 1);
       fireEvent.click(cell11);
 
@@ -146,6 +143,10 @@ describe('<XGrid /> - Events Params', () => {
     });
 
     it('should include the correct params when grid is sorted', () => {
+      const handleClick = (params, event) => {
+        eventArgs = { params, event };
+      };
+      render(<TestEvents onCellClick={handleClick} />);
       const header = screen
         .getByRole('columnheader', { name: 'first' })
         .querySelector('.MuiDataGrid-colCellTitleContainer');
@@ -169,6 +170,10 @@ describe('<XGrid /> - Events Params', () => {
     });
 
     it('should consider value getter', () => {
+      const handleClick = (params, event) => {
+        eventArgs = { params, event };
+      };
+      render(<TestEvents onCellClick={handleClick} />);
       const cellFirstAge = getCell(1, 3);
       fireEvent.click(cellFirstAge);
 
@@ -176,6 +181,10 @@ describe('<XGrid /> - Events Params', () => {
     });
 
     it('should consider value formatter', () => {
+      const handleClick = (params, event) => {
+        eventArgs = { params, event };
+      };
+      render(<TestEvents onCellClick={handleClick} />);
       const cellFirstAge = getCell(1, 3);
       fireEvent.click(cellFirstAge);
 

--- a/packages/grid/x-grid/src/tests/export.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/export.XGrid.test.tsx
@@ -3,16 +3,15 @@ import { expect } from 'chai';
 import * as React from 'react';
 import { createClientRenderStrictMode } from 'test/utils';
 
-describe('<XGrid /> - Export', () => {
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
+describe('<XGrid /> - Export', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
+
+  const baselineProps = {
+    autoHeight: isJSDOM,
+  };
 
   let apiRef: GridApiRef;
 
@@ -22,6 +21,7 @@ describe('<XGrid /> - Export', () => {
       return (
         <div style={{ width: 300, height: 300 }}>
           <XGrid
+            {...baselineProps}
             apiRef={apiRef}
             columns={[{ field: 'brand', headerName: 'Brand' }]}
             rows={[
@@ -60,6 +60,7 @@ describe('<XGrid /> - Export', () => {
       return (
         <div style={{ width: 300, height: 300 }}>
           <XGrid
+            {...baselineProps}
             apiRef={apiRef}
             columns={[{ field: 'brand', headerName: 'Brand' }]}
             rows={[
@@ -87,6 +88,7 @@ describe('<XGrid /> - Export', () => {
       return (
         <div style={{ width: 300, height: 300 }}>
           <XGrid
+            {...baselineProps}
             apiRef={apiRef}
             columns={[{ field: 'brand', headerName: 'Brand' }]}
             rows={[

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -23,6 +23,8 @@ import {
 } from 'test/utils';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Filter', () => {
   let clock;
 
@@ -37,17 +39,11 @@ describe('<XGrid /> - Filter', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   let apiRef: GridApiRef;
 
   const TestCase = (props: Partial<GridComponentProps>) => {
     const baselineProps = {
+      autoHeight: isJSDOM,
       rows: [
         {
           id: 0,

--- a/packages/grid/x-grid/src/tests/pagination.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/pagination.XGrid.test.tsx
@@ -7,11 +7,14 @@ import * as React from 'react';
 import { expect } from 'chai';
 import { XGrid, useGridApiRef } from '@material-ui/x-grid';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Pagination', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,
@@ -28,13 +31,6 @@ describe('<XGrid /> - Pagination', () => {
     ],
     columns: [{ field: 'brand', width: 100 }],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   it('should apply setPage correctly', () => {
     let apiRef;

--- a/packages/grid/x-grid/src/tests/reorder.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/reorder.XGrid.test.tsx
@@ -17,11 +17,14 @@ import {
 } from 'test/utils/helperFn';
 import { GridApiRef, useGridApiRef, XGrid } from '@material-ui/x-grid';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Reorder', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,
@@ -34,13 +37,6 @@ describe('<XGrid /> - Reorder', () => {
     ],
     columns: [{ field: 'id' }, { field: 'brand' }],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   describe('Columns', () => {
     it('resizing after columns reorder should respect the new columns order', async () => {

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -5,7 +5,6 @@ import { expect } from 'chai';
 import { getCell, getColumnValues } from 'test/utils/helperFn';
 import {
   GridApiRef,
-  GridColDef,
   GridComponentProps,
   GridRowData,
   useGridApiRef,
@@ -14,25 +13,21 @@ import {
 } from '@material-ui/x-grid';
 import { useData } from 'packages/storybook/src/hooks/useData';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Rows', () => {
   let clock;
-  let baselineProps: { columns: GridColDef[]; rows: GridRowData[] };
+  let baselineProps;
 
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   describe('getRowId', () => {
     beforeEach(() => {
       clock = useFakeTimers();
 
       baselineProps = {
+        autoHeight: isJSDOM,
         rows: [
           {
             clientId: 'c1',
@@ -131,6 +126,7 @@ describe('<XGrid /> - Rows', () => {
       clock = useFakeTimers();
 
       baselineProps = {
+        autoHeight: isJSDOM,
         rows: [
           {
             id: 0,
@@ -159,12 +155,7 @@ describe('<XGrid /> - Rows', () => {
       apiRef = useGridApiRef();
       return (
         <div style={{ width: 300, height: 300 }}>
-          <XGrid
-            apiRef={apiRef}
-            columns={baselineProps.columns}
-            rows={baselineProps.rows}
-            {...props}
-          />
+          <XGrid {...baselineProps} apiRef={apiRef} {...props} />
         </div>
       );
     };
@@ -245,8 +236,8 @@ describe('<XGrid /> - Rows', () => {
         return (
           <div style={{ width: 300, height: 300 }}>
             <XGrid
+              {...baselineProps}
               apiRef={apiRef}
-              columns={baselineProps.columns}
               rows={baselineProps.rows.map((row) => ({ idField: row.id, brand: row.brand }))}
               getRowId={getRowId}
             />
@@ -268,6 +259,13 @@ describe('<XGrid /> - Rows', () => {
   });
 
   describe('virtualization', () => {
+    before(function beforeHook() {
+      if (isJSDOM) {
+        // Need layouting
+        this.skip();
+      }
+    });
+
     let apiRef: GridApiRef;
     const TestCaseVirtualization = (
       props: Partial<XGridProps> & { nbRows?: number; nbCols?: number; height?: number },

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -4,20 +4,16 @@ import { expect } from 'chai';
 import { spy } from 'sinon';
 import { GridApiRef, GridComponentProps, useGridApiRef, XGrid } from '@material-ui/x-grid';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   let apiRef: GridApiRef;
 
   const baselineProps = {
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -15,6 +15,8 @@ import {
 } from 'test/utils';
 import { useData } from 'packages/storybook/src/hooks/useData';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - Sorting', () => {
   let clock;
 
@@ -29,13 +31,6 @@ describe('<XGrid /> - Sorting', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
-
   let apiRef: GridApiRef;
 
   const TestCase = (props: {
@@ -44,6 +39,7 @@ describe('<XGrid /> - Sorting', () => {
     disableMultipleColumnsSorting?: boolean;
   }) => {
     const baselineProps = {
+      autoHeight: isJSDOM,
       rows: [
         {
           id: 0,

--- a/packages/grid/x-grid/src/tests/state.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/state.XGrid.test.tsx
@@ -5,11 +5,14 @@ import { getColumnValues } from 'test/utils/helperFn';
 import { expect } from 'chai';
 import { XGrid, useGridApiRef } from '@material-ui/x-grid';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<XGrid /> - State', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
   const baselineProps = {
+    autoHeight: isJSDOM,
     rows: [
       {
         id: 0,
@@ -26,13 +29,6 @@ describe('<XGrid /> - State', () => {
     ],
     columns: [{ field: 'brand', width: 100 }],
   };
-
-  before(function beforeHook() {
-    if (/jsdom/.test(window.navigator.userAgent)) {
-      // Need layouting
-      this.skip();
-    }
-  });
 
   it('should trigger on state change and pass the correct params', () => {
     let onStateParams;

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -9,6 +9,16 @@ export const createClientRenderStrictMode = () => {
   const strictTheme = unstable_createMuiStrictModeTheme();
   const Wrapper = (props) => <ThemeProvider theme={strictTheme} {...props} />;
 
+  // @material-ui/styles leak in strict mode. We leave a growing number of style in the head.
+  // It significantly slowdown the tests in watch mode (linear growth with rerun).
+  // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
+  // TODO v5: remove
+  afterEach(() => {
+    Array.from(document.querySelectorAll('style')).forEach((style) => {
+      document.head.removeChild(style);
+    });
+  });
+
   return (element: React.ReactElement, options = {}) =>
     render(element, {
       wrapper: Wrapper,

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -9,15 +9,20 @@ export const createClientRenderStrictMode = () => {
   const strictTheme = unstable_createMuiStrictModeTheme();
   const Wrapper = (props) => <ThemeProvider theme={strictTheme} {...props} />;
 
-  // @material-ui/styles leak in strict mode. We leave a growing number of style in the head.
-  // It significantly slowdown the tests in watch mode (linear growth with rerun).
-  // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
-  // TODO v5: remove
-  // after(() => {
-  //   Array.from(document.querySelectorAll('style')).forEach((style) => {
-  //     document.head.removeChild(style);
-  //   });
-  // });
+  const isKarma = Boolean(process.env.KARMA);
+
+  // Doesn't work in Karma, unclear why
+  if (!isKarma) {
+    // @material-ui/styles leak in strict mode. We leave a growing number of style in the head.
+    // It significantly slowdown the tests in watch mode (linear growth with rerun).
+    // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
+    // TODO v5: remove
+    after(() => {
+      Array.from(document.querySelectorAll('style')).forEach((style) => {
+        document.head.removeChild(style);
+      });
+    });
+  }
 
   return (element: React.ReactElement, options = {}) =>
     render(element, {

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -13,12 +13,11 @@ export const createClientRenderStrictMode = () => {
   // It significantly slowdown the tests in watch mode (linear growth with rerun).
   // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
   // TODO v5: remove
-  // @ts-expect-error need to remove jest
-  after(() => {
-    Array.from(document.querySelectorAll('style')).forEach((style) => {
-      document.head.removeChild(style);
-    });
-  });
+  // after(() => {
+  //   Array.from(document.querySelectorAll('style')).forEach((style) => {
+  //     document.head.removeChild(style);
+  //   });
+  // });
 
   return (element: React.ReactElement, options = {}) =>
     render(element, {

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -13,6 +13,7 @@ export const createClientRenderStrictMode = () => {
   // It significantly slowdown the tests in watch mode (linear growth with rerun).
   // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
   // TODO v5: remove
+  // @ts-expect-error need to remove jest
   after(() => {
     Array.from(document.querySelectorAll('style')).forEach((style) => {
       document.head.removeChild(style);

--- a/test/utils/index.tsx
+++ b/test/utils/index.tsx
@@ -13,7 +13,7 @@ export const createClientRenderStrictMode = () => {
   // It significantly slowdown the tests in watch mode (linear growth with rerun).
   // It's similar to why https://github.com/mui-org/material-ui/pull/24837.
   // TODO v5: remove
-  afterEach(() => {
+  after(() => {
     Array.from(document.querySelectorAll('style')).forEach((style) => {
       document.head.removeChild(style);
     });


### PR DESCRIPTION
Work on #1151:

- Fix the autosize warnings for jsdom
- Workaround jsdom/jsdom#1422 by replacing .scrollTo(x, y) with .scrollLeft and .scrollTop.
- Set more constraints in the CI so we don't introduce unknown regression

We go from 2% of coverage

<img width="192" alt="Screenshot 2021-04-24 at 17 01 30" src="https://user-images.githubusercontent.com/3165635/115963172-c0f7cf80-a51e-11eb-8534-6555a6c5158e.png">

to 69% of coverage

<img width="181" alt="Screenshot 2021-04-24 at 17 19 45" src="https://user-images.githubusercontent.com/3165635/115963811-4d0af680-a521-11eb-88d9-fbf12f69edd0.png">

for tests running in jsdom.

---

Two issues I didn't spend time on here. I'm breaking them down into two new PRs.

- [x] Setting the license key doesn't work in watch mode: #1384

```jsx
import { LicenseInfo } from '@material-ui/x-grid';

LicenseInfo.setLicenseKey(
  '0f94d8b65161817ca5d7f7af8ac2f042T1JERVI6TVVJLVN0b3J5Ym9vayxFWFBJUlk9MTY1NDg1ODc1MzU1MCxLRVlWRVJTSU9OPTE=',
);
```

  I wouldn't be surprised if this impacts developers in their project too. Not great

- [ ] In the main repo, we have a `yarn t xxxx` script to only run a specific test, really fast. It would be great to bring it here. #1385