### PR TITLE
[DataGrid] Add missing filter tooltip translations

### DIFF
--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -1,9 +1,9 @@
+import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import { capitalize } from '@material-ui/core/utils';
-import * as React from 'react';
 import { gridColumnLookupSelector } from '../../hooks/features/columns/gridColumnsSelector';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import {

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -19,7 +19,7 @@ import { GridApiContext } from '../GridApiContext';
 const useStyles = makeStyles(
   (theme) => ({
     list: {
-      margin: theme.spacing(1),
+      margin: theme.spacing(1, 1, 0.5),
       padding: theme.spacing(0, 1),
     },
   }),

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -37,11 +37,11 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
           {activeFilters.map((item) => ({
             ...(lookup[item.columnField!] && (
               <li key={item.id}>
-                {lookup[item.columnField!].headerName || item.columnField}{' '}
-                {apiRef!.current.getLocaleText(
+                {`${lookup[item.columnField!].headerName || item.columnField}
+                ${apiRef!.current.getLocaleText(
                   `filterOperator${capitalize(item.operatorValue!)}` as GridTranslationKeys,
-                )}{' '}
-                {item.value}
+                )}
+                ${item.value}`}
               </li>
             )),
           }))}

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -1,4 +1,4 @@
-import { makeStyles } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -16,14 +16,15 @@ import { optionsSelector } from '../../hooks/utils/optionsSelector';
 import { GridTranslationKeys } from '../../models/api/gridLocaleTextApi';
 import { GridApiContext } from '../GridApiContext';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    '& ul': {
+const useStyles = makeStyles(
+  (theme) => ({
+    list: {
       margin: theme.spacing(1),
       padding: theme.spacing(0, 1),
     },
-  },
-}));
+  }),
+  { name: 'MuiDataGridFilterButtonTooltipList' },
+);
 
 export const GridFilterToolbarButton: React.FC<{}> = () => {
   const classes = useStyles();
@@ -42,9 +43,9 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
       return apiRef!.current.getLocaleText('toolbarFiltersTooltipShow') as React.ReactElement;
     }
     return (
-      <div className={classes.root}>
+      <div>
         {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')(counter)}
-        <ul>
+        <ul className={classes.list}>
           {activeFilters.map((item) => ({
             ...(lookup[item.columnField!] && (
               <li key={item.id}>
@@ -77,7 +78,7 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
 
   const OpenFilterButtonIcon = apiRef!.current.components!.OpenFilterButtonIcon!;
   return (
-    <Tooltip open title={tooltipContentNode} enterDelay={1000}>
+    <Tooltip title={tooltipContentNode} enterDelay={1000}>
       <Button
         onClick={toggleFilter}
         size="small"

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -1,6 +1,7 @@
 import Badge from '@material-ui/core/Badge';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
+import { capitalize } from '@material-ui/core/utils';
 import * as React from 'react';
 import { gridColumnLookupSelector } from '../../hooks/features/columns/gridColumnsSelector';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
@@ -11,6 +12,7 @@ import {
 import { gridPreferencePanelStateSelector } from '../../hooks/features/preferencesPanel/gridPreferencePanelSelector';
 import { GridPreferencePanelsValue } from '../../hooks/features/preferencesPanel/gridPreferencePanelsValue';
 import { optionsSelector } from '../../hooks/utils/optionsSelector';
+import { GridTranslationKeys } from '../../models/api/gridLocaleTextApi';
 import { GridApiContext } from '../GridApiContext';
 
 export const GridFilterToolbarButton: React.FC<{}> = () => {
@@ -35,7 +37,10 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
           {activeFilters.map((item) => ({
             ...(lookup[item.columnField!] && (
               <li key={item.id}>
-                {lookup[item.columnField!].headerName || item.columnField} {item.operatorValue}{' '}
+                {lookup[item.columnField!].headerName || item.columnField}{' '}
+                {apiRef!.current.getLocaleText(
+                  `filterOperator${capitalize(item.operatorValue!)}` as GridTranslationKeys,
+                )}{' '}
                 {item.value}
               </li>
             )),

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -23,7 +23,7 @@ const useStyles = makeStyles(
       padding: theme.spacing(0, 1),
     },
   }),
-  { name: 'MuiDataGridFilterButtonTooltipList' },
+  { name: 'MuiDataGridFilterToolbarButton' },
 );
 
 export const GridFilterToolbarButton: React.FC<{}> = () => {

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -26,7 +26,10 @@ const useStyles = makeStyles(
   { name: 'MuiDataGridFilterToolbarButton' },
 );
 
-export const GridFilterToolbarButton: React.FC<{}> = () => {
+export const GridFilterToolbarButton = React.forwardRef<
+  HTMLButtonElement,
+  React.HTMLAttributes<HTMLButtonElement>
+>(function GridFilterToolbarButton(props, ref) {
   const classes = useStyles();
   const apiRef = React.useContext(GridApiContext);
   const options = useGridSelector(apiRef, optionsSelector);
@@ -50,10 +53,10 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
             ...(lookup[item.columnField!] && (
               <li key={item.id}>
                 {`${lookup[item.columnField!].headerName || item.columnField}
-                ${apiRef!.current.getLocaleText(
-                  `filterOperator${capitalize(item.operatorValue!)}` as GridTranslationKeys,
-                )}
-                ${item.value}`}
+                  ${apiRef!.current.getLocaleText(
+                    `filterOperator${capitalize(item.operatorValue!)}` as GridTranslationKeys,
+                  )}
+                  ${item.value}`}
               </li>
             )),
           }))}
@@ -80,6 +83,8 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
   return (
     <Tooltip title={tooltipContentNode} enterDelay={1000}>
       <Button
+        ref={ref}
+        {...props}
         onClick={toggleFilter}
         size="small"
         color="primary"
@@ -94,4 +99,4 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
       </Button>
     </Tooltip>
   );
-};
+});

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import Badge from '@material-ui/core/Badge';
-import Button from '@material-ui/core/Button';
+import Button, { ButtonProps } from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
 import { capitalize } from '@material-ui/core/utils';
 import { gridColumnLookupSelector } from '../../hooks/features/columns/gridColumnsSelector';
@@ -26,77 +26,76 @@ const useStyles = makeStyles(
   { name: 'MuiDataGridFilterToolbarButton' },
 );
 
-export const GridFilterToolbarButton = React.forwardRef<
-  HTMLButtonElement,
-  React.HTMLAttributes<HTMLButtonElement>
->(function GridFilterToolbarButton(props, ref) {
-  const classes = useStyles();
-  const apiRef = React.useContext(GridApiContext);
-  const options = useGridSelector(apiRef, optionsSelector);
-  const counter = useGridSelector(apiRef, filterGridItemsCounterSelector);
-  const activeFilters = useGridSelector(apiRef, activeGridFilterItemsSelector);
-  const lookup = useGridSelector(apiRef, gridColumnLookupSelector);
-  const preferencePanel = useGridSelector(apiRef, gridPreferencePanelStateSelector);
+export const GridFilterToolbarButton = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  function GridFilterToolbarButton(props, ref) {
+    const classes = useStyles();
+    const apiRef = React.useContext(GridApiContext);
+    const options = useGridSelector(apiRef, optionsSelector);
+    const counter = useGridSelector(apiRef, filterGridItemsCounterSelector);
+    const activeFilters = useGridSelector(apiRef, activeGridFilterItemsSelector);
+    const lookup = useGridSelector(apiRef, gridColumnLookupSelector);
+    const preferencePanel = useGridSelector(apiRef, gridPreferencePanelStateSelector);
 
-  const tooltipContentNode = React.useMemo(() => {
-    if (preferencePanel.open) {
-      return apiRef!.current.getLocaleText('toolbarFiltersTooltipHide') as React.ReactElement;
-    }
-    if (counter === 0) {
-      return apiRef!.current.getLocaleText('toolbarFiltersTooltipShow') as React.ReactElement;
-    }
-    return (
-      <div>
-        {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')(counter)}
-        <ul className={classes.list}>
-          {activeFilters.map((item) => ({
-            ...(lookup[item.columnField!] && (
-              <li key={item.id}>
-                {`${lookup[item.columnField!].headerName || item.columnField}
+    const tooltipContentNode = React.useMemo(() => {
+      if (preferencePanel.open) {
+        return apiRef!.current.getLocaleText('toolbarFiltersTooltipHide') as React.ReactElement;
+      }
+      if (counter === 0) {
+        return apiRef!.current.getLocaleText('toolbarFiltersTooltipShow') as React.ReactElement;
+      }
+      return (
+        <div>
+          {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')(counter)}
+          <ul className={classes.list}>
+            {activeFilters.map((item) => ({
+              ...(lookup[item.columnField!] && (
+                <li key={item.id}>
+                  {`${lookup[item.columnField!].headerName || item.columnField}
                   ${apiRef!.current.getLocaleText(
                     `filterOperator${capitalize(item.operatorValue!)}` as GridTranslationKeys,
                   )}
                   ${item.value}`}
-              </li>
-            )),
-          }))}
-        </ul>
-      </div>
-    );
-  }, [apiRef, preferencePanel.open, counter, activeFilters, lookup, classes]);
+                </li>
+              )),
+            }))}
+          </ul>
+        </div>
+      );
+    }, [apiRef, preferencePanel.open, counter, activeFilters, lookup, classes]);
 
-  const toggleFilter = React.useCallback(() => {
-    const { open, openedPanelValue } = preferencePanel;
-    if (open && openedPanelValue === GridPreferencePanelsValue.filters) {
-      apiRef!.current.hideFilterPanel();
-    } else {
-      apiRef!.current.showFilterPanel();
+    const toggleFilter = React.useCallback(() => {
+      const { open, openedPanelValue } = preferencePanel;
+      if (open && openedPanelValue === GridPreferencePanelsValue.filters) {
+        apiRef!.current.hideFilterPanel();
+      } else {
+        apiRef!.current.showFilterPanel();
+      }
+    }, [apiRef, preferencePanel]);
+
+    // Disable the button if the corresponding is disabled
+    if (options.disableColumnFilter) {
+      return null;
     }
-  }, [apiRef, preferencePanel]);
 
-  // Disable the button if the corresponding is disabled
-  if (options.disableColumnFilter) {
-    return null;
-  }
-
-  const OpenFilterButtonIcon = apiRef!.current.components!.OpenFilterButtonIcon!;
-  return (
-    <Tooltip title={tooltipContentNode} enterDelay={1000}>
-      <Button
-        ref={ref}
-        {...props}
-        onClick={toggleFilter}
-        size="small"
-        color="primary"
-        aria-label={apiRef!.current.getLocaleText('toolbarFiltersLabel')}
-        startIcon={
-          <Badge badgeContent={counter} color="primary">
-            <OpenFilterButtonIcon />
-          </Badge>
-        }
-      >
-        {apiRef!.current.getLocaleText('toolbarFilters')}
-      </Button>
-    </Tooltip>
-  );
-});
+    const OpenFilterButtonIcon = apiRef!.current.components!.OpenFilterButtonIcon!;
+    return (
+      <Tooltip title={tooltipContentNode} enterDelay={1000}>
+        <Button
+          ref={ref}
+          {...props}
+          onClick={toggleFilter}
+          size="small"
+          color="primary"
+          aria-label={apiRef!.current.getLocaleText('toolbarFiltersLabel')}
+          startIcon={
+            <Badge badgeContent={counter} color="primary">
+              <OpenFilterButtonIcon />
+            </Badge>
+          }
+        >
+          {apiRef!.current.getLocaleText('toolbarFilters')}
+        </Button>
+      </Tooltip>
+    );
+  },
+);

--- a/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridFilterToolbarButton.tsx
@@ -1,3 +1,4 @@
+import { makeStyles } from '@material-ui/core';
 import Badge from '@material-ui/core/Badge';
 import Button from '@material-ui/core/Button';
 import Tooltip from '@material-ui/core/Tooltip';
@@ -15,7 +16,17 @@ import { optionsSelector } from '../../hooks/utils/optionsSelector';
 import { GridTranslationKeys } from '../../models/api/gridLocaleTextApi';
 import { GridApiContext } from '../GridApiContext';
 
+const useStyles = makeStyles((theme) => ({
+  root: {
+    '& ul': {
+      margin: theme.spacing(1),
+      padding: theme.spacing(0, 1),
+    },
+  },
+}));
+
 export const GridFilterToolbarButton: React.FC<{}> = () => {
+  const classes = useStyles();
   const apiRef = React.useContext(GridApiContext);
   const options = useGridSelector(apiRef, optionsSelector);
   const counter = useGridSelector(apiRef, filterGridItemsCounterSelector);
@@ -31,7 +42,7 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
       return apiRef!.current.getLocaleText('toolbarFiltersTooltipShow') as React.ReactElement;
     }
     return (
-      <div>
+      <div className={classes.root}>
         {apiRef!.current.getLocaleText('toolbarFiltersTooltipActive')(counter)}
         <ul>
           {activeFilters.map((item) => ({
@@ -48,7 +59,7 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
         </ul>
       </div>
     );
-  }, [apiRef, preferencePanel.open, counter, activeFilters, lookup]);
+  }, [apiRef, preferencePanel.open, counter, activeFilters, lookup, classes]);
 
   const toggleFilter = React.useCallback(() => {
     const { open, openedPanelValue } = preferencePanel;
@@ -66,7 +77,7 @@ export const GridFilterToolbarButton: React.FC<{}> = () => {
 
   const OpenFilterButtonIcon = apiRef!.current.components!.OpenFilterButtonIcon!;
   return (
-    <Tooltip title={tooltipContentNode} enterDelay={1000}>
+    <Tooltip open title={tooltipContentNode} enterDelay={1000}>
       <Button
         onClick={toggleFilter}
         size="small"


### PR DESCRIPTION
Fixes #1098 

The fix was easier than anticipated. I did the same we did inside the `GridFilterForm` component.

Preview https://deploy-preview-1367--material-ui-x.netlify.app/components/data-grid/demo/#data-grid-demo