### PR TITLE
[core] Drop support for Node 10

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -48,20 +48,20 @@ samsung 11.1-11.2
 
 # snapshot of `npx browserslist "maintained node versions"`
 [node]
-node 10.0
+node 12.0
 
 # same as `node`
 [coverage]
-node 10.0
+node 12.0
 
 # same as `node`
 [development]
-node 10.0
+node 12.0
 
 # same as `node`
 [test]
-node 10.0
+node 12.0
 
 # same as `node`
 [benchmark]
-node 10.0
+node 12.0

--- a/.codesandbox/ci.json
+++ b/.codesandbox/ci.json
@@ -1,5 +1,6 @@
 {
   "buildCommand": "build:codesandbox",
+  "node": "12",
   "packages": [
     "packages/x-license",
     "packages/grid/data-grid",

--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,7 @@
   command = "yarn docs:build && yarn docs:export && yarn storybook:build && yarn storybook:export"
 
 [build.environment]
-  NODE_VERSION = "10"
+  NODE_VERSION = "12"
   NODE_OPTIONS = "--max_old_space_size=4096"
   # Not using `playwright` when building docs.
   PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD = "1"

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -43,6 +43,6 @@
     "<rootDir>/src/setupTests.js"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   }
 }

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -43,6 +43,6 @@
     "<rootDir>/src/setupTests.js"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   }
 }

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -44,6 +44,6 @@
     "<rootDir>/src/setupTests.js"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   }
 }

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -36,6 +36,6 @@
     "<rootDir>/src/setupTests.js"
   ],
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   }
 }


### PR DESCRIPTION
**BREAKING CHANGE**

- [core] Increase the minimum Node.js version from 10.x to 12.x

---

Closes #1312 

Also enables to upgrade @material-ui/monorepo and many other packages like in PRs #1484, #1478