### PR TITLE
[docs] Fix GitHub references in API docs

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -163,7 +163,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component style](https://github.com/mui-org/material-ui-x/blob/master/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts) for more detail.
+If that's not sufficient, you can check the [implementation of the component style](https://github.com/mui-org/material-ui-x/blob/master/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts) for more detail.
 
 ## Demos
 

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -169,7 +169,7 @@ You can override the style of the component thanks to one of these customization
 - With a [global class name](/customization/components/#overriding-styles-with-global-class-names).
 - With a theme and an [`overrides` property](/customization/globals/#css).
 
-If that's not sufficient, you can check the [implementation of the component style](https://github.com/mui-org/material-ui-x/blob/master/packages/grid/_modules_/grid/components/styled-wrappers/GridRootStyles.ts) for more detail.
+If that's not sufficient, you can check the [implementation of the component style](https://github.com/mui-org/material-ui-x/blob/master/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts) for more detail.
 
 ## Demos
 


### PR DESCRIPTION
Fix GitHub references in API docs which are broken in these two pages:
https://material-ui.com/api/data-grid/
https://material-ui.com/api/x-grid/

The files were moved in 0719b02c6bd3f5e67b91299850b17d6ee1b5d050 and it seems an update of the docs were forgotten.

Fix #1281