### PR TITLE
[docs] Header convention for controllable prop

### DIFF
--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -56,7 +56,7 @@ The editable cells have a green background for better visibility.
 
 {{"demo": "pages/components/data-grid/editing/IsCellEditableGrid.js", "bg": "inline"}}
 
-### Control editing
+### Controlled editing
 
 The `editRowsModel` prop lets you control the editing state.
 You can handle the `onEditRowModelChange` callback to control the `GridEditRowsModel` state.


### PR DESCRIPTION
All the headers that touch a controllable prop start with `Controlled`.