### PR TITLE
[l10n] Correct quantities in plPL locale

### DIFF
--- a/packages/grid/_modules_/grid/locales/plPL.ts
+++ b/packages/grid/_modules_/grid/locales/plPL.ts
@@ -24,7 +24,7 @@ export const plPLGrid: Partial<GridLocaleText> = {
   toolbarFiltersLabel: 'Pokaż filtry',
   toolbarFiltersTooltipHide: 'Ukryj filtry',
   toolbarFiltersTooltipShow: 'Pokaż filtry',
-  toolbarFiltersTooltipActive: (count) => `Ilość aktywnych filtrów: ${count}`,
+  toolbarFiltersTooltipActive: (count) => `Liczba aktywnych filtrów: ${count}`,
 
   // Export selector toolbar button text
   toolbarExport: 'Eksportuj',
@@ -70,12 +70,12 @@ export const plPLGrid: Partial<GridLocaleText> = {
   columnMenuSortDesc: 'Sortuj malejąco',
 
   // Column header text
-  columnHeaderFiltersTooltipActive: (count) => `Ilość aktywnych filtrów: ${count}`,
+  columnHeaderFiltersTooltipActive: (count) => `Liczba aktywnych filtrów: ${count}`,
   columnHeaderFiltersLabel: 'Pokaż filtry',
   columnHeaderSortIconLabel: 'Sortuj',
 
   // Rows selected footer text
-  footerRowSelected: (count) => `Ilość wybranych wierszy: ${count.toLocaleString()}`,
+  footerRowSelected: (count) => `Liczba wybranych wierszy: ${count.toLocaleString()}`,
 
   // Total rows footer text
   footerTotalRows: 'Łączna liczba wierszy:',


### PR DESCRIPTION
When it comes to quantities, in polish 'liczba' does not equal 'ilość'.
Same as in English:
"Number refers to how many of something there is: how many mice, how many mutations, or how many calcium channels, for example. In other words, number refers to items we can count.

By contrast, amount refers to how much of something there is: how much stimulation, how much resistance, or how much liquid. In effect, amount refers to quantities we can measure but not individually count."
"Amount" is "ilość" and "number of" is "liczba".
In conclusion, I think it's a welcome small change 👍