### PR TITLE
[docs] Update PropType to cover required props

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -13,11 +13,12 @@ import { DataGrid } from '@material-ui/data-grid';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name required">columns<abbr title="required">*</abbr></span> | <span class="prop-type">GridColumns</span> |   | Set of columns of type 'GridColumns'. |
+| <span class="prop-name required">rows<abbr title="required">*</abbr></span> | <span class="prop-type">GridRowsProp</span> |  | Set of rows of type 'GridRowsProp'. |
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | Css classname to add on the outer container. |
-| <span class="prop-name required">columns<abbr title="required">*</abbr></span> | <span class="prop-type">GridColumns</span> |   | Set of columns of type 'GridColumns'. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">GridColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridSlotsComponent</span> |   | Overrideable components. |
@@ -75,7 +76,6 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">page</span> | <span class="prop-type">number</span> | 1   |  Set the current page. |
 | <span class="prop-name">pageSize</span> | <span class="prop-type">number</span> | 100 | Set the number of rows in one page. |
 | <span class="prop-name">paginationMode</span> | <span class="prop-type">GridFeatureMode</span> | 'client' | Pagination can be processed on the server or client-side. Set it to 'client' if you would like to handle the pagination on the client-side. Set it to 'server' if you would like to handle the pagination on the server-side. |
-| <span class="prop-name required">rows<abbr title="required">*</abbr></span> | <span class="prop-type">GridRowsProp</span> |  | Set of rows of type 'GridRowsProp'. |
 | <span class="prop-name">rowCount</span> | <span class="prop-type">number</span> |   |  Set the total number of rows, if it is different than the length of the value `rows` prop. |
 | <span class="prop-name">rowHeight</span> | <span class="prop-type">number</span> | 52 | Set the height in pixel of a row in the grid. |
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">number[]</span> | [25, 50, 100] | Select the pageSize dynamically using the component UI. |

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -13,12 +13,13 @@ import { XGrid } from '@material-ui/x-grid';
 
 | Name | Type | Default | Description |
 |:-----|:-----|:--------|:------------|
+| <span class="prop-name required">columns<abbr title="required">*</abbr></span> | <span class="prop-type">GridColumns</span> |   | Set of columns of type 'GridColumns'. |
+| <span class="prop-name required">rows<abbr title="required">*</abbr></span> | <span class="prop-type">GridRowsProp</span> |  | Set of rows of type 'GridRowsProp'. |
 | <span class="prop-name">apiRef</span> | <span class="prop-type">GridApiRef</span> |   | The ref object that allows grid manipulation. Can be instantiated with 'useGridApiRef()'. |
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | Css classname to add on the outer container. |
-| <span class="prop-name required">columns<abbr title="required">*</abbr></span> | <span class="prop-type">GridColumns</span> |   | Set of columns of type 'GridColumns'. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |
 | <span class="prop-name">columnTypes</span> | <span class="prop-type">GridColumnTypesRecord</span> |   | Extend native column types with your new column types. |
 | <span class="prop-name">components</span> | <span class="prop-type">GridSlotsComponent</span> |   | Overrideable components slots. |
@@ -80,7 +81,6 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">pageSize</span> | <span class="prop-type">number</span> | 100 | Set the number of rows in one page. |
 | <span class="prop-name">pagination</span> | <span class="prop-type">boolean</span> | false | If `true`, pagination is enabled. |
 | <span class="prop-name">paginationMode</span> | <span class="prop-type">GridFeatureMode</span> | 'client' | Pagination can be processed on the server or client-side. Set it to 'client' if you would like to handle the pagination on the client-side. Set it to 'server' if you would like to handle the pagination on the server-side. |
-| <span class="prop-name required">rows<abbr title="required">*</abbr></span> | <span class="prop-type">GridRowsProp</span> |  | Set of rows of type 'GridRowsProp'. |
 | <span class="prop-name">rowCount</span> | <span class="prop-type">number</span> |   |  Set the total number of rows, if it is different than the length of the value `rows` prop. |
 | <span class="prop-name">rowHeight</span> | <span class="prop-type">number</span> | 52 | Set the height in pixel of a row in the grid. |
 | <span class="prop-name">rowsPerPageOptions</span> | <span class="prop-type">number[]</span> | [25, 50, 100] | Select the pageSize dynamically using the component UI. |

--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -40,7 +40,10 @@ export type DataGridProps = Omit<
 
 const MAX_PAGE_SIZE = 100;
 
-const DataGrid2 = React.forwardRef<HTMLDivElement, DataGridProps>(function DataGrid(inProps, ref) {
+const DataGridRaw = React.forwardRef<HTMLDivElement, DataGridProps>(function DataGrid(
+  inProps,
+  ref,
+) {
   const props = useThemeProps({ props: inProps, name: 'MuiDataGrid' });
   const { className, pageSize: pageSizeProp, ...other } = props;
 
@@ -61,7 +64,10 @@ const DataGrid2 = React.forwardRef<HTMLDivElement, DataGridProps>(function DataG
   );
 });
 
-DataGrid2.propTypes = {
+export const DataGrid = React.memo(DataGridRaw);
+
+// @ts-ignore
+DataGrid.propTypes = {
   apiRef: chainPropTypes(PropTypes.any, (props: any) => {
     if (props.apiRef != null) {
       return new Error(
@@ -75,7 +81,7 @@ DataGrid2.propTypes = {
     }
     return null;
   }),
-  columns: chainPropTypes(PropTypes.any, (props: any) => {
+  columns: chainPropTypes(PropTypes.array.isRequired, (props: any) => {
     if (props.columns && props.columns.some((column) => column.resizable)) {
       return new Error(
         [
@@ -192,6 +198,7 @@ DataGrid2.propTypes = {
     }
     return null;
   }),
+  rows: PropTypes.array.isRequired,
   scrollEndThreshold: chainPropTypes(PropTypes.number, (props: any) => {
     if (props.scrollEndThreshold) {
       return new Error(
@@ -205,10 +212,4 @@ DataGrid2.propTypes = {
     }
     return null;
   }),
-  rows: PropTypes.array.isRequired,
 } as any;
-
-export const DataGrid = React.memo(DataGrid2);
-
-// @ts-ignore
-DataGrid.Naked = DataGrid2;

--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -205,6 +205,7 @@ DataGrid2.propTypes = {
     }
     return null;
   }),
+  rows: PropTypes.array.isRequired,
 } as any;
 
 export const DataGrid = React.memo(DataGrid2);

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -417,9 +417,11 @@ describe('<DataGrid /> - Layout & Warnings', () => {
       expect(() => {
         PropTypes.checkPropTypes(
           // @ts-ignore
-          DataGrid.Naked.propTypes,
+          DataGrid.propTypes,
           {
             pagination: false,
+            columns: [],
+            rows: [],
           },
           'prop',
           'MockedDataGrid',

--- a/packages/grid/x-grid/src/XGrid.tsx
+++ b/packages/grid/x-grid/src/XGrid.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import { LicenseInfo, useLicenseVerifier } from '@material-ui/x-license';
 import { ponyfillGlobal } from '@material-ui/utils';
 import { GridComponent, GridComponentProps, classnames, useThemeProps } from '../../_modules_/grid';
@@ -17,19 +18,25 @@ LicenseInfo.setReleaseInfo(RELEASE_INFO);
 
 export type XGridProps = Omit<GridComponentProps, 'licenseStatus'>;
 
-export const XGrid = React.memo(
-  React.forwardRef<HTMLDivElement, XGridProps>(function XGrid(inProps, ref) {
-    const props = useThemeProps({ props: inProps, name: 'MuiDataGrid' });
-    const { className, ...other } = props;
-    const licenseStatus = useLicenseVerifier();
+const XGridRaw = React.forwardRef<HTMLDivElement, XGridProps>(function XGrid(inProps, ref) {
+  const props = useThemeProps({ props: inProps, name: 'MuiDataGrid' });
+  const { className, ...other } = props;
+  const licenseStatus = useLicenseVerifier();
 
-    return (
-      <GridComponent
-        ref={ref}
-        className={classnames('MuiDataGrid-root', className)}
-        {...other}
-        licenseStatus={licenseStatus.toString()}
-      />
-    );
-  }),
-);
+  return (
+    <GridComponent
+      ref={ref}
+      className={classnames('MuiDataGrid-root', className)}
+      {...other}
+      licenseStatus={licenseStatus.toString()}
+    />
+  );
+});
+
+export const XGrid = React.memo(XGridRaw);
+
+// @ts-ignore
+XGridRaw.propTypes = {
+  columns: PropTypes.array.isRequired,
+  rows: PropTypes.array.isRequired,
+} as any;


### PR DESCRIPTION
Fixes #982. The change improves the DX for developers that have ignored the TypeScript lint errors. It's not a bit easier to recover when not provided the right props:

<img width="1268" alt="Screenshot 2021-04-17 at 16 37 24" src="https://user-images.githubusercontent.com/3165635/115116697-461d3a80-9f9b-11eb-8dba-8ff54533b971.png">

Also, we sort required props to be first as said in this [comment](https://github.com/mui-org/material-ui-x/issues/982#issuecomment-774056422) first point.