### PR TITLE
[DataGrid] Fix support for numeric ids in selection

### DIFF
--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -53,7 +53,7 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
           }
           key={id}
           id={id}
-          selected={!!selectionState[id]}
+          selected={selectionState[id] !== undefined}
           rowIndex={renderState.renderContext!.firstRowIdx! + idx}
         >
           <GridEmptyCell width={renderState.renderContext!.leftEmptyWidth} height={rowHeight} />

--- a/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/seralizers/csvSeraliser.ts
@@ -31,7 +31,7 @@ export function serialiseRow(
 export function buildCSV(
   columns: GridColumns,
   rows: Map<GridRowId, GridRowModel>,
-  selectedRows: Record<GridRowId, boolean>,
+  selectedRows: Record<string, GridRowId>,
   getCellValue: (id: GridRowId, field: string) => GridCellValue,
 ): string {
   let rowIds = [...rows.keys()];

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -66,16 +66,6 @@ export const useGridKeyboard = (
     [apiRef, forceUpdate, logger, setGridState],
   );
 
-  const selectActiveRow = React.useCallback(() => {
-    const rowEl = findParentElementFromClassName(
-      document.activeElement as HTMLDivElement,
-      GRID_ROW_CSS_CLASS,
-    )! as HTMLElement;
-
-    const rowId = getIdFromRowElem(rowEl);
-    apiRef.current.selectRow(rowId);
-  }, [apiRef]);
-
   const expandSelection = React.useCallback(
     (params: GridCellParams, event: React.KeyboardEvent) => {
       const rowEl = findParentElementFromClassName(
@@ -164,7 +154,7 @@ export const useGridKeyboard = (
 
       if (isSpaceKey(event.key) && event.shiftKey) {
         event.preventDefault();
-        selectActiveRow();
+        apiRef.current.selectRow(params.id);
         return;
       }
 
@@ -189,7 +179,7 @@ export const useGridKeyboard = (
         apiRef.current.selectRows(apiRef.current.getAllRowIds(), true);
       }
     },
-    [apiRef, expandSelection, handleCopy, selectActiveRow],
+    [apiRef, expandSelection, handleCopy],
   );
 
   const handleColumnHeaderKeyDown = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionSelector.ts
@@ -23,5 +23,5 @@ export const selectedGridRowsSelector = createSelector<
   gridSelectionStateSelector,
   gridRowsLookupSelector,
   (selectedRows, rowsLookup) =>
-    new Map(Object.keys(selectedRows).map((id) => [id, rowsLookup[id]])),
+    new Map(Object.values(selectedRows).map((id) => [id, rowsLookup[id]])),
 );

--- a/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/gridSelectionState.ts
@@ -1,3 +1,3 @@
 import { GridRowId } from '../../../models/gridRows';
 
-export type GridSelectionState = Record<GridRowId, boolean>;
+export type GridSelectionState = Record<string, GridRowId>;

--- a/packages/grid/_modules_/grid/models/api/gridSelectionApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridSelectionApi.ts
@@ -9,10 +9,10 @@ export interface GridSelectionApi {
   /**
    * Toggle the row selected state.
    * @param id
-   * @param allowMultiple Default: false = deselect other rows if isSelected is true
    * @param isSelected Default true
+   * @param allowMultiple Default: false = deselect other rows if isSelected is true
    */
-  selectRow: (id: GridRowId, allowMultiple?: boolean, isSelected?: boolean) => void;
+  selectRow: (id: GridRowId, isSelected?: boolean, allowMultiple?: boolean) => void;
   /**
    * Batch toggle rows selected state.
    * @param ids

--- a/packages/grid/_modules_/grid/models/colDef/gridCheckboxSelection.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridCheckboxSelection.tsx
@@ -16,7 +16,7 @@ export const gridCheckboxSelectionColDef: GridColDef = {
   filterable: false,
   disableClickEventBubbling: true,
   disableColumnMenu: true,
-  valueGetter: (params) => params.api.getState().selection[params.id],
+  valueGetter: (params) => params.api.getState().selection[params.id] !== undefined,
   renderHeader: (params) => <GridHeaderCheckbox {...params} />,
   renderCell: (params) => <GridCellCheckboxRenderer {...params} />,
   cellClassName: 'MuiDataGrid-cellCheckbox',

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 // @ts-expect-error need to migrate helpers to TypeScript
 import { fireEvent, screen, createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
+import { spy } from 'sinon';
 import { DataGrid } from '@material-ui/data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
@@ -120,6 +121,41 @@ describe('<DataGrid /> - Selection', () => {
       // https://github.com/mui-org/material-ui-x/issues/190
       expect(row0).to.not.have.class('Mui-selected');
       expect(row1).to.have.class('Mui-selected');
+    });
+
+    it('should not call onSelectionModelChange if the new value is the same', () => {
+      const onSelectionModelChange = spy();
+      const data = {
+        rows: [
+          {
+            id: 0,
+            brand: 'Nike',
+          },
+          {
+            id: 1,
+            brand: 'Hugo Boss',
+          },
+        ],
+        columns: [{ field: 'brand', width: 100 }],
+        checkboxSelection: true,
+        onSelectionModelChange,
+      };
+      function Demo(props) {
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGrid {...data} selectionModel={props.selectionModel} />
+          </div>
+        );
+      }
+      const { setProps } = render(<Demo selectionModel={[0]} />);
+      expect(onSelectionModelChange.callCount).to.equal(1);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equals([0]);
+      setProps({ selectionModel: [0, 1] });
+      expect(onSelectionModelChange.callCount).to.equal(2);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equals([0, 1]);
+      setProps({ selectionModel: [0, 1] });
+      expect(onSelectionModelChange.callCount).to.equal(2);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equals([0, 1]);
     });
   });
 });

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -213,7 +213,7 @@ describe('<XGrid /> - Filter', () => {
     render(<TestCase checkboxSelection filterModel={newModel} />);
     const checkAllCell = getColumnHeaderCell(1).querySelector('input');
     fireEvent.click(checkAllCell);
-    expect(apiRef.current.getState().selection).to.deep.equal({ 1: true });
+    expect(apiRef.current.getState().selection).to.deep.equal({ 1: 1 });
   });
 
   it('should allow to clear filters by passing an empty filter model', () => {

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -1,13 +1,8 @@
 import * as React from 'react';
 import { createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
-import {
-  GridApiRef,
-  GridComponentProps,
-  useGridApiRef,
-  XGrid,
-  GRID_SELECTION_CHANGED,
-} from '@material-ui/x-grid';
+import { spy } from 'sinon';
+import { GridApiRef, GridComponentProps, useGridApiRef, XGrid } from '@material-ui/x-grid';
 
 describe('<XGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
@@ -20,43 +15,93 @@ describe('<XGrid /> - Selection', () => {
     }
   });
 
+  let apiRef: GridApiRef;
+
+  const baselineProps = {
+    rows: [
+      {
+        id: 0,
+        brand: 'Nike',
+      },
+      {
+        id: 1,
+        brand: 'Adidas',
+      },
+      {
+        id: 2,
+        brand: 'Puma',
+      },
+    ],
+    columns: [{ field: 'brand' }],
+  };
+
+  const Test = (props: Partial<GridComponentProps>) => {
+    apiRef = useGridApiRef();
+    return (
+      <div style={{ width: 300, height: 300 }}>
+        <XGrid apiRef={apiRef} {...baselineProps} {...props} />
+      </div>
+    );
+  };
+
   describe('getSelectedRows', () => {
-    const baselineProps = {
+    it('should return the latest values when called inside onSelectionModelChange', () => {
+      render(
+        <Test
+          onSelectionModelChange={() => {
+            expect(apiRef!.current.getSelectedRows().size).to.equal(1);
+            expect(apiRef!.current.getSelectedRows().get(1)).to.equal(baselineProps.rows[1]);
+          }}
+        />,
+      );
+      expect(apiRef!.current.getSelectedRows().size).to.equal(0);
+      apiRef!.current.selectRow(1);
+    });
+  });
+
+  describe('selectRow', () => {
+    it('should call onSelectionModelChange with the ids selected', () => {
+      const onSelectionModelChange = spy();
+      render(<Test onSelectionModelChange={onSelectionModelChange} />);
+      apiRef!.current.selectRow(1);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([1]);
+      apiRef!.current.selectRow(2);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([2]);
+      // Keep old selection
+      apiRef!.current.selectRow(3, true, true);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([2, 3]);
+      apiRef!.current.selectRow(3, false, true);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([2]);
+    });
+  });
+
+  describe('selectRows', () => {
+    it('should call onSelectionModelChange with the ids selected', () => {
+      const onSelectionModelChange = spy();
+      render(<Test onSelectionModelChange={onSelectionModelChange} />);
+      apiRef!.current.selectRows([1, 2]);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([1, 2]);
+      apiRef!.current.selectRows([3]);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([1, 2, 3]);
+      apiRef!.current.selectRows([1, 2], false);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([3]);
+      // Deselect others
+      apiRef!.current.selectRows([4, 5], true, true);
+      expect(onSelectionModelChange.lastCall.args[0].selectionModel).to.deep.equal([4, 5]);
+    });
+  });
+
+  it('should clean the selected ids when the rows prop changes', () => {
+    const { setProps } = render(<Test selectionModel={[0, 1, 2]} checkboxSelection />);
+    expect(apiRef.current.getSelectedRows()).to.have.keys([0, 1, 2]);
+    setProps({
       rows: [
         {
           id: 0,
           brand: 'Nike',
         },
-        {
-          id: 1,
-          brand: 'Adidas',
-        },
-        {
-          id: 2,
-          brand: 'Puma',
-        },
       ],
-      columns: [{ field: 'brand' }],
-    };
-
-    it('should always return the latest values', () => {
-      let apiRef: GridApiRef;
-      const Test = (props: Partial<GridComponentProps>) => {
-        apiRef = useGridApiRef();
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <XGrid apiRef={apiRef} {...baselineProps} {...props} />
-          </div>
-        );
-      };
-      render(<Test />);
-      expect(apiRef!.current.getSelectedRows().size).to.equal(0);
-      apiRef!.current.on(GRID_SELECTION_CHANGED, () => {
-        expect(apiRef!.current.getSelectedRows().size).to.equal(1);
-        // TODO remove cast to string once state.selection is converted to Map
-        expect(apiRef!.current.getSelectedRows().get('1')).to.equal(baselineProps.rows[1]);
-      });
-      apiRef!.current.selectRow(1);
     });
+    expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
   });
 });


### PR DESCRIPTION
Fixes #874

I changed to use a `Set`, as it supports numbers and strings and it's faster than a flat array or a object. This PR should be merged after #1377.