### PR TITLE
[core] Label our packages as side effect free

### DIFF
--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -10,6 +10,7 @@
     "dist/*"
   ],
   "license": "MIT",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -10,6 +10,7 @@
     "dist/*"
   ],
   "license": "MIT",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -10,6 +10,7 @@
     "dist/*"
   ],
   "license": "See LICENSE file",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -18,6 +18,7 @@
     "dist/*"
   ],
   "license": "See LICENSE file",
+  "sideEffects": false,
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
A follow-up on https://github.com/mui-org/material-ui-x/pull/1447#discussion_r619691464. This is a mandatory step toward making the data grid packages tree shakeable. I'm not aware of any module side effects in the code, it should be safe.