### PR TITLE
[docs] Fix focus isn't set on the text box in `Edit using external button` demo

### DIFF
--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -79,7 +79,7 @@ export default function StartEditButtonGrid() {
 
   // Prevent from rolling back on escape
   const handleCellKeyDown = React.useCallback((params, event) => {
-    if (['Escape', 'Delete', 'Enter'].includes(event.key)) {
+    if (['Escape', 'Delete', 'Backspace', 'Enter'].includes(event.key)) {
       event.stopPropagation();
     }
   }, []);

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -32,7 +32,7 @@ function EditToolbar({
       setButtonLabel('Save');
     }
     // Or you can use the editRowModel prop, but I find it easier with apiRef
-  }, [apiRef, selectedCellParams, setButtonLabel]);
+  }, [apiRef, selectedCellParams, setButtonLabel, setSelectedCellParams]);
 
   return (
     <div

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -36,7 +36,7 @@ function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }
       }}
     >
       <Button
-        onMouseDown={handleButtonClick}
+        onClick={handleButtonClick}
         disabled={!selectedCellParams}
         color="primary"
       >

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -79,10 +79,7 @@ export default function StartEditButtonGrid() {
 
   // Prevent from rolling back on escape
   const handleCellKeyDown = React.useCallback((params, event) => {
-    if (
-      params.cellMode === 'edit' &&
-      (event.key === 'Escape' || event.key === 'Delete' || event.key === 'Enter')
-    ) {
+    if (['Escape', 'Delete', 'Enter'].includes(event.key)) {
       event.stopPropagation();
     }
   }, []);

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
-import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { useGridApiRef, XGrid } from '@material-ui/x-grid';
 import {
@@ -8,15 +7,21 @@ import {
   randomTraderName,
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
+import { makeStyles } from '@material-ui/core/styles';
 
-function EditToolbar({
-  buttonLabel,
-  selectedCellParams,
-  apiRef,
-  setButtonLabel,
-  setSelectedCellParams,
-}) {
-  const handleButtonClick = React.useCallback(() => {
+const useStyles = makeStyles((theme) => ({
+  root: {
+    justifyContent: 'center',
+    display: 'flex',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+}));
+
+function EditToolbar(props) {
+  const { selectedCellParams, apiRef, setSelectedCellParams } = props;
+  const classes = useStyles();
+
+  const handleClick = () => {
     if (!selectedCellParams) {
       return;
     }
@@ -25,56 +30,38 @@ function EditToolbar({
       const editedCellProps = apiRef.current.getEditCellPropsParams(id, field);
       apiRef.current.commitCellChange(editedCellProps);
       apiRef.current.setCellMode(id, field, 'view');
-      setButtonLabel('Edit');
+      setSelectedCellParams({ ...selectedCellParams, cellMode: 'view' });
     } else {
       apiRef.current.setCellMode(id, field, 'edit');
       setSelectedCellParams({ ...selectedCellParams, cellMode: 'edit' });
-      setButtonLabel('Save');
     }
-    // Or you can use the editRowModel prop, but I find it easier with apiRef
-  }, [apiRef, selectedCellParams, setButtonLabel, setSelectedCellParams]);
+  };
+
+  const handleMouseDown = (event) => {
+    // Keep the focus in the cell
+    event.preventDefault();
+  };
 
   return (
-    <div
-      style={{
-        justifyContent: 'center',
-        display: 'flex',
-        borderBottom: '1px solid rgba(224, 224, 224, 1)',
-      }}
-    >
+    <div className={classes.root}>
       <Button
-        onClick={handleButtonClick}
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
         disabled={!selectedCellParams}
         color="primary"
       >
-        {buttonLabel}
+        {selectedCellParams?.cellMode === 'edit' ? 'Save' : 'Edit'}
       </Button>
     </div>
   );
 }
 
-EditToolbar.propTypes = {
-  apiRef: PropTypes.any.isRequired,
-  buttonLabel: PropTypes.any.isRequired,
-  selectedCellParams: PropTypes.any.isRequired,
-  setButtonLabel: PropTypes.any.isRequired,
-  setSelectedCellParams: PropTypes.any.isRequired,
-};
-
 export default function StartEditButtonGrid() {
   const apiRef = useGridApiRef();
-  const [buttonLabel, setButtonLabel] = React.useState('Edit');
   const [selectedCellParams, setSelectedCellParams] = React.useState(null);
 
   const handleCellClick = React.useCallback((params) => {
     setSelectedCellParams(params);
-
-    const { cellMode } = params;
-    if (cellMode === 'edit') {
-      setButtonLabel('Save');
-    } else {
-      setButtonLabel('Edit');
-    }
   }, []);
 
   const handleDoubleCellClick = React.useCallback((params, event) => {
@@ -114,9 +101,7 @@ export default function StartEditButtonGrid() {
         componentsProps={{
           toolbar: {
             selectedCellParams,
-            buttonLabel,
             apiRef,
-            setButtonLabel,
             setSelectedCellParams,
           },
         }}

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -58,6 +58,7 @@ EditToolbar.propTypes = {
   buttonLabel: PropTypes.any.isRequired,
   selectedCellParams: PropTypes.any.isRequired,
   setButtonLabel: PropTypes.any.isRequired,
+  setSelectedCellParams: PropTypes.any.isRequired,
 };
 
 export default function StartEditButtonGrid() {

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -9,7 +9,13 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }) {
+function EditToolbar({
+  buttonLabel,
+  selectedCellParams,
+  apiRef,
+  setButtonLabel,
+  setSelectedCellParams,
+}) {
   const handleButtonClick = React.useCallback(() => {
     if (!selectedCellParams) {
       return;
@@ -22,6 +28,7 @@ function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }
       setButtonLabel('Edit');
     } else {
       apiRef.current.setCellMode(id, field, 'edit');
+      setSelectedCellParams({ ...selectedCellParams, cellMode: 'edit' });
       setButtonLabel('Save');
     }
     // Or you can use the editRowModel prop, but I find it easier with apiRef
@@ -109,6 +116,7 @@ export default function StartEditButtonGrid() {
             buttonLabel,
             apiRef,
             setButtonLabel,
+            setSelectedCellParams,
           },
         }}
       />

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.js
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
 import * as React from 'react';
+import PropTypes from 'prop-types';
 import Button from '@material-ui/core/Button';
 import { useGridApiRef, XGrid } from '@material-ui/x-grid';
 import {
@@ -55,6 +56,14 @@ function EditToolbar(props) {
     </div>
   );
 }
+
+EditToolbar.propTypes = {
+  apiRef: PropTypes.shape({
+    current: PropTypes.object.isRequired,
+  }).isRequired,
+  selectedCellParams: PropTypes.any.isRequired,
+  setSelectedCellParams: PropTypes.func.isRequired,
+};
 
 export default function StartEditButtonGrid() {
   const apiRef = useGridApiRef();

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -14,7 +14,13 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }) {
+function EditToolbar({
+  buttonLabel,
+  selectedCellParams,
+  apiRef,
+  setButtonLabel,
+  setSelectedCellParams,
+}) {
   const handleButtonClick = React.useCallback(() => {
     if (!selectedCellParams) {
       return;
@@ -27,6 +33,7 @@ function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }
       setButtonLabel('Edit');
     } else {
       apiRef.current.setCellMode(id, field, 'edit');
+      setSelectedCellParams({ ...selectedCellParams, cellMode: 'edit' });
       setButtonLabel('Save');
     }
     // Or you can use the editRowModel prop, but I find it easier with apiRef
@@ -119,6 +126,7 @@ export default function StartEditButtonGrid() {
             buttonLabel,
             apiRef,
             setButtonLabel,
+            setSelectedCellParams,
           },
         }}
       />

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -37,7 +37,7 @@ function EditToolbar({
       setButtonLabel('Save');
     }
     // Or you can use the editRowModel prop, but I find it easier with apiRef
-  }, [apiRef, selectedCellParams, setButtonLabel]);
+  }, [apiRef, selectedCellParams, setButtonLabel, setSelectedCellParams]);
 
   return (
     <div

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -32,6 +32,7 @@ function EditToolbar(props) {
       const editedCellProps = apiRef.current.getEditCellPropsParams(id, field);
       apiRef.current.commitCellChange(editedCellProps);
       apiRef.current.setCellMode(id, field, 'view');
+      setSelectedCellParams({ ...selectedCellParams, cellMode: 'view' });
       setButtonLabel('Edit');
     } else {
       apiRef.current.setCellMode(id, field, 'edit');

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -40,6 +40,11 @@ function EditToolbar(props) {
     }
   };
 
+  const handleMouseDown = (event) => {
+    // Keep the focus in the cell
+    event.preventDefault();
+  };
+
   return (
     <div
       style={{
@@ -48,7 +53,12 @@ function EditToolbar(props) {
         borderBottom: '1px solid rgba(224, 224, 224, 1)',
       }}
     >
-      <Button onClick={handleClick} disabled={!selectedCellParams} color="primary">
+      <Button
+        onClick={handleClick}
+        onMouseDown={handleMouseDown}
+        disabled={!selectedCellParams}
+        color="primary"
+      >
         {buttonLabel}
       </Button>
     </div>

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -13,9 +13,19 @@ import {
   randomTraderName,
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    justifyContent: 'center',
+    display: 'flex',
+    borderBottom: `1px solid ${theme.palette.divider}`,
+  },
+}));
 
 function EditToolbar(props) {
   const { selectedCellParams, apiRef, setSelectedCellParams } = props;
+  const classes = useStyles();
 
   const handleClick = () => {
     if (!selectedCellParams) {
@@ -39,13 +49,7 @@ function EditToolbar(props) {
   };
 
   return (
-    <div
-      style={{
-        justifyContent: 'center',
-        display: 'flex',
-        borderBottom: '1px solid rgba(224, 224, 224, 1)',
-      }}
-    >
+    <div className={classes.root}>
       <Button
         onClick={handleClick}
         onMouseDown={handleMouseDown}

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -15,13 +15,7 @@ import {
 } from '@material-ui/x-grid-data-generator';
 
 function EditToolbar(props) {
-  const {
-    buttonLabel,
-    selectedCellParams,
-    apiRef,
-    setButtonLabel,
-    setSelectedCellParams,
-  } = props;
+  const { selectedCellParams, apiRef, setSelectedCellParams } = props;
 
   const handleClick = () => {
     if (!selectedCellParams) {
@@ -33,11 +27,9 @@ function EditToolbar(props) {
       apiRef.current.commitCellChange(editedCellProps);
       apiRef.current.setCellMode(id, field, 'view');
       setSelectedCellParams({ ...selectedCellParams, cellMode: 'view' });
-      setButtonLabel('Edit');
     } else {
       apiRef.current.setCellMode(id, field, 'edit');
       setSelectedCellParams({ ...selectedCellParams, cellMode: 'edit' });
-      setButtonLabel('Save');
     }
   };
 
@@ -60,7 +52,7 @@ function EditToolbar(props) {
         disabled={!selectedCellParams}
         color="primary"
       >
-        {buttonLabel}
+        {selectedCellParams?.cellMode === 'edit' ? 'Save' : 'Edit'}
       </Button>
     </div>
   );
@@ -68,7 +60,6 @@ function EditToolbar(props) {
 
 export default function StartEditButtonGrid() {
   const apiRef = useGridApiRef();
-  const [buttonLabel, setButtonLabel] = React.useState('Edit');
   const [
     selectedCellParams,
     setSelectedCellParams,
@@ -76,13 +67,6 @@ export default function StartEditButtonGrid() {
 
   const handleCellClick = React.useCallback((params: GridCellParams) => {
     setSelectedCellParams(params);
-
-    const { cellMode } = params;
-    if (cellMode === 'edit') {
-      setButtonLabel('Save');
-    } else {
-      setButtonLabel('Edit');
-    }
   }, []);
 
   const handleDoubleCellClick = React.useCallback(
@@ -131,9 +115,7 @@ export default function StartEditButtonGrid() {
         componentsProps={{
           toolbar: {
             selectedCellParams,
-            buttonLabel,
             apiRef,
-            setButtonLabel,
             setSelectedCellParams,
           },
         }}

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -14,14 +14,16 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-function EditToolbar({
-  buttonLabel,
-  selectedCellParams,
-  apiRef,
-  setButtonLabel,
-  setSelectedCellParams,
-}) {
-  const handleButtonClick = React.useCallback(() => {
+function EditToolbar(props) {
+  const {
+    buttonLabel,
+    selectedCellParams,
+    apiRef,
+    setButtonLabel,
+    setSelectedCellParams,
+  } = props;
+
+  const handleClick = () => {
     if (!selectedCellParams) {
       return;
     }
@@ -36,8 +38,7 @@ function EditToolbar({
       setSelectedCellParams({ ...selectedCellParams, cellMode: 'edit' });
       setButtonLabel('Save');
     }
-    // Or you can use the editRowModel prop, but I find it easier with apiRef
-  }, [apiRef, selectedCellParams, setButtonLabel, setSelectedCellParams]);
+  };
 
   return (
     <div
@@ -47,11 +48,7 @@ function EditToolbar({
         borderBottom: '1px solid rgba(224, 224, 224, 1)',
       }}
     >
-      <Button
-        onClick={handleButtonClick}
-        disabled={!selectedCellParams}
-        color="primary"
-      >
+      <Button onClick={handleClick} disabled={!selectedCellParams} color="primary">
         {buttonLabel}
       </Button>
     </div>

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -90,10 +90,7 @@ export default function StartEditButtonGrid() {
   // Prevent from rolling back on escape
   const handleCellKeyDown = React.useCallback(
     (params, event: React.KeyboardEvent) => {
-      if (
-        params.cellMode === 'edit' &&
-        (event.key === 'Escape' || event.key === 'Delete' || event.key === 'Enter')
-      ) {
+      if (['Escape', 'Delete', 'Enter'].includes(event.key)) {
         event.stopPropagation();
       }
     },

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -41,7 +41,7 @@ function EditToolbar({ buttonLabel, selectedCellParams, apiRef, setButtonLabel }
       }}
     >
       <Button
-        onMouseDown={handleButtonClick}
+        onClick={handleButtonClick}
         disabled={!selectedCellParams}
         color="primary"
       >

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -90,7 +90,7 @@ export default function StartEditButtonGrid() {
   // Prevent from rolling back on escape
   const handleCellKeyDown = React.useCallback(
     (params, event: React.KeyboardEvent) => {
-      if (['Escape', 'Delete', 'Enter'].includes(event.key)) {
+      if (['Escape', 'Delete', 'Backspace', 'Enter'].includes(event.key)) {
         event.stopPropagation();
       }
     },

--- a/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/StartEditButtonGrid.tsx
@@ -7,6 +7,7 @@ import {
   GridRowsProp,
   useGridApiRef,
   XGrid,
+  GridApiRef,
 } from '@material-ui/x-grid';
 import {
   randomCreatedDate,
@@ -23,7 +24,13 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-function EditToolbar(props) {
+interface EditToolbarProps {
+  apiRef: GridApiRef;
+  setSelectedCellParams: (value: any) => void;
+  selectedCellParams: any;
+}
+
+function EditToolbar(props: EditToolbarProps) {
   const { selectedCellParams, apiRef, setSelectedCellParams } = props;
   const classes = useStyles();
 


### PR DESCRIPTION
Fixes #1502

Not sure why `onMouseDown` doesn't work 😅 , does it stop event propagation?

Preview: https://deploy-preview-1515--material-ui-x.netlify.app/components/data-grid/editing/#edit-using-external-button