### PR TITLE
[test] Add test case for .focus stealing

### DIFF
--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -232,4 +232,19 @@ describe('<XGrid /> - Edit Rows', () => {
     expect(cell).to.have.text('1970');
     expect(getActiveCell()).to.equal('1-0');
   });
+
+  it('should the focus to the new field', () => {
+    const handleCellBlur = (params, event) => {
+      if (params.cellMode === 'edit') {
+        event?.stopPropagation();
+      }
+    };
+    render(<TestCase onCellBlur={handleCellBlur} />);
+    apiRef!.current.setCellMode(0, 'brand', 'edit');
+    getCell(1, 0).focus();
+    apiRef!.current.setCellMode(1, 'brand', 'edit');
+    const input = getCell(0, 0).querySelector('input');
+    fireEvent.click(input);
+    expect(document.activeElement).to.have.property('value', 'Nike');
+  });
 });

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -240,12 +240,18 @@ describe('<XGrid /> - Edit Rows', () => {
       }
     };
     render(<TestCase onCellBlur={handleCellBlur} />);
+    // Turn first cell into edit mode
     apiRef!.current.setCellMode(0, 'brand', 'edit');
+
+    // Turn second cell into edit mode
     getCell(1, 0).focus();
     apiRef!.current.setCellMode(1, 'brand', 'edit');
-    const input = getCell(0, 0).querySelector('input');
-    input!.focus();
-    fireEvent.click(input);
+    expect(document.querySelectorAll('input').length).to.equal(2);
+
+    // Try to focus the first cell's input
+    const input0 = getCell(0, 0).querySelector('input');
+    input0!.focus();
+    fireEvent.click(input0);
     expect(document.activeElement).to.have.property('value', 'Nike');
   });
 });

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -244,6 +244,7 @@ describe('<XGrid /> - Edit Rows', () => {
     getCell(1, 0).focus();
     apiRef!.current.setCellMode(1, 'brand', 'edit');
     const input = getCell(0, 0).querySelector('input');
+    input!.focus();
     fireEvent.click(input);
     expect(document.activeElement).to.have.property('value', 'Nike');
   });


### PR DESCRIPTION
Asked by @dtassone in #1421. This is a test case for this bug #1416. It took me 27 minutes (actually, more with the polish).
Regarding what's going wrong with the bug:

1. Focus is on input 2
2. Clicking on input 1 triggers the row selection
3. The row selection update the state
4. The update of the state rerenders the cell
5. The rerender of the call triggers the useLayoutEffect with the .focus()

⚠️ I think that I will mention this each time I find this problem surface. It might the third time already 😛. I have never seen calling .focus() inside a cell a solution that can work (too many edge cases). I would highly recommend managing the focus imperatively . I guess the longer it stays, the more battle-tested it becomes, the more we will know if it's flying or not.