### PR TITLE
[DataGrid] Fix autoPageSize

### DIFF
--- a/packages/grid/_modules_/grid/hooks/root/useGridContainerProps.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useGridContainerProps.ts
@@ -35,13 +35,14 @@ export const useGridContainerProps = (
 
   const getVirtualRowCount = React.useCallback(() => {
     logger.debug('Calculating virtual row count.');
-    if (options.pagination) {
+    if (options.pagination && !options.autoPageSize) {
       const rowsLeft = visibleRowsCount - paginationState.page * paginationState.pageSize;
       return rowsLeft > paginationState.pageSize ? paginationState.pageSize : rowsLeft;
     }
     return visibleRowsCount;
   }, [
     logger,
+    options.autoPageSize,
     options.pagination,
     paginationState.page,
     paginationState.pageSize,
@@ -140,7 +141,7 @@ export const useGridContainerProps = (
         const requiredHeight = viewportPageSize * rowHeight + scrollBarState.scrollBarSize.x;
 
         const indexes: GridContainerProps = {
-          isVirtualized,
+          isVirtualized: false,
           virtualRowsCount: viewportPageSize,
           renderingZonePageSize: viewportPageSize,
           viewportPageSize,

--- a/packages/grid/_modules_/grid/models/gridContainerProps.ts
+++ b/packages/grid/_modules_/grid/models/gridContainerProps.ts
@@ -29,7 +29,7 @@ export interface GridContainerProps {
    */
   isVirtualized: boolean;
   /**
-   * The maximum number of rows that will be rendered at any given time in the grid.
+   * The number of rows that fit in the rendering zone.
    */
   renderingZonePageSize: number;
   /**
@@ -37,7 +37,7 @@ export interface GridContainerProps {
    */
   viewportPageSize: number;
   /**
-   * The number of rows allocated for the rendered zone.
+   * The total number of rows that are scrollable in the viewport. If pagination then it would be page size. If not, it would be the full set of rows.
    */
   virtualRowsCount: number;
   /**

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -196,19 +196,12 @@ describe('<DataGrid /> - Pagination', () => {
 
     describe('prop: autoPageSize', () => {
       it('should always render the same amount of rows and fit the viewport', () => {
-        const TestCaseAutoPageSize = (
-          props: { nbRows: number; height?: number },
-        ) => {
-          const data = useData(props.nbRows,  10);
+        const TestCaseAutoPageSize = (props: { nbRows: number; height?: number }) => {
+          const data = useData(props.nbRows, 10);
 
           return (
             <div style={{ width: 300, height: props.height }}>
-              <DataGrid
-                columns={data.columns}
-                rows={data.rows}
-                autoPageSize
-                pagination
-              />
+              <DataGrid columns={data.columns} rows={data.rows} autoPageSize pagination />
             </div>
           );
         };

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -194,21 +194,20 @@ describe('<DataGrid /> - Pagination', () => {
       expect(getColumnValues()).to.deep.equal(['Nike 1']);
     });
 
-    describe('AutoPageSize', () => {
+    describe('prop: autoPageSize', () => {
       it('should always render the same amount of rows and fit the viewport', () => {
         const TestCaseAutoPageSize = (
-          props: Partial<DataGridProps> & { nbRows?: number; nbCols?: number; height?: number },
+          props: { nbRows: number; height?: number },
         ) => {
-          const data = useData(props.nbRows || 100, props.nbCols || 10);
+          const data = useData(props.nbRows,  10);
 
           return (
-            <div style={{ width: 300, height: props.height || 300 }}>
+            <div style={{ width: 300, height: props.height }}>
               <DataGrid
                 columns={data.columns}
                 rows={data.rows}
                 autoPageSize
                 pagination
-                {...props}
               />
             </div>
           );

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -213,14 +213,16 @@ describe('<DataGrid /> - Pagination', () => {
             </div>
           );
         };
-        const height = 780;
-        const footerHeight = 52;
         const nbRows = 27;
+        const height = 780;
+        render(<TestCaseAutoPageSize nbRows={nbRows} height={height} />);
+
+        const footerHeight = document.querySelector('.MuiDataGrid-footer')!.clientHeight;
         const expectedViewportRowsLength = Math.floor(
           (height - DEFAULT_GRID_OPTIONS.headerHeight - footerHeight) /
             DEFAULT_GRID_OPTIONS.rowHeight,
         );
-        render(<TestCaseAutoPageSize nbRows={nbRows} height={height} />);
+
         let rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
         expect(rows.length).to.equal(expectedViewportRowsLength);
 
@@ -236,6 +238,13 @@ describe('<DataGrid /> - Pagination', () => {
         fireEvent.click(screen.getByRole('button', { name: /next page/i }));
         rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
         expect(rows.length).to.equal(nbRows % expectedViewportRowsLength);
+
+        // make sure there is no more pages.
+        const nextPageBtn = document.querySelector('.MuiTablePagination-actions button:last-child');
+        expect(nextPageBtn!.getAttribute('disabled')).to.not.equal(
+          null,
+          'next page should be disabled.',
+        );
       });
     });
   });

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -10,6 +10,7 @@ import { expect } from 'chai';
 import { DataGrid, DataGridProps, GridRowsProp } from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
+import { useData } from 'packages/storybook/src/hooks/useData';
 
 describe('<DataGrid /> - Pagination', () => {
   // TODO v5: replace with createClientRender
@@ -186,6 +187,44 @@ describe('<DataGrid /> - Pagination', () => {
       expect(getColumnValues()).to.deep.equal(['Nike 0']);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       expect(getColumnValues()).to.deep.equal(['Nike 1']);
+    });
+
+    describe('AutoPageSize', () => {
+      it('should always render the same amount of rows and fit the viewport', () => {
+        const TestCaseAutoPageSize = (
+          props: Partial<DataGridProps> & { nbRows?: number; nbCols?: number; height?: number },
+        ) => {
+          const data = useData(props.nbRows || 100, props.nbCols || 10);
+
+          return (
+            <div style={{ width: 300, height: props.height || 300 }}>
+              <DataGrid
+                columns={data.columns}
+                rows={data.rows}
+                autoPageSize
+                pagination
+                {...props}
+              />
+            </div>
+          );
+        };
+        render(<TestCaseAutoPageSize nbRows={27} height={800} />);
+        let rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
+        expect(rows.length).to.equal(12);
+
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
+        expect(rows.length).to.equal(12);
+
+        fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
+        rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
+        expect(rows.length).to.equal(12);
+
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+        rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
+        expect(rows.length).to.equal(3);
+      });
     });
   });
 });

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -208,7 +208,7 @@ describe('<DataGrid /> - Pagination', () => {
             </div>
           );
         };
-        render(<TestCaseAutoPageSize nbRows={27} height={800} />);
+        render(<TestCaseAutoPageSize nbRows={27} height={780} />);
         let rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
         expect(rows.length).to.equal(12);
 

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -7,7 +7,12 @@ import {
   screen,
 } from 'test/utils';
 import { expect } from 'chai';
-import { DataGrid, DataGridProps, GridRowsProp } from '@material-ui/data-grid';
+import {
+  DataGrid,
+  DataGridProps,
+  DEFAULT_GRID_OPTIONS,
+  GridRowsProp,
+} from '@material-ui/data-grid';
 import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
 import { useData } from 'packages/storybook/src/hooks/useData';
@@ -208,22 +213,29 @@ describe('<DataGrid /> - Pagination', () => {
             </div>
           );
         };
-        render(<TestCaseAutoPageSize nbRows={27} height={780} />);
+        const height = 780;
+        const footerHeight = 52;
+        const nbRows = 27;
+        const expectedViewportRowsLength = Math.floor(
+          (height - DEFAULT_GRID_OPTIONS.headerHeight - footerHeight) /
+            DEFAULT_GRID_OPTIONS.rowHeight,
+        );
+        render(<TestCaseAutoPageSize nbRows={nbRows} height={height} />);
         let rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
-        expect(rows.length).to.equal(12);
+        expect(rows.length).to.equal(expectedViewportRowsLength);
 
         fireEvent.click(screen.getByRole('button', { name: /next page/i }));
         rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
-        expect(rows.length).to.equal(12);
+        expect(rows.length).to.equal(expectedViewportRowsLength);
 
         fireEvent.click(screen.getByRole('button', { name: /previous page/i }));
         rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
-        expect(rows.length).to.equal(12);
+        expect(rows.length).to.equal(expectedViewportRowsLength);
 
         fireEvent.click(screen.getByRole('button', { name: /next page/i }));
         fireEvent.click(screen.getByRole('button', { name: /next page/i }));
         rows = document.querySelectorAll('.MuiDataGrid-viewport [role="row"]');
-        expect(rows.length).to.equal(3);
+        expect(rows.length).to.equal(nbRows % expectedViewportRowsLength);
       });
     });
   });

--- a/packages/storybook/src/stories/grid-pagination.stories.tsx
+++ b/packages/storybook/src/stories/grid-pagination.stories.tsx
@@ -43,10 +43,11 @@ export function PageSize100() {
   );
 }
 
-export const PaginationArgs: Story = (args) => {
-  const data = useData(200, 20);
+export const PaginationArgs: Story = (props) => {
+  const { rowCount, ...others } = props;
+  const data = useData(rowCount, 20);
 
-  return <XGrid rows={data.rows} columns={data.columns} {...args} />;
+  return <XGrid rows={data.rows} columns={data.columns} {...others} />;
 };
 PaginationArgs.args = {
   pagination: true,
@@ -437,6 +438,30 @@ export function CommodityAutoPageSizeSnap() {
   return (
     <div className="grid-container">
       <DataGrid rows={data.rows} columns={data.columns} pagination autoPageSize />
+    </div>
+  );
+}
+const xyRows = [
+  { id: 1, x: 1, y: 1 },
+  { id: 2, x: 1, y: 2 },
+  { id: 3, x: 1, y: 3 },
+  { id: 4, x: 1, y: 4 },
+  { id: 5, x: 1, y: 5 },
+  { id: 6, x: 1, y: 6 },
+  { id: 7, x: 1, y: 7 },
+  { id: 8, x: 1, y: 8 },
+  { id: 9, x: 1, y: 9 },
+];
+
+const xyColumns = [
+  { field: 'x', type: 'number' },
+  { field: 'y', type: 'number' },
+];
+
+export function SmallAutoPageSizeLastPageSnap() {
+  return (
+    <div style={{ height: 400, width: 400 }}>
+      <DataGrid pagination autoPageSize rows={xyRows} columns={xyColumns} page={1} />
     </div>
   );
 }


### PR DESCRIPTION
When autoPageSize is enabled, the pageSize prop value should not be used as it should be calculated according to the height of the viewport.

fix #1334 