### PR TITLE
Fix typo

### DIFF
--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -68,7 +68,7 @@ export const GRID_ROWS_SCROLL_END = 'scroll:rowEnd';
 
 export const GRID_COLUMN_SEPARATOR_MOUSE_DOWN = 'columnSeparatorMouseDown';
 export const GRID_COLUMN_RESIZE = 'columnResize';
-export const GRID_COLUMN_RESIZE_COMMITED = 'columnResizeCommited';
+export const GRID_COLUMN_RESIZE_COMMITTED = 'columnResizeCommitted';
 export const GRID_COLUMN_RESIZE_START = 'columnResizeStart';
 export const GRID_COLUMN_RESIZE_STOP = 'columnResizeStop';
 

--- a/packages/grid/_modules_/grid/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/columnResize/useGridColumnResize.tsx
@@ -8,7 +8,7 @@ import {
   GRID_COLUMN_RESIZE_START,
   GRID_COLUMN_RESIZE_STOP,
   GRID_COLUMN_RESIZE,
-  GRID_COLUMN_RESIZE_COMMITED,
+  GRID_COLUMN_RESIZE_COMMITTED,
 } from '../../../constants/eventsConstants';
 import {
   GRID_HEADER_CELL_CSS_CLASS,
@@ -109,7 +109,7 @@ export const useGridColumnResize = (
     clearTimeout(stopResizeEventTimeout.current);
     stopResizeEventTimeout.current = setTimeout(() => {
       apiRef.current.publishEvent(GRID_COLUMN_RESIZE_STOP);
-      apiRef.current.publishEvent(GRID_COLUMN_RESIZE_COMMITED, {
+      apiRef.current.publishEvent(GRID_COLUMN_RESIZE_COMMITTED, {
         element: colElementRef.current,
         colDef: colDefRef.current,
         api: apiRef,
@@ -329,5 +329,5 @@ export const useGridColumnResize = (
   useGridApiEventHandler(apiRef, GRID_COLUMN_RESIZE_STOP, handleResizeStop);
 
   useGridApiOptionHandler(apiRef, GRID_COLUMN_RESIZE, options.onColumnResize);
-  useGridApiOptionHandler(apiRef, GRID_COLUMN_RESIZE_COMMITED, options.onColumnResizeCommitted);
+  useGridApiOptionHandler(apiRef, GRID_COLUMN_RESIZE_COMMITTED, options.onColumnResizeCommitted);
 };

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -2,7 +2,7 @@ import * as React from 'react';
 import {
   GRID_COLUMNS_UPDATED,
   GRID_COLUMN_ORDER_CHANGE,
-  GRID_COLUMN_RESIZE_COMMITED,
+  GRID_COLUMN_RESIZE_COMMITTED,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridColumnApi } from '../../../models/api/gridColumnApi';
@@ -207,7 +207,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
       const column = apiRef.current.getColumnFromField(field);
       apiRef.current.updateColumn({ ...column, width });
 
-      apiRef.current.publishEvent(GRID_COLUMN_RESIZE_COMMITED, {
+      apiRef.current.publishEvent(GRID_COLUMN_RESIZE_COMMITTED, {
         element: apiRef.current.getColumnHeaderElement(field),
         colDef: column,
         api: apiRef,


### PR DESCRIPTION
Fixes #1400 

FIxes the typo in the `GRID_COLUMN_RESIZE_COMMITED` -> `GRID_COLUMN_RESIZE_COMMITTED`

There were also discussions around the naming `onColumnResize` and `onColumnResizeCommitted`. I can make it to `onColumnSizeChange` but my concern with this is that it would also need to be triggered when the columns are resized because of screen size change. For example, if you use the fluid columns feature and resize the screen an option with a name like `onColumnSizeChange` would need to be called.

It would probably be a better idea to make a callback like this available on the column definition itself? Any thoughts about this?