### PR TITLE
[DataGrid] Remove use of row.id when id prop is available

### DIFF
--- a/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
@@ -51,11 +51,11 @@ export const GridHeaderCheckbox: React.FC<GridColumnHeaderParams> = () => {
 GridHeaderCheckbox.displayName = 'GridHeaderCheckbox';
 
 export const GridCellCheckboxRenderer: React.FC<GridCellParams> = React.memo((props) => {
-  const { row, getValue, field } = props;
+  const { getValue, field, id } = props;
   const apiRef = React.useContext(GridApiContext);
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
-    apiRef!.current.selectRow(row.id, checked, true);
+    apiRef!.current.selectRow(id, checked, true);
   };
 
   return (

--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -60,6 +60,7 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
           <GridRowCells
             columns={visibleColumns}
             row={r}
+            id={r.id}
             firstColIdx={renderState.renderContext!.firstColIdx!}
             lastColIdx={renderState.renderContext!.lastColIdx!}
             hasScroll={{ y: scrollBarState!.hasScrollY, x: scrollBarState.hasScrollX }}

--- a/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
@@ -7,6 +7,7 @@ import {
   GridCellClassRules,
   GridCellParams,
   GridCellIndexCoordinates,
+  GridRowId,
 } from '../../models/index';
 import { GridCell, GridCellProps } from './GridCell';
 import { GridApiContext } from '../GridApiContext';
@@ -26,6 +27,7 @@ interface RowCellsProps {
   columns: GridColumns;
   extendRowFullWidth: boolean;
   firstColIdx: number;
+  id: GridRowId;
   hasScroll: { y: boolean; x: boolean };
   lastColIdx: number;
   row: GridRowModel;
@@ -39,8 +41,8 @@ export const GridRowCells: React.FC<RowCellsProps> = React.memo((props) => {
     columns,
     firstColIdx,
     hasScroll,
+    id,
     lastColIdx,
-    row,
     rowIndex,
     cellFocus,
     showCellRightBorder,
@@ -56,7 +58,7 @@ export const GridRowCells: React.FC<RowCellsProps> = React.memo((props) => {
       ? showCellRightBorder
       : !removeLastBorderRight && !props.extendRowFullWidth;
 
-    const cellParams: GridCellParams = apiRef!.current.getCellParams(row.id, column.field);
+    const cellParams: GridCellParams = apiRef!.current.getCellParams(id, column.field);
 
     let cssClassProp = { cssClass: '' };
     if (column.cellClassName) {
@@ -72,7 +74,7 @@ export const GridRowCells: React.FC<RowCellsProps> = React.memo((props) => {
       cssClassProp = { cssClass: `${cssClassProp.cssClass} ${cssClass}` };
     }
 
-    const editCellState = editRowsState[row.id] && editRowsState[row.id][column.field];
+    const editCellState = editRowsState[id] && editRowsState[id][column.field];
     let cellComponent: React.ReactElement | null = null;
 
     if (editCellState == null && column.renderCell) {
@@ -90,7 +92,7 @@ export const GridRowCells: React.FC<RowCellsProps> = React.memo((props) => {
       value: cellParams.value,
       field: column.field,
       width: column.width!,
-      rowId: row.id,
+      rowId: id,
       height: rowHeight,
       showRightBorder,
       formattedValue: cellParams.formattedValue,

--- a/packages/grid/_modules_/grid/models/colDef/gridCheckboxSelection.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridCheckboxSelection.tsx
@@ -16,7 +16,7 @@ export const gridCheckboxSelectionColDef: GridColDef = {
   filterable: false,
   disableClickEventBubbling: true,
   disableColumnMenu: true,
-  valueGetter: (params) => params.api.getState().selection[params.row.id],
+  valueGetter: (params) => params.api.getState().selection[params.id],
   renderHeader: (params) => <GridHeaderCheckbox {...params} />,
   renderCell: (params) => <GridCellCheckboxRenderer {...params} />,
   cellClassName: 'MuiDataGrid-cellCheckbox',

--- a/packages/grid/_modules_/grid/models/gridRows.ts
+++ b/packages/grid/_modules_/grid/models/gridRows.ts
@@ -27,16 +27,18 @@ export interface GridObjectWithId {
 }
 
 /**
- * An helper function allowing to check if [[GridRowData]] is valid.
+ * An helper function to check if the id provided is valid.
  *
+ * @param id Id as [[GridRowId]].
  * @param row Row as [[GridRowData]].
  * @returns a boolean
  */
-export function checkGridRowHasId(
+export function checkGridRowIdIsValid(
+  id: GridRowId,
   row: GridRowModel | Partial<GridRowModel>,
   detailErrorMessage?: string,
 ): boolean {
-  if (row.id == null) {
+  if (id == null) {
     throw new Error(
       [
         'Material-UI: The data grid component requires all rows to have a unique id property.',


### PR DESCRIPTION
Related to #1119, #1200, #1315

This is the first batch of changes to satisfy the need of removing `id` from the rowData. In this PR I'm replacing `row.id` with the `id` prop in all places where it's already available. It has no breaking changes. In the next PR I'll do the rest of the work that requires changes in the API too.