### PR TITLE
[license] Use a global storage rather than a module singleton

### DIFF
--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -25,6 +25,7 @@
     "licensegen": "./bin/license-gen-script.js"
   },
   "dependencies": {
+    "@material-ui/utils": "^5.0.0-alpha.14",
     "esm": "^3.2.25",
     "yargs": "^16.2.0"
   },

--- a/packages/x-license/src/licenseInfo.ts
+++ b/packages/x-license/src/licenseInfo.ts
@@ -5,7 +5,7 @@ import { ponyfillGlobal } from '@material-ui/utils';
 // when module duplication occurs. The duplication of the modules can happen
 // if using multiple version of Material-UI X at the same time of the bundler
 // decide to duplicate to improve the size of the chunks.
-ponyfillGlobal.__MUI_LICENSE_INFO__ ||= {
+ponyfillGlobal.__MUI_LICENSE_INFO__ = ponyfillGlobal.__MUI_LICENSE_INFO__ || {
   key: undefined as undefined | string,
   releaseInfo: undefined as undefined | string,
 };

--- a/packages/x-license/src/licenseInfo.ts
+++ b/packages/x-license/src/licenseInfo.ts
@@ -1,13 +1,29 @@
-export class LicenseInfo {
-  public static key: string;
+/* eslint-disable no-underscore-dangle */
+import { ponyfillGlobal } from '@material-ui/utils';
 
-  public static releaseInfo: string;
+// Store the license information in a global so it can be shared
+// when module duplication occurs. The duplication of the modules can happen
+// if using multiple version of Material-UI X at the same time of the bundler
+// decide to duplicate to improve the size of the chunks.
+ponyfillGlobal.__MUI_LICENSE_INFO__ ||= {
+  key: undefined as undefined | string,
+  releaseInfo: undefined as undefined | string,
+};
+
+export class LicenseInfo {
+  public static getKey(): string {
+    return ponyfillGlobal.__MUI_LICENSE_INFO__.key;
+  }
+
+  public static getReleaseInfo(): string {
+    return ponyfillGlobal.__MUI_LICENSE_INFO__.releaseInfo;
+  }
 
   public static setLicenseKey(key: string) {
-    LicenseInfo.key = key;
+    ponyfillGlobal.__MUI_LICENSE_INFO__.key = key;
   }
 
   public static setReleaseInfo(encodedReleaseInfo: string) {
-    LicenseInfo.releaseInfo = encodedReleaseInfo;
+    ponyfillGlobal.__MUI_LICENSE_INFO__.releaseInfo = encodedReleaseInfo;
   }
 }

--- a/packages/x-license/src/useLicenseVerifier.ts
+++ b/packages/x-license/src/useLicenseVerifier.ts
@@ -12,7 +12,7 @@ export function useLicenseVerifier() {
   const [licenseStatus, setLicenseStatus] = React.useState(LicenseStatus.Invalid);
 
   React.useEffect(() => {
-    const newLicenseStatus = verifyLicense(LicenseInfo.releaseInfo, LicenseInfo.key);
+    const newLicenseStatus = verifyLicense(LicenseInfo.getReleaseInfo(), LicenseInfo.getKey());
     setLicenseStatus(newLicenseStatus);
     if (newLicenseStatus === LicenseStatus.Invalid) {
       showInvalidLicenseError();


### PR DESCRIPTION
This is a follow-up of #1361. 

This is one possible option in order to get the tests run in watch mode in jsdom. It's not the only one. I have pushed this option forward as it seems to bring value for developers ending up with duplicates of `@material-ui/x-license` in their package.
The duplication can happen for multiple reasons. For instance, webpack might decide to optimize the bundle and duplicate the package between two chunks. Or a developer might use two different versions of our components. 
In order to solve these issues, we only have two viable options:

1. We make `@material-ui/x-license` a peer dependency of the other packages. It's has a singleton
2. We share the license info as a global.

I have moved with 2. We usually avoid this option as it can be a pain in the *** when releasing new versions. However,  we issue a license key that needs to work for each release in the next 12 months, we have to handle this versioning pain anyway. And, the license singleton is a plain simple structure, which makes it significantly easier to handle.