### PR TITLE
[DataGrid] Add support for custom row ids without cloning

### DIFF
--- a/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
@@ -31,10 +31,7 @@ export const GridHeaderCheckbox: React.FC<GridColumnHeaderParams> = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
     setChecked(checked);
-    apiRef!.current.selectRows(
-      visibleRows.map((row) => row.id),
-      checked,
-    );
+    apiRef!.current.selectRows([...visibleRows.keys()], checked);
   };
 
   return (

--- a/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/GridCheckboxRenderer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Checkbox from '@material-ui/core/Checkbox';
 import { useGridSelector } from '../hooks/features/core/useGridSelector';
-import { visibleSortedGridRowsSelector } from '../hooks/features/filter/gridFilterSelector';
+import { visibleSortedGridRowIdsSelector } from '../hooks/features/filter/gridFilterSelector';
 import { gridRowCountSelector } from '../hooks/features/rows/gridRowsSelector';
 import { selectedGridRowsCountSelector } from '../hooks/features/selection/gridSelectionSelector';
 import { GridColumnHeaderParams } from '../models/params/gridColumnHeaderParams';
@@ -10,7 +10,7 @@ import { GridApiContext } from './GridApiContext';
 
 export const GridHeaderCheckbox: React.FC<GridColumnHeaderParams> = () => {
   const apiRef = React.useContext(GridApiContext);
-  const visibleRows = useGridSelector(apiRef, visibleSortedGridRowsSelector);
+  const visibleRowIds = useGridSelector(apiRef, visibleSortedGridRowIdsSelector);
 
   const totalSelectedRows = useGridSelector(apiRef, selectedGridRowsCountSelector);
   const totalRows = useGridSelector(apiRef, gridRowCountSelector);
@@ -31,7 +31,7 @@ export const GridHeaderCheckbox: React.FC<GridColumnHeaderParams> = () => {
 
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>, checked: boolean) => {
     setChecked(checked);
-    apiRef!.current.selectRows([...visibleRows.keys()], checked);
+    apiRef!.current.selectRows(visibleRowIds, checked);
   };
 
   return (

--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -42,25 +42,25 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
         return null;
       }
 
-      const renderedRows = rows.slice(
+      const renderedRows = [...rows.entries()].slice(
         renderState.renderContext.firstRowIdx,
         renderState.renderContext.lastRowIdx!,
       );
-      return renderedRows.map((r, idx) => (
+      return renderedRows.map(([id, row], idx) => (
         <GridRow
           className={
             (renderState.renderContext!.firstRowIdx! + idx) % 2 === 0 ? 'Mui-even' : 'Mui-odd'
           }
-          key={r.id}
-          id={r.id}
-          selected={!!selectionState[r.id]}
+          key={id}
+          id={id}
+          selected={!!selectionState[id]}
           rowIndex={renderState.renderContext!.firstRowIdx! + idx}
         >
           <GridEmptyCell width={renderState.renderContext!.leftEmptyWidth} height={rowHeight} />
           <GridRowCells
             columns={visibleColumns}
-            row={r}
-            id={r.id}
+            row={row}
+            id={id}
             firstColIdx={renderState.renderContext!.firstColIdx!}
             lastColIdx={renderState.renderContext!.lastColIdx!}
             hasScroll={{ y: scrollBarState!.hasScrollY, x: scrollBarState.hasScrollX }}

--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { visibleGridColumnsSelector } from '../hooks/features/columns/gridColumnsSelector';
 import { useGridSelector } from '../hooks/features/core/useGridSelector';
 import { gridDensityRowHeightSelector } from '../hooks/features/density/densitySelector';
-import { visibleSortedGridRowsSelector } from '../hooks/features/filter/gridFilterSelector';
+import { visibleSortedGridRowsAsArraySelector } from '../hooks/features/filter/gridFilterSelector';
 import { gridKeyboardCellSelector } from '../hooks/features/keyboard/gridKeyboardSelector';
 import { gridSelectionStateSelector } from '../hooks/features/selection/gridSelectionSelector';
 import { renderStateSelector } from '../hooks/features/virtualization/renderingStateSelector';
@@ -34,7 +34,7 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
     const renderState = useGridSelector(apiRef, renderStateSelector);
     const cellFocus = useGridSelector(apiRef, gridKeyboardCellSelector);
     const selectionState = useGridSelector(apiRef, gridSelectionStateSelector);
-    const rows = useGridSelector(apiRef, visibleSortedGridRowsSelector);
+    const rows = useGridSelector(apiRef, visibleSortedGridRowsAsArraySelector);
     const rowHeight = useGridSelector(apiRef, gridDensityRowHeightSelector);
 
     const getRowsElements = () => {
@@ -42,7 +42,7 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
         return null;
       }
 
-      const renderedRows = [...rows.entries()].slice(
+      const renderedRows = rows.slice(
         renderState.renderContext.firstRowIdx,
         renderState.renderContext.lastRowIdx!,
       );

--- a/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
@@ -46,7 +46,7 @@ export function buildCSV(
     .map((column) => serialiseCellValue(column.headerName || column.field))
     .toString()}\r\n`;
   const CSVBody = rowIds
-    .reduce<string>((soFar, id) => `${soFar}${serialiseRow(id, columns, getCellValue)}\r\n`, '')
+    .reduce<string>((acc, id) => `${acc}${serialiseRow(id, columns, getCellValue)}\r\n`, '')
     .trim();
   const csv = `${CSVHead}${CSVBody}`.trim();
 

--- a/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
@@ -3,7 +3,6 @@ import {
   gridCheckboxSelectionColDef,
   GridColumns,
   GridRowId,
-  GridRowModel,
 } from '../../../../models';
 
 const serialiseCellValue = (value) => {
@@ -30,22 +29,22 @@ export function serialiseRow(
 
 export function buildCSV(
   columns: GridColumns,
-  rows: Map<GridRowId, GridRowModel>,
+  rowIds: GridRowId[],
   selectedRows: Record<GridRowId, boolean>,
   getCellValue: (id: GridRowId, field: string) => GridCellValue,
 ): string {
-  let rowIds = [...rows.keys()];
+  let rowIdsToSerialize = [...rowIds];
   const selectedRowIds = Object.keys(selectedRows);
 
   if (selectedRowIds.length) {
-    rowIds = rowIds.filter((id) => selectedRowIds.includes(`${id}`));
+    rowIdsToSerialize = rowIds.filter((id) => selectedRowIds.includes(`${id}`));
   }
 
   const CSVHead = `${columns
     .filter((column) => column.field !== gridCheckboxSelectionColDef.field)
     .map((column) => serialiseCellValue(column.headerName || column.field))
     .toString()}\r\n`;
-  const CSVBody = rowIds
+  const CSVBody = rowIdsToSerialize
     .reduce<string>((soFar, id) => `${soFar}${serialiseRow(id, columns, getCellValue)}\r\n`, '')
     .trim();
   const csv = `${CSVHead}${CSVBody}`.trim();

--- a/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
@@ -15,7 +15,7 @@ const serialiseCellValue = (value) => {
 };
 
 export function serialiseRow(
-  row: GridRowModel,
+  id: GridRowId,
   columns: GridColumns,
   getCellValue: (id: GridRowId, field: string) => GridCellValue,
 ): Array<string> {
@@ -23,29 +23,30 @@ export function serialiseRow(
   columns.forEach(
     (column) =>
       column.field !== gridCheckboxSelectionColDef.field &&
-      mappedRow.push(serialiseCellValue(getCellValue(row.id, column.field))),
+      mappedRow.push(serialiseCellValue(getCellValue(id, column.field))),
   );
   return mappedRow;
 }
 
 export function buildCSV(
   columns: GridColumns,
-  rows: GridRowModel[],
+  rows: Map<GridRowId, GridRowModel>,
   selectedRows: Record<GridRowId, boolean>,
   getCellValue: (id: GridRowId, field: string) => GridCellValue,
 ): string {
-  const selectedRowsIds = Object.keys(selectedRows);
+  let rowIds = [...rows.keys()];
+  const selectedRowIds = Object.keys(selectedRows);
 
-  if (selectedRowsIds.length) {
-    rows = rows.filter((row) => selectedRowsIds.includes(`${row.id}`));
+  if (selectedRowIds.length) {
+    rowIds = rowIds.filter((id) => selectedRowIds.includes(`${id}`));
   }
 
   const CSVHead = `${columns
     .filter((column) => column.field !== gridCheckboxSelectionColDef.field)
     .map((column) => serialiseCellValue(column.headerName || column.field))
     .toString()}\r\n`;
-  const CSVBody = rows
-    .reduce((soFar, row) => `${soFar}${serialiseRow(row, columns, getCellValue)}\r\n`, '')
+  const CSVBody = rowIds
+    .reduce<string>((soFar, id) => `${soFar}${serialiseRow(id, columns, getCellValue)}\r\n`, '')
     .trim();
   const csv = `${CSVHead}${CSVBody}`.trim();
 

--- a/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
@@ -3,6 +3,7 @@ import {
   gridCheckboxSelectionColDef,
   GridColumns,
   GridRowId,
+  GridRowModel,
 } from '../../../../models';
 
 const serialiseCellValue = (value) => {
@@ -29,22 +30,22 @@ export function serialiseRow(
 
 export function buildCSV(
   columns: GridColumns,
-  rowIds: GridRowId[],
+  rows: Map<GridRowId, GridRowModel>,
   selectedRows: Record<GridRowId, boolean>,
   getCellValue: (id: GridRowId, field: string) => GridCellValue,
 ): string {
-  let rowIdsToSerialize = [...rowIds];
+  let rowIds = [...rows.keys()];
   const selectedRowIds = Object.keys(selectedRows);
 
   if (selectedRowIds.length) {
-    rowIdsToSerialize = rowIds.filter((id) => selectedRowIds.includes(`${id}`));
+    rowIds = rowIds.filter((id) => selectedRowIds.includes(`${id}`));
   }
 
   const CSVHead = `${columns
     .filter((column) => column.field !== gridCheckboxSelectionColDef.field)
     .map((column) => serialiseCellValue(column.headerName || column.field))
     .toString()}\r\n`;
-  const CSVBody = rowIdsToSerialize
+  const CSVBody = rowIds
     .reduce<string>((soFar, id) => `${soFar}${serialiseRow(id, columns, getCellValue)}\r\n`, '')
     .trim();
   const csv = `${CSVHead}${CSVBody}`.trim();

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -3,7 +3,7 @@ import { GridApiRef } from '../../../models/api/gridApiRef';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
 import { useGridSelector } from '../core/useGridSelector';
 import { visibleGridColumnsSelector } from '../columns';
-import { visibleSortedGridRowsSelector } from '../filter';
+import { visibleSortedGridRowIdsSelector } from '../filter';
 import { gridSelectionStateSelector } from '../selection';
 import { GridCsvExportApi } from '../../../models';
 import { useLogger } from '../../utils/useLogger';
@@ -13,14 +13,14 @@ import { buildCSV } from './seralizers/csvSeraliser';
 export const useGridCsvExport = (apiRef: GridApiRef): void => {
   const logger = useLogger('useGridCsvExport');
   const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
-  const visibleSortedRows = useGridSelector(apiRef, visibleSortedGridRowsSelector);
+  const visibleSortedRowIds = useGridSelector(apiRef, visibleSortedGridRowIdsSelector);
   const selection = useGridSelector(apiRef, gridSelectionStateSelector);
 
   const getDataAsCsv = React.useCallback((): string => {
     logger.debug(`Get data as CSV`);
 
-    return buildCSV(visibleColumns, visibleSortedRows, selection, apiRef.current.getCellValue);
-  }, [logger, visibleColumns, visibleSortedRows, selection, apiRef]);
+    return buildCSV(visibleColumns, visibleSortedRowIds, selection, apiRef.current.getCellValue);
+  }, [logger, visibleColumns, visibleSortedRowIds, selection, apiRef]);
 
   const exportDataAsCsv = React.useCallback((): void => {
     logger.debug(`Export data as CSV`);

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -3,7 +3,7 @@ import { GridApiRef } from '../../../models/api/gridApiRef';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
 import { useGridSelector } from '../core/useGridSelector';
 import { visibleGridColumnsSelector } from '../columns';
-import { visibleSortedGridRowIdsSelector } from '../filter';
+import { visibleSortedGridRowsSelector } from '../filter';
 import { gridSelectionStateSelector } from '../selection';
 import { GridCsvExportApi } from '../../../models';
 import { useLogger } from '../../utils/useLogger';
@@ -13,14 +13,14 @@ import { buildCSV } from './seralizers/csvSeraliser';
 export const useGridCsvExport = (apiRef: GridApiRef): void => {
   const logger = useLogger('useGridCsvExport');
   const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
-  const visibleSortedRowIds = useGridSelector(apiRef, visibleSortedGridRowIdsSelector);
+  const visibleSortedRows = useGridSelector(apiRef, visibleSortedGridRowsSelector);
   const selection = useGridSelector(apiRef, gridSelectionStateSelector);
 
   const getDataAsCsv = React.useCallback((): string => {
     logger.debug(`Get data as CSV`);
 
-    return buildCSV(visibleColumns, visibleSortedRowIds, selection, apiRef.current.getCellValue);
-  }, [logger, visibleColumns, visibleSortedRowIds, selection, apiRef]);
+    return buildCSV(visibleColumns, visibleSortedRows, selection, apiRef.current.getCellValue);
+  }, [logger, visibleColumns, visibleSortedRows, selection, apiRef]);
 
   const exportDataAsCsv = React.useCallback((): void => {
     logger.debug(`Export data as CSV`);

--- a/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { GridFilterItem } from '../../../models/gridFilterItem';
-import { GridRowId, GridRowData } from '../../../models/gridRows';
+import { GridRowId, GridRowModel } from '../../../models/gridRows';
 import { GridState } from '../core/gridState';
 import { gridRowCountSelector } from '../rows/gridRowsSelector';
 import { sortedGridRowsSelector } from '../sorting/gridSortingSelector';
@@ -12,8 +12,8 @@ export const visibleGridRowsStateSelector = (state: GridState) => state.visibleR
 export const visibleSortedGridRowsSelector = createSelector<
   GridState,
   VisibleGridRowsState,
-  Map<GridRowId, GridRowData>,
-  Map<GridRowId, GridRowData>
+  Map<GridRowId, GridRowModel>,
+  Map<GridRowId, GridRowModel>
 >(visibleGridRowsStateSelector, sortedGridRowsSelector, (visibleRowsState, sortedRows) => {
   const map = new Map();
   sortedRows.forEach((row, id) => {
@@ -22,6 +22,30 @@ export const visibleSortedGridRowsSelector = createSelector<
     }
   });
   return map;
+});
+
+export const visibleSortedGridRowsAsArraySelector = createSelector<
+  GridState,
+  Map<GridRowId, GridRowModel>,
+  [GridRowId, GridRowModel][]
+>(visibleSortedGridRowsSelector, (visibleSortedRows) => {
+  const result: [GridRowId, GridRowModel][] = [];
+  visibleSortedRows.forEach((row, id) => {
+    result.push([id, row]);
+  });
+  return result;
+});
+
+export const visibleSortedGridRowIdsSelector = createSelector<
+  GridState,
+  Map<GridRowId, GridRowModel>,
+  GridRowId[]
+>(visibleSortedGridRowsSelector, (visibleSortedRows) => {
+  const result: GridRowId[] = [];
+  visibleSortedRows.forEach((row, id) => {
+    result.push(id);
+  });
+  return result;
 });
 
 export const visibleGridRowCountSelector = createSelector<

--- a/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
@@ -29,11 +29,7 @@ export const visibleSortedGridRowsAsArraySelector = createSelector<
   Map<GridRowId, GridRowModel>,
   [GridRowId, GridRowModel][]
 >(visibleSortedGridRowsSelector, (visibleSortedRows) => {
-  const result: [GridRowId, GridRowModel][] = [];
-  visibleSortedRows.forEach((row, id) => {
-    result.push([id, row]);
-  });
-  return result;
+  return [...visibleSortedRows.entries()]
 });
 
 export const visibleSortedGridRowIdsSelector = createSelector<
@@ -41,11 +37,7 @@ export const visibleSortedGridRowIdsSelector = createSelector<
   Map<GridRowId, GridRowModel>,
   GridRowId[]
 >(visibleSortedGridRowsSelector, (visibleSortedRows) => {
-  const result: GridRowId[] = [];
-  visibleSortedRows.forEach((row, id) => {
-    result.push(id);
-  });
-  return result;
+  return [...visibleSortedRows.keys()];
 });
 
 export const visibleGridRowCountSelector = createSelector<

--- a/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
@@ -1,6 +1,6 @@
 import { createSelector } from 'reselect';
 import { GridFilterItem } from '../../../models/gridFilterItem';
-import { GridRowModel } from '../../../models/gridRows';
+import { GridRowId, GridRowData } from '../../../models/gridRows';
 import { GridState } from '../core/gridState';
 import { gridRowCountSelector } from '../rows/gridRowsSelector';
 import { sortedGridRowsSelector } from '../sorting/gridSortingSelector';
@@ -12,15 +12,17 @@ export const visibleGridRowsStateSelector = (state: GridState) => state.visibleR
 export const visibleSortedGridRowsSelector = createSelector<
   GridState,
   VisibleGridRowsState,
-  GridRowModel[],
-  GridRowModel[]
->(
-  visibleGridRowsStateSelector,
-  sortedGridRowsSelector,
-  (visibleRowsState, sortedRows: GridRowModel[]) => {
-    return [...sortedRows].filter((row) => visibleRowsState.visibleRowsLookup[row.id] !== false);
-  },
-);
+  Map<GridRowId, GridRowData>,
+  Map<GridRowId, GridRowData>
+>(visibleGridRowsStateSelector, sortedGridRowsSelector, (visibleRowsState, sortedRows) => {
+  const map = new Map();
+  sortedRows.forEach((row, id) => {
+    if (visibleRowsState.visibleRowsLookup[id] !== false) {
+      map.set(id, row);
+    }
+  });
+  return map;
+});
 
 export const visibleGridRowCountSelector = createSelector<
   GridState,

--- a/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/gridFilterSelector.ts
@@ -29,7 +29,7 @@ export const visibleSortedGridRowsAsArraySelector = createSelector<
   Map<GridRowId, GridRowModel>,
   [GridRowId, GridRowModel][]
 >(visibleSortedGridRowsSelector, (visibleSortedRows) => {
-  return [...visibleSortedRows.entries()]
+  return [...visibleSortedRows.entries()];
 });
 
 export const visibleSortedGridRowIdsSelector = createSelector<

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -10,7 +10,7 @@ import { FilterApi } from '../../../models/api/filterApi';
 import { GridFeatureModeConstant } from '../../../models/gridFeatureMode';
 import { GridFilterItem, GridLinkOperator } from '../../../models/gridFilterItem';
 import { GridFilterModelParams } from '../../../models/params/gridFilterModelParams';
-import { GridRowsProp, GridRowId } from '../../../models/gridRows';
+import { GridRowsProp, GridRowId, GridRowModel } from '../../../models/gridRows';
 import { isDeepEqual } from '../../../utils/utils';
 import { useGridApiEventHandler, useGridApiOptionHandler } from '../../root/useGridApiEventHandler';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
@@ -91,7 +91,7 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
         // This way we have latest rows on the first rendering
         const rows = sortedGridRowsSelector(state);
 
-        [...rows.keys()].forEach((id: GridRowId) => {
+        rows.forEach((row: GridRowModel, id: GridRowId) => {
           const params = apiRef.current.getCellParams(id, filterItem.columnField!);
 
           const isShown = applyFilterOnRow(params);

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -10,7 +10,7 @@ import { FilterApi } from '../../../models/api/filterApi';
 import { GridFeatureModeConstant } from '../../../models/gridFeatureMode';
 import { GridFilterItem, GridLinkOperator } from '../../../models/gridFilterItem';
 import { GridFilterModelParams } from '../../../models/params/gridFilterModelParams';
-import { GridRowsProp } from '../../../models/gridRows';
+import { GridRowsProp, GridRowId } from '../../../models/gridRows';
 import { isDeepEqual } from '../../../utils/utils';
 import { useGridApiEventHandler, useGridApiOptionHandler } from '../../root/useGridApiEventHandler';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
@@ -91,17 +91,17 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
         // This way we have latest rows on the first rendering
         const rows = sortedGridRowsSelector(state);
 
-        rows.forEach((row) => {
-          const params = apiRef.current.getCellParams(row.id, filterItem.columnField!);
+        [...rows.keys()].forEach((id: GridRowId) => {
+          const params = apiRef.current.getCellParams(id, filterItem.columnField!);
 
           const isShown = applyFilterOnRow(params);
-          if (visibleRowsLookup[row.id] == null) {
-            visibleRowsLookup[row.id] = isShown;
+          if (visibleRowsLookup[id] == null) {
+            visibleRowsLookup[id] = isShown;
           } else {
-            visibleRowsLookup[row.id] =
+            visibleRowsLookup[id] =
               linkOperator === GridLinkOperator.And
-                ? visibleRowsLookup[row.id] && isShown
-                : visibleRowsLookup[row.id] || isShown;
+                ? visibleRowsLookup[id] && isShown
+                : visibleRowsLookup[id] || isShown;
           }
         });
 

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -78,11 +78,9 @@ export const useGridKeyboard = (
       let selectionFromRowIndex = currentRowIndex;
 
       // TODO Refactor here to not use api call
-      const selectedRows = apiRef.current.getSelectedRows();
-      if (selectedRows.length > 0) {
-        const selectedRowsIndex = selectedRows.map((row) =>
-          apiRef.current.getRowIndexFromId(row.id),
-        );
+      const selectedRowsIds = [...apiRef.current.getSelectedRows().keys()];
+      if (selectedRowsIds.length > 0) {
+        const selectedRowsIndex = selectedRowsIds.map((id) => apiRef.current.getRowIndexFromId(id));
 
         const diffWithCurrentIndex: number[] = selectedRowsIndex.map((idx) =>
           Math.abs(currentRowIndex - idx),

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -200,13 +200,16 @@ export const useGridRows = (
     [apiRef, forceUpdate, getRowFromId, getRowIdProp, setGridState, setRows],
   );
 
-  const getRowModels = React.useCallback(() => {
-    const map = new Map<GridRowId, GridRowModel>();
-    apiRef.current.state.rows.allRows.forEach((id) => {
-      map.set(id, apiRef.current.state.rows.idRowsLookup[id]);
-    });
-    return map;
-  }, [apiRef]);
+  const getRowModels = React.useCallback(
+    () =>
+      new Map(
+        apiRef.current.state.rows.allRows.map((id) => [
+          id,
+          apiRef.current.state.rows.idRowsLookup[id],
+        ]),
+      ),
+    [apiRef],
+  );
   const getRowsCount = React.useCallback(() => apiRef.current.state.rows.totalRowCount, [apiRef]);
   const getAllRowIds = React.useCallback(() => apiRef.current.state.rows.allRows, [apiRef]);
 

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -123,11 +123,11 @@ export const useGridRows = (
       }
 
       const allRows: GridRowId[] = [];
-      const idRowsLookup = allNewRows.reduce((lookup, row) => {
+      const idRowsLookup = allNewRows.reduce((acc, row) => {
         const id = getGridRowId(row, getRowIdProp);
-        lookup[id] = row;
+        acc[id] = row;
         allRows.push(id);
-        return lookup;
+        return acc;
       }, {});
 
       const totalRowCount =
@@ -149,14 +149,14 @@ export const useGridRows = (
   const updateRows = React.useCallback(
     (updates: GridRowModelUpdate[]) => {
       // we removes duplicate updates. A server can batch updates, and send several updates for the same row in one fn call.
-      const uniqUpdates = updates.reduce((uniq, update) => {
+      const uniqUpdates = updates.reduce((acc, update) => {
         const id = getGridRowId(
           update,
           getRowIdProp,
           'A row was provided without id when calling updateRows():',
         );
-        uniq[id] = uniq[id] != null ? { ...uniq[id!], ...update } : update;
-        return uniq;
+        acc[id] = acc[id] != null ? { ...acc[id!], ...update } : update;
+        return acc;
       }, {} as { [id: string]: GridRowModel });
 
       const addedRows: GridRowModel[] = [];

--- a/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
@@ -19,10 +19,9 @@ export const selectedGridRowsSelector = createSelector<
   GridSelectionState,
   GridRowsLookup,
   Map<GridRowId, GridRowModel>
->(gridSelectionStateSelector, gridRowsLookupSelector, (selectedRows, rowsLookup) => {
-  const map = new Map();
-  Object.keys(selectedRows).forEach((id) => {
-    map.set(id, rowsLookup[id]);
-  });
-  return map;
-});
+>(
+  gridSelectionStateSelector,
+  gridRowsLookupSelector,
+  (selectedRows, rowsLookup) =>
+    new Map(Object.keys(selectedRows).map((id) => [id, rowsLookup[id]])),
+);

--- a/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
@@ -1,6 +1,8 @@
 import { createSelector, OutputSelector } from 'reselect';
+import { gridRowsLookupSelector, GridRowsLookup } from '../rows/gridRowsSelector';
 import { GridState } from '../core/gridState';
 import { GridSelectionState } from './gridSelectionState';
+import { GridRowId, GridRowModel } from '../../../models/gridRows';
 
 export const gridSelectionStateSelector = (state: GridState) => state.selection;
 export const selectedGridRowsCountSelector: OutputSelector<
@@ -11,3 +13,16 @@ export const selectedGridRowsCountSelector: OutputSelector<
   gridSelectionStateSelector,
   (selection) => Object.keys(selection).length,
 );
+
+export const selectedGridRowsSelector = createSelector<
+  GridState,
+  GridSelectionState,
+  GridRowsLookup,
+  Map<GridRowId, GridRowModel>
+>(gridSelectionStateSelector, gridRowsLookupSelector, (selectedRows, rowsLookup) => {
+  const map = new Map();
+  Object.keys(selectedRows).forEach((id) => {
+    map.set(id, rowsLookup[id]);
+  });
+  return map;
+});

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -21,13 +21,15 @@ import { useGridState } from '../core/useGridState';
 import { gridKeyboardMultipleKeySelector } from '../keyboard/gridKeyboardSelector';
 import { gridRowsLookupSelector } from '../rows/gridRowsSelector';
 import { GridSelectionState } from './gridSelectionState';
+import { selectedGridRowsSelector } from './gridSelectionSelector';
 
 export const useGridSelection = (apiRef: GridApiRef): void => {
   const logger = useLogger('useGridSelection');
-  const [gridState, setGridState, forceUpdate] = useGridState(apiRef);
+  const [, setGridState, forceUpdate] = useGridState(apiRef);
   const options = useGridSelector(apiRef, optionsSelector);
   const rowsLookup = useGridSelector(apiRef, gridRowsLookupSelector);
   const isMultipleKeyPressed = useGridSelector(apiRef, gridKeyboardMultipleKeySelector);
+  const selectedRows = useGridSelector(apiRef, selectedGridRowsSelector);
 
   const allowMultipleSelectionKeyPressed = React.useRef<boolean>(false);
 
@@ -36,14 +38,7 @@ export const useGridSelection = (apiRef: GridApiRef): void => {
       !options.disableMultipleSelection && isMultipleKeyPressed;
   }, [isMultipleKeyPressed, options.disableMultipleSelection]);
 
-  const getSelectedRows = React.useCallback((): Map<GridRowId, GridRowModel> => {
-    // TODO replace with selector
-    const map = new Map();
-    Object.keys(gridState.selection).forEach((id) => {
-      map.set(id, apiRef.current.getRowFromId(id));
-    });
-    return map;
-  }, [apiRef, gridState.selection]);
+  const getSelectedRows = React.useCallback(() => selectedRows, [selectedRows]);
 
   const selectRowModel = React.useCallback(
     (id: GridRowId, row: GridRowModel, allowMultipleOverride?: boolean, isSelected?: boolean) => {

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -29,7 +29,6 @@ export const useGridSelection = (apiRef: GridApiRef): void => {
   const options = useGridSelector(apiRef, optionsSelector);
   const rowsLookup = useGridSelector(apiRef, gridRowsLookupSelector);
   const isMultipleKeyPressed = useGridSelector(apiRef, gridKeyboardMultipleKeySelector);
-  const selectedRows = useGridSelector(apiRef, selectedGridRowsSelector);
 
   const allowMultipleSelectionKeyPressed = React.useRef<boolean>(false);
 
@@ -38,7 +37,10 @@ export const useGridSelection = (apiRef: GridApiRef): void => {
       !options.disableMultipleSelection && isMultipleKeyPressed;
   }, [isMultipleKeyPressed, options.disableMultipleSelection]);
 
-  const getSelectedRows = React.useCallback(() => selectedRows, [selectedRows]);
+  const getSelectedRows = React.useCallback(
+    () => selectedGridRowsSelector(apiRef.current.getState()),
+    [apiRef],
+  );
 
   const selectRowModel = React.useCallback(
     (id: GridRowId, row: GridRowModel, allowMultipleOverride?: boolean, isSelected?: boolean) => {

--- a/packages/grid/_modules_/grid/hooks/features/sorting/gridSortingSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/gridSortingSelector.ts
@@ -6,7 +6,6 @@ import {
   GridRowsLookup,
   gridRowsLookupSelector,
   unorderedGridRowIdsSelector,
-  unorderedGridRowModelsSelector,
 } from '../rows/gridRowsSelector';
 import { GridSortingState } from './gridSortingState';
 
@@ -27,14 +26,16 @@ export const sortedGridRowsSelector = createSelector<
   GridState,
   GridRowId[],
   GridRowsLookup,
-  GridRowModel[],
-  GridRowModel[]
+  Map<GridRowId, GridRowModel>
 >(
   sortedGridRowIdsSelector,
   gridRowsLookupSelector,
-  unorderedGridRowModelsSelector,
-  (sortedIds: GridRowId[], idRowsLookup, unordered) => {
-    return sortedIds.length > 0 ? sortedIds.map((id) => idRowsLookup[id]) : unordered;
+  (sortedIds: GridRowId[], idRowsLookup: GridRowsLookup) => {
+    const map = new Map<GridRowId, GridRowModel>();
+    sortedIds.forEach((id) => {
+      map.set(id, idRowsLookup[id]);
+    });
+    return map;
   },
 );
 export const gridSortModelSelector = createSelector<GridState, GridSortingState, GridSortModel>(

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -112,16 +112,18 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
   );
 
   const comparatorListAggregate = React.useCallback(
-    (row1: GridRowModel, row2: GridRowModel) => {
+    (id1: GridRowId, id2: GridRowId) => {
       const result = comparatorList.current.reduce((res, colComparator) => {
         const { field, comparator } = colComparator;
+        const sortCellParams1 = getSortCellParams(id1, field);
+        const sortCellParams2 = getSortCellParams(id2, field);
         res =
           res ||
           comparator(
-            row1[field],
-            row2[field],
-            getSortCellParams(row1.id, field),
-            getSortCellParams(row2.id, field),
+            sortCellParams1.value,
+            sortCellParams2.value,
+            sortCellParams1,
+            sortCellParams2,
           );
         return res;
       }, 0);
@@ -160,7 +162,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
       setGridState((oldState) => {
         return {
           ...oldState,
-          sorting: { ...oldState.sorting, sortedRows: rowModels.map((row) => row.id) },
+          sorting: { ...oldState.sorting, sortedRows: Object.keys(rowModels) },
         };
       });
       return;
@@ -168,7 +170,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
 
     const sortModel = apiRef.current.getState().sorting.sortModel;
     logger.debug('Sorting rows with ', sortModel);
-    const sorted = [...rowModels];
+    const sorted = [...rowModels.keys()];
     if (sortModel.length > 0) {
       comparatorList.current = buildComparatorList(sortModel);
       sorted.sort(comparatorListAggregate);
@@ -177,7 +179,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
     setGridState((oldState) => {
       return {
         ...oldState,
-        sorting: { ...oldState.sorting, sortedRows: sorted.map((row) => row.id) },
+        sorting: { ...oldState.sorting, sortedRows: sorted },
       };
     });
     forceUpdate();
@@ -243,7 +245,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
   ]);
 
   const getSortedRows = React.useCallback(
-    (): GridRowModel[] => sortedGridRowsSelector(apiRef.current.state),
+    (): GridRowModel[] => Object.values(sortedGridRowsSelector(apiRef.current.state)),
     [apiRef],
   );
 

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -155,14 +155,14 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
   );
 
   const applySorting = React.useCallback(() => {
-    const rowModels = apiRef.current.getRowModels();
+    const rowIds = apiRef.current.getAllRowIds();
 
     if (options.sortingMode === GridFeatureModeConstant.server) {
       logger.debug('Skipping sorting rows as sortingMode = server');
       setGridState((oldState) => {
         return {
           ...oldState,
-          sorting: { ...oldState.sorting, sortedRows: Object.keys(rowModels) },
+          sorting: { ...oldState.sorting, sortedRows: rowIds },
         };
       });
       return;
@@ -170,7 +170,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
 
     const sortModel = apiRef.current.getState().sorting.sortModel;
     logger.debug('Sorting rows with ', sortModel);
-    const sorted = [...rowModels.keys()];
+    const sorted = [...rowIds];
     if (sortModel.length > 0) {
       comparatorList.current = buildComparatorList(sortModel);
       sorted.sort(comparatorListAggregate);

--- a/packages/grid/_modules_/grid/models/api/filterApi.ts
+++ b/packages/grid/_modules_/grid/models/api/filterApi.ts
@@ -1,6 +1,6 @@
+import { GridRowId, GridRowData } from 'packages/grid/data-grid/dist/data-grid';
 import { GridFilterModel } from '../../hooks/features/filter/gridFilterModelState';
 import { GridFilterItem, GridLinkOperator } from '../gridFilterItem';
-import { GridRowModel } from '../gridRows';
 import { GridFilterModelParams } from '../params/gridFilterModelParams';
 
 export interface FilterApi {
@@ -13,5 +13,5 @@ export interface FilterApi {
   applyFilterLinkOperator: (operator: GridLinkOperator) => void;
   onFilterModelChange: (handler: (params: GridFilterModelParams) => void) => void;
   setFilterModel: (model: GridFilterModel) => void;
-  getVisibleRowModels: () => GridRowModel[];
+  getVisibleRowModels: () => Map<GridRowId, GridRowData>;
 }

--- a/packages/grid/_modules_/grid/models/api/filterApi.ts
+++ b/packages/grid/_modules_/grid/models/api/filterApi.ts
@@ -1,4 +1,4 @@
-import { GridRowId, GridRowData } from 'packages/grid/data-grid/dist/data-grid';
+import { GridRowId, GridRowData } from '../gridRows';
 import { GridFilterModel } from '../../hooks/features/filter/gridFilterModelState';
 import { GridFilterItem, GridLinkOperator } from '../gridFilterItem';
 import { GridFilterModelParams } from '../params/gridFilterModelParams';

--- a/packages/grid/_modules_/grid/models/api/filterApi.ts
+++ b/packages/grid/_modules_/grid/models/api/filterApi.ts
@@ -1,4 +1,4 @@
-import { GridRowId, GridRowData } from '../gridRows';
+import { GridRowId, GridRowModel } from '../gridRows';
 import { GridFilterModel } from '../../hooks/features/filter/gridFilterModelState';
 import { GridFilterItem, GridLinkOperator } from '../gridFilterItem';
 import { GridFilterModelParams } from '../params/gridFilterModelParams';
@@ -13,5 +13,5 @@ export interface FilterApi {
   applyFilterLinkOperator: (operator: GridLinkOperator) => void;
   onFilterModelChange: (handler: (params: GridFilterModelParams) => void) => void;
   setFilterModel: (model: GridFilterModel) => void;
-  getVisibleRowModels: () => Map<GridRowId, GridRowData>;
+  getVisibleRowModels: () => Map<GridRowId, GridRowModel>;
 }

--- a/packages/grid/_modules_/grid/models/api/gridRowApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridRowApi.ts
@@ -8,7 +8,7 @@ export interface GridRowApi {
    * Get the full set of rows as [[Rows]].
    * @returns [[Rows]]
    */
-  getRowModels: () => GridRowModel[];
+  getRowModels: () => Map<GridRowId, GridRowModel>;
   /**
    * Get the total number of rows in the grid.
    */

--- a/packages/grid/_modules_/grid/models/api/gridRowApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridRowApi.ts
@@ -5,8 +5,8 @@ import { GridRowModel, GridRowId, GridRowModelUpdate } from '../gridRows';
  */
 export interface GridRowApi {
   /**
-   * Get the full set of rows as [[Rows]].
-   * @returns [[Rows]]
+   * Get the full set of rows as [[Map<GridRowId, GridRowModel>]].
+   * @returns [[Map<GridRowId, GridRowModel>]]
    */
   getRowModels: () => Map<GridRowId, GridRowModel>;
   /**

--- a/packages/grid/_modules_/grid/models/api/gridSelectionApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridSelectionApi.ts
@@ -24,7 +24,7 @@ export interface GridSelectionApi {
   /**
    * Get an array of selected rows.
    */
-  getSelectedRows: () => GridRowModel[];
+  getSelectedRows: () => Map<GridRowId, GridRowModel>;
   /**
    * Callback fired after a row is selected.
    * @param handler

--- a/packages/grid/_modules_/grid/models/gridRows.ts
+++ b/packages/grid/_modules_/grid/models/gridRows.ts
@@ -22,10 +22,6 @@ export type GridRowId = string | number;
  */
 export type GridRowIdGetter = (row: GridRowData) => GridRowId;
 
-export interface GridObjectWithId {
-  id: GridRowId;
-}
-
 /**
  * An helper function to check if the id provided is valid.
  *

--- a/packages/grid/_modules_/grid/models/gridRows.ts
+++ b/packages/grid/_modules_/grid/models/gridRows.ts
@@ -4,7 +4,7 @@ export type GridRowData = { [key: string]: any };
 /**
  * The key value object representing the data of a row.
  */
-export type GridRowModel = GridObjectWithId & GridRowData;
+export type GridRowModel = GridRowData;
 
 export type GridUpdateAction = 'delete';
 

--- a/packages/grid/_modules_/grid/models/params/gridFilterModelParams.ts
+++ b/packages/grid/_modules_/grid/models/params/gridFilterModelParams.ts
@@ -1,6 +1,6 @@
 import { GridFilterModel } from '../../hooks/features/filter/gridFilterModelState';
 import { GridColumns } from '../colDef/gridColDef';
-import { GridRowModel } from '../gridRows';
+import { GridRowModel, GridRowId } from '../gridRows';
 
 /**
  * Object passed as parameter of the filter changed event.
@@ -17,11 +17,11 @@ export interface GridFilterModelParams {
   /**
    * The full set of rows.
    */
-  rows: GridRowModel[];
+  rows: Map<GridRowId, GridRowModel>;
   /**
    * The set of currently visible rows.
    */
-  visibleRows: GridRowModel[];
+  visibleRows: Map<GridRowId, GridRowModel>;
   /**
    * Api that let you manipulate the grid.
    */

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -453,7 +453,6 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       }).toErrorDev([
         'The data grid component requires all rows to have a unique id property',
         'The above error occurred in the <ForwardRef(GridComponent)> component',
-        'The above error occurred in the <ForwardRef(GridComponent)> component',
       ]);
       expect((errorRef.current as any).errors).to.have.length(1);
       expect((errorRef.current as any).errors[0].toString()).to.include(

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -453,6 +453,7 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       }).toErrorDev([
         'The data grid component requires all rows to have a unique id property',
         'The above error occurred in the <ForwardRef(GridComponent)> component',
+        'The above error occurred in the <ForwardRef(GridComponent)> component',
       ]);
       expect((errorRef.current as any).errors).to.have.length(1);
       expect((errorRef.current as any).errors[0].toString()).to.include(

--- a/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/rows.DataGrid.test.tsx
@@ -26,7 +26,7 @@ describe('<DataGrid /> - Rows', () => {
         age: 20,
       },
     ],
-    columns: [{ field: 'id' }, { field: 'first' }, { field: 'age' }],
+    columns: [{ field: 'clientId' }, { field: 'first' }, { field: 'age' }],
   };
 
   before(function beforeHook() {
@@ -45,16 +45,6 @@ describe('<DataGrid /> - Rows', () => {
         </div>,
       );
       expect(getColumnValues()).to.deep.equal(['c1', 'c2', 'c3']);
-    });
-
-    it('should allow to compute row ids', () => {
-      const getRowId = (row) => `${row.first}-${row.age}`;
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid {...baselineProps} getRowId={getRowId} />
-        </div>,
-      );
-      expect(getColumnValues()).to.deep.equal(['Mike-11', 'Jack-11', 'Mike-20']);
     });
   });
 });

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -9,6 +9,7 @@ import {
   GridPreferencePanelsValue,
   GridRowModel,
   GridFilterModelParams,
+  GridRowId,
   useGridApiRef,
   XGrid,
   SUBMIT_FILTER_STROKE_TIME,
@@ -21,7 +22,6 @@ import {
   fireEvent,
 } from 'test/utils';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
-import { GridRowId } from 'packages/grid/data-grid/dist/data-grid';
 
 describe('<XGrid /> - Filter', () => {
   let clock;

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -8,6 +8,7 @@ import {
   GridLinkOperator,
   GridPreferencePanelsValue,
   GridRowModel,
+  GridFilterModelParams,
   useGridApiRef,
   XGrid,
   SUBMIT_FILTER_STROKE_TIME,
@@ -20,6 +21,7 @@ import {
   fireEvent,
 } from 'test/utils';
 import { getColumnHeaderCell, getColumnValues } from 'test/utils/helperFn';
+import { GridRowId } from 'packages/grid/data-grid/dist/data-grid';
 
 describe('<XGrid /> - Filter', () => {
   let clock;
@@ -231,8 +233,8 @@ describe('<XGrid /> - Filter', () => {
   });
 
   it('should show the latest visibleRows onFilterChange', () => {
-    let visibleRows: any[] = [];
-    const onFilterChange = (params) => {
+    let visibleRows: Map<GridRowId, GridRowModel> = new Map();
+    const onFilterChange = (params: GridFilterModelParams) => {
       visibleRows = params.visibleRows;
     };
 
@@ -253,8 +255,10 @@ describe('<XGrid /> - Filter', () => {
     const input = screen.getByPlaceholderText('Filter value');
     fireEvent.change(input, { target: { value: 'ad' } });
     clock.tick(SUBMIT_FILTER_STROKE_TIME);
-    expect(visibleRows).to.deep.equal([{ id: 1, brand: 'Adidas' }]);
-    expect(apiRef.current.getVisibleRowModels()).to.deep.equal([{ id: 1, brand: 'Adidas' }]);
+    expect(visibleRows.size).to.equal(1);
+    expect(visibleRows.get(1)).to.deep.equal({ id: 1, brand: 'Adidas' });
+    expect(apiRef.current.getVisibleRowModels().size).to.equal(1);
+    expect(apiRef.current.getVisibleRowModels().get(1)).to.deep.equal({ id: 1, brand: 'Adidas' });
   });
 
   describe('Server', () => {

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -50,7 +50,7 @@ describe('<XGrid /> - Rows', () => {
             age: 20,
           },
         ],
-        columns: [{ field: 'id' }, { field: 'first' }, { field: 'age' }],
+        columns: [{ field: 'clientId' }, { field: 'first' }, { field: 'age' }],
       };
     });
 
@@ -108,6 +108,21 @@ describe('<XGrid /> - Rows', () => {
       expect(cell).to.have.class('MuiDataGrid-cellEditable');
       expect(cell).not.to.have.class('MuiDataGrid-cellEditing');
       expect(cell.querySelector('input')).to.equal(null);
+    });
+
+    it('should not clone the row', () => {
+      const getRowId = (row) => `${row.clientId}`;
+      let apiRef: GridApiRef;
+      const Test = () => {
+        apiRef = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <XGrid {...baselineProps} getRowId={getRowId} apiRef={apiRef} />
+          </div>
+        );
+      };
+      render(<Test />);
+      expect(apiRef!.current.getRowFromId('c1')).to.equal(baselineProps.rows[0]);
     });
   });
 

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -1,0 +1,62 @@
+import * as React from 'react';
+import { createClientRenderStrictMode } from 'test/utils';
+import { expect } from 'chai';
+import {
+  GridApiRef,
+  GridComponentProps,
+  useGridApiRef,
+  XGrid,
+  GRID_SELECTION_CHANGED,
+} from '@material-ui/x-grid';
+
+describe('<XGrid /> - Selection', () => {
+  // TODO v5: replace with createClientRender
+  const render = createClientRenderStrictMode();
+
+  before(function beforeHook() {
+    if (/jsdom/.test(window.navigator.userAgent)) {
+      // Need layouting
+      this.skip();
+    }
+  });
+
+  describe('getSelectedRows', () => {
+    const baselineProps = {
+      rows: [
+        {
+          id: 0,
+          brand: 'Nike',
+        },
+        {
+          id: 1,
+          brand: 'Adidas',
+        },
+        {
+          id: 2,
+          brand: 'Puma',
+        },
+      ],
+      columns: [{ field: 'brand' }],
+    };
+
+    it('should always return the latest values', () => {
+      let apiRef: GridApiRef;
+      const Test = (props: Partial<GridComponentProps>) => {
+        apiRef = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <XGrid apiRef={apiRef} {...baselineProps} {...props} />
+          </div>
+        );
+      };
+      render(<Test />);
+      expect(apiRef!.current.getSelectedRows().size).to.equal(0);
+      apiRef!.current.on(GRID_SELECTION_CHANGED, () => {
+        expect(apiRef!.current.getSelectedRows().size).to.equal(1);
+        // TODO remove cast to string once state.selection is converted to Map
+        expect(apiRef!.current.getSelectedRows().get('1')).to.equal(baselineProps.rows[1]);
+      });
+      apiRef!.current.selectRow(1);
+    });
+  });
+});


### PR DESCRIPTION
### Breaking changes

- [DataGrid] `GridFilterModelParams.rows` changed to `Map<GridRowId, GridRowModel>`
- [DataGrid] `GridFilterModelParams.visibleRows` changed to `Map<GridRowId, GridRowModel>`
- [DataGrid] Return of `apiRef.current.getSelectedRows` changed to `Map<GridRowId, GridRowModel>`
- [DataGrid] Return of `apiRef.current.getRowModels` changed to `Map<GridRowId, GridRowModel>`
- [DataGrid] Return of `apiRef.current.getVisibleRowModels` changed to `Map<GridRowId, GridRowModel>`

---

This is a follow up of #1371. Basically I changed all methods that were returning `GridRowModel[]` to `Map<GridRowId, GridRowModel>`. This structure allows to keep the computed id and data of each row isolated while maintaining the order that they were inserted, even for numeric ids. The sorting with 100k rows is freezing, I have to test again once #1368 gets merged.

Closes #1119
Closes #1200
Closes #1315