### PR TITLE
[test] Add yarn t support

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "prettier:all": "node ./scripts/prettier.js write",
     "size:snapshot": "node --max-old-space-size=2048 ./scripts/sizeSnapshot/create",
     "size:why": "yarn size:snapshot --analyze --accurateBundles",
+    "t": "node test/cli.js",
     "test": "lerna run test --parallel",
     "test:coverage": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/*.test.tsx' --exclude '**/node_modules/**' && nyc report -r lcovonly",
     "test:coverage:html": "cross-env NODE_ENV=test BABEL_ENV=coverage nyc mocha 'packages/**/*.test.tsx' --exclude '**/node_modules/**' && nyc report --reporter=html",

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,1 @@
+require('@material-ui/monorepo/test/cli');


### PR DESCRIPTION
This is a follow-up of #1361. I'm trying to bring https://github.com/mui-org/material-ui/pull/23369 to this repository. However, I'm facing a blocker with this line: [`const workspaceRoot = path.resolve(__dirname, '../');`](https://github.com/mui-org/material-ui/blob/87ae5ae931d99420fa7dd6b9ecb5d9010b6d3edb/test/cli.js#L8). It doesn't resolve to the correct root of this repository.

For prettier, we could get it working with this workaround: [`const workspaceRoot = process.cwd();`](https://github.com/mui-org/material-ui/blob/87ae5ae931d99420fa7dd6b9ecb5d9010b6d3edb/scripts/prettier.js#L15-L16)

@eps1lon do you have a preference on the solution we take this time?