### PR TITLE
[XGrid] Fix multi-sorting when focus is not in the grid root

### DIFF
--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -79,5 +79,3 @@ export const GRID_SORT_MODEL_CHANGE = 'sortModelChange';
 export const GRID_FILTER_MODEL_CHANGE = 'filterModelChange';
 
 export const GRID_STATE_CHANGE = 'stateChange';
-
-export const GRID_MULTIPLE_KEY_PRESS_CHANGED = 'multipleKeyPressChange';

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -8,7 +8,6 @@ import {
   GRID_ELEMENT_FOCUS_OUT,
   GRID_KEYDOWN,
   GRID_KEYUP,
-  GRID_MULTIPLE_KEY_PRESS_CHANGED,
   GRID_COLUMN_HEADER_NAVIGATION_KEYDOWN,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
@@ -61,9 +60,8 @@ export const useGridKeyboard = (
       }
 
       forceUpdate();
-      apiRef.current.publishEvent(GRID_MULTIPLE_KEY_PRESS_CHANGED, isPressed);
     },
-    [apiRef, forceUpdate, logger, setGridState],
+    [forceUpdate, logger, setGridState],
   );
 
   const selectActiveRow = React.useCallback(() => {

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -3,7 +3,6 @@ import { GRID_ROW_CSS_CLASS } from '../../../constants/cssClassesConstants';
 import {
   GRID_CELL_KEYDOWN,
   GRID_CELL_NAVIGATION_KEYDOWN,
-  GRID_COLUMN_HEADER_CLICK,
   GRID_COLUMN_HEADER_KEYDOWN,
   GRID_ELEMENT_FOCUS_OUT,
   GRID_KEYDOWN,
@@ -207,15 +206,6 @@ export const useGridKeyboard = (
 
       if (isEnterKey(event.key) && (event.ctrlKey || event.metaKey)) {
         apiRef!.current.toggleColumnMenu(params.field);
-        return;
-      }
-
-      if (isEnterKey(event.key) || isSpaceKey(event.key)) {
-        apiRef.current.publishEvent(
-          GRID_COLUMN_HEADER_CLICK,
-          apiRef!.current.getColumnHeaderParams(params.field),
-          event,
-        );
       }
     },
     [apiRef],

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -216,7 +216,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
         return;
       }
       const sortItem = createSortItem(column, direction);
-      let sortModel: GridSortItem[] | undefined;
+      let sortModel: GridSortItem[];
       if (!allowMultipleSorting || options.disableMultipleColumnsSorting) {
         sortModel = !sortItem ? [] : [sortItem];
       } else {

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -228,7 +228,8 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
   );
 
   const headerClickHandler = React.useCallback(
-    ({ colDef }: GridColumnHeaderParams) => {
+    ({ colDef }: GridColumnHeaderParams, event: React.MouseEvent) => {
+      allowMultipleSorting.current = event.shiftKey || event.metaKey || event.ctrlKey;
       sortColumn(colDef);
     },
     [sortColumn],

--- a/packages/grid/_modules_/grid/models/api/gridSortApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridSortApi.ts
@@ -29,8 +29,13 @@ export interface GridSortApi {
    * Set the sort direction of a column.
    * @param column
    * @param direction
+   * @param allowMultipleSorting
    */
-  sortColumn: (column: GridColDef, direction?: GridSortDirection) => void;
+  sortColumn: (
+    column: GridColDef,
+    direction?: GridSortDirection,
+    allowMultipleSorting?: boolean,
+  ) => void;
   /**
    * Get the full set of sorted rows as [[GridRowModel]].
    * @returns [[GridRowModel]]

--- a/packages/grid/_modules_/grid/utils/keyboardUtils.ts
+++ b/packages/grid/_modules_/grid/utils/keyboardUtils.ts
@@ -38,3 +38,6 @@ export const isNavigationKey = (key: string) =>
 export const isKeyboardEvent = (event: any): event is React.KeyboardEvent => !!event.key;
 
 export const isHideMenuKey = (key) => isTabKey(key) || isEscapeKey(key);
+
+export const isMultipleKeyPressed = (event: any) =>
+  event.shiftKey || event.metaKey || event.ctrlKey;

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -38,7 +38,11 @@ describe('<XGrid /> - Sorting', () => {
 
   let apiRef: GridApiRef;
 
-  const TestCase = (props: { rows?: any[]; sortModel: GridSortModel }) => {
+  const TestCase = (props: {
+    rows?: any[];
+    sortModel: GridSortModel;
+    disableMultipleColumnsSorting?: boolean;
+  }) => {
     const baselineProps = {
       rows: [
         {
@@ -60,7 +64,7 @@ describe('<XGrid /> - Sorting', () => {
       columns: [{ field: 'brand' }, { field: 'year', type: 'number' }],
     };
 
-    const { sortModel, rows } = props;
+    const { sortModel, rows, disableMultipleColumnsSorting } = props;
     apiRef = useGridApiRef();
     return (
       <div style={{ width: 300, height: 300 }}>
@@ -69,6 +73,7 @@ describe('<XGrid /> - Sorting', () => {
           {...baselineProps}
           rows={rows || baselineProps.rows}
           sortModel={sortModel}
+          disableMultipleColumnsSorting={disableMultipleColumnsSorting}
         />
       </div>
     );
@@ -141,12 +146,30 @@ describe('<XGrid /> - Sorting', () => {
     expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
   });
 
-  ['shiftKey', 'metaKey', 'ctrlKey'].forEach((key) => {
-    it(`should do a multi-sorting when clicking the header cell while the ${key} is pressed`, () => {
+  describe('multi-sorting', () => {
+    ['shiftKey', 'metaKey', 'ctrlKey'].forEach((key) => {
+      it(`should do a multi-sorting if ${key} is pressed`, () => {
+        render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
+        expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+        fireEvent.click(getColumnHeaderCell(1), { [key]: true });
+        expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
+      });
+    });
+
+    it(`should not do a multi-sorting if no multiple key is pressed`, () => {
       render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
       expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
-      fireEvent.click(getColumnHeaderCell(1), { [key]: true });
-      expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
+      fireEvent.click(getColumnHeaderCell(1));
+      expect(getColumnValues()).to.deep.equal(['Adidas', 'Nike', 'Puma']);
+    });
+
+    it('should not do a multi-sorting if disableMultipleColumnsSorting is true', () => {
+      render(
+        <TestCase sortModel={[{ field: 'year', sort: 'desc' }]} disableMultipleColumnsSorting />,
+      );
+      expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+      fireEvent.click(getColumnHeaderCell(1), { shiftKey: true });
+      expect(getColumnValues()).to.deep.equal(['Adidas', 'Nike', 'Puma']);
     });
   });
 

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -3,7 +3,7 @@ import { GridApiRef, GridSortModel, useGridApiRef } from '@material-ui/data-grid
 import { XGrid } from '@material-ui/x-grid';
 import { expect } from 'chai';
 import { useFakeTimers } from 'sinon';
-import { getColumnValues } from 'test/utils/helperFn';
+import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
 import {
   createClientRenderStrictMode,
   // @ts-expect-error need to migrate helpers to TypeScript
@@ -139,6 +139,15 @@ describe('<XGrid /> - Sorting', () => {
 
     apiRef.current.setSortModel(sortModel);
     expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
+  });
+
+  ['shiftKey', 'metaKey', 'ctrlKey'].forEach((key) => {
+    it(`should do a multi-sorting when clicking the header cell while the ${key} is pressed`, () => {
+      render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
+      expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+      fireEvent.click(getColumnHeaderCell(1), { [key]: true });
+      expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
+    });
   });
 
   describe('performance', () => {

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -148,12 +148,30 @@ describe('<XGrid /> - Sorting', () => {
 
   describe('multi-sorting', () => {
     ['shiftKey', 'metaKey', 'ctrlKey'].forEach((key) => {
-      it(`should do a multi-sorting if ${key} is pressed`, () => {
+      it(`should do a multi-sorting when clicking the header cell while ${key} is pressed`, () => {
         render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
         expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
         fireEvent.click(getColumnHeaderCell(1), { [key]: true });
         expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
       });
+    });
+
+    ['metaKey', 'ctrlKey'].forEach((key) => {
+      it(`should do nothing when pressing Enter while ${key} is pressed`, () => {
+        render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
+        expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+        getColumnHeaderCell(1).focus();
+        fireEvent.keyDown(getColumnHeaderCell(1), { key: 'Enter', [key]: true });
+        expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+      });
+    });
+
+    it('should do a multi-sorting pressing Enter while shiftKey is pressed', () => {
+      render(<TestCase sortModel={[{ field: 'year', sort: 'desc' }]} />);
+      expect(getColumnValues()).to.deep.equal(['Puma', 'Nike', 'Adidas']);
+      getColumnHeaderCell(1).focus();
+      fireEvent.keyDown(getColumnHeaderCell(1), { key: 'Enter', shiftKey: true });
+      expect(getColumnValues()).to.deep.equal(['Puma', 'Adidas', 'Nike']);
     });
 
     it(`should not do a multi-sorting if no multiple key is pressed`, () => {


### PR DESCRIPTION
Fixes #1204 

There're multiple solutions to this bug:

1. Check if a multiple key was pressed during `click`.
2. Listen for `keydown` events in the document.
3. 1 + remove the `GRID_MULTIPLE_KEY_PRESS_CHANGED` listener and add a 3nd argument to `sortColumn` for when it's called programatically.

~I went with 1, as it's the simplest and has less side effects than 2.~ 3