### PR TITLE
[docs] Fix anchor links on the /data-grid/filtering/ page

### DIFF
--- a/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.js
+++ b/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.js
@@ -57,7 +57,7 @@ export default function ColumnTypeFilteringGrid() {
         }}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.js
+++ b/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.js
@@ -1,10 +1,6 @@
 import * as React from 'react';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import {
-  DataGrid,
-  getGridNumericColumnOperators,
-  GridPreferencePanelsValue,
-} from '@material-ui/data-grid';
+import { DataGrid, getGridNumericColumnOperators } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
 
 const priceColumnType = {
@@ -54,12 +50,6 @@ export default function ColumnTypeFilteringGrid() {
           items: [
             { columnField: 'totalPrice', value: '3000000', operatorValue: '>' },
           ],
-        }}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
         }}
       />
     </div>

--- a/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx
+++ b/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx
@@ -57,7 +57,7 @@ export default function ColumnTypeFilteringGrid() {
         }}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx
+++ b/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx
@@ -4,7 +4,6 @@ import {
   DataGrid,
   GridColTypeDef,
   getGridNumericColumnOperators,
-  GridPreferencePanelsValue,
 } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
 
@@ -54,12 +53,6 @@ export default function ColumnTypeFilteringGrid() {
           items: [
             { columnField: 'totalPrice', value: '3000000', operatorValue: '>' },
           ],
-        }}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
         }}
       />
     </div>

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Rating } from '@material-ui/lab';
-import { GridPreferencePanelsValue, DataGrid } from '@material-ui/data-grid';
+import { DataGrid } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
 
 const useStyles = makeStyles({
@@ -93,12 +93,6 @@ export default function CustomRatingOperator() {
         columns={columns}
         filterModel={{
           items: [{ columnField: 'rating', value: '3.5', operatorValue: 'from' }],
-        }}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
         }}
       />
     </div>

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
@@ -96,7 +96,7 @@ export default function CustomRatingOperator() {
         }}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx
@@ -3,7 +3,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Rating } from '@material-ui/lab';
 import {
   GridFilterInputValueProps,
-  GridPreferencePanelsValue,
   DataGrid,
   GridFilterItem,
   GridColDef,
@@ -87,12 +86,6 @@ export default function CustomRatingOperator() {
         columns={columns}
         filterModel={{
           items: [{ columnField: 'rating', value: '3.5', operatorValue: 'from' }],
-        }}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
         }}
       />
     </div>

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx
@@ -90,7 +90,7 @@ export default function CustomRatingOperator() {
         }}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
@@ -2,11 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Rating } from '@material-ui/lab';
-import {
-  DataGrid,
-  getGridNumericColumnOperators,
-  GridPreferencePanelsValue,
-} from '@material-ui/data-grid';
+import { DataGrid, getGridNumericColumnOperators } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
 
 const useStyles = makeStyles({
@@ -76,17 +72,7 @@ export default function ExtendNumericOperator() {
   }
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={data.rows}
-        columns={columns}
-        filterModel={filterModel}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
-        }}
-      />
+      <DataGrid rows={data.rows} columns={columns} filterModel={filterModel} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
@@ -82,7 +82,7 @@ export default function ExtendNumericOperator() {
         filterModel={filterModel}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx
@@ -5,7 +5,6 @@ import {
   DataGrid,
   GridFilterInputValueProps,
   getGridNumericColumnOperators,
-  GridPreferencePanelsValue,
 } from '@material-ui/data-grid';
 import { useDemoData } from '@material-ui/x-grid-data-generator';
 
@@ -65,17 +64,7 @@ export default function ExtendNumericOperator() {
   }
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <DataGrid
-        rows={data.rows}
-        columns={columns}
-        filterModel={filterModel}
-        state={{
-          preferencePanel: {
-            open: false,
-            openedPanelValue: GridPreferencePanelsValue.filters,
-          },
-        }}
-      />
+      <DataGrid rows={data.rows} columns={columns} filterModel={filterModel} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx
@@ -71,7 +71,7 @@ export default function ExtendNumericOperator() {
         filterModel={filterModel}
         state={{
           preferencePanel: {
-            open: true,
+            open: false,
             openedPanelValue: GridPreferencePanelsValue.filters,
           },
         }}

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -17,7 +17,9 @@ LicenseInfo.setLicenseKey(
 );
 
 const blacklist = [
-  // 'stories-grid-pagination/Page1Prop.png',
+  'docs-components-data-grid-filtering/CustomRatingOperator.png', // Needs interaction
+  'docs-components-data-grid-filtering/ColumnTypeFilteringGrid.png', // Needs interaction
+  'docs-components-data-grid-filtering/ExtendNumericOperator.png', // Needs interaction
   // 'docs-system-typography',
   /^stories(.*)(?<!Snap)\.png$/, // Excludes stories that aren't suffixed with 'Snap'.
 ];


### PR DESCRIPTION
This issue was spotted in one of our conversation with customers

<img width="959" alt="Screenshot 2021-04-11 at 17 26 17" src="https://user-images.githubusercontent.com/3165635/114310440-12e63180-9aeb-11eb-8e7d-b344ed4cd25b.png">

The link to https://material-ui.com/components/data-grid/filtering/#server-side-filter is broken. The preference panel traps the focus, which means calls `.focus()` on it when it opens. This moves the body scrollbar position.

The preference panel also closes as soon as a click is performed on the page, meaning, that the change in this PR only improves the UX on the documentation, there are no downsides.

As for improving the demo to have the preference panel open, we could imagine adding a button on the demo, or use a lazy-rendering strategy (only mount the demo once in the viewport, hoping it won't mess the scroll but it seems safe).

The fix in action: https://deploy-preview-1398--material-ui-x.netlify.app/components/data-grid/filtering/#server-side-filter (note that we fixed the scroll position flash in v5) 