### PR TITLE
[DataGrid] Add `onColumnVisibilityChange` prop

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -62,6 +62,7 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">onColumnOrderChange</span> | <span class="prop-type">(param: GridColumnOrderChangeParams, event: React.MouseEvent) => void</span> |   | Callback fired when a column is reordered. |
 | <span class="prop-name">onColumnResize</span> | <span class="prop-type">(param: GridColumnResizeParams) => void</span> |   | Callback fired when a column is resizing. |
 | <span class="prop-name">onColumnResizeCommitted</span> | <span class="prop-type">(param: GridColumnResizeParams) => void</span> |   | Callback fired when a column is resized. |
+| <span class="prop-name">onColumnVisibilityChange</span> | <span class="prop-type">(param: GridColumnVisibilityChangeParams) => void</span> |   | Callback fired when a column visibility changes. |
 | <span class="prop-name">onError</span> | <span class="prop-type">(args: any) => void</span> |   | Callback fired when an exception is thrown in the grid, or when the `showError` API method is called. |
 | <span class="prop-name">onEditCellChange</span> | <span class="prop-type">(params: GridEditCellParams) => void</span> |   |  Callback fired when the edit cell value changed. |
 | <span class="prop-name">onEditCellChangeCommitted</span> | <span class="prop-type">(params: GridEditCellParams) => void</span> |   | Callback fired when the cell changes are committed. |

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -66,6 +66,7 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">onColumnOrderChange</span> | <span class="prop-type">(param: GridColumnOrderChangeParams, event: React.MouseEvent) => void</span> |   | Callback fired when a column is reordered. |
 | <span class="prop-name">onColumnResize</span> | <span class="prop-type">(param: GridColumnResizeParams) => void</span> |   | Callback fired when a column is resizing. |
 | <span class="prop-name">onColumnResizeCommitted</span> | <span class="prop-type">(param: GridColumnResizeParams) => void</span> |   | Callback fired when a column is resized. |
+| <span class="prop-name">onColumnVisibilityChange</span> | <span class="prop-type">(param: GridColumnVisibilityChangeParams) => void</span> |   | Callback fired when a column visibility changes. |
 | <span class="prop-name">onError</span> | <span class="prop-type">(args: any) => void</span> |   | Callback fired when an exception is thrown in the grid, or when the `showError` API method is called. |
 | <span class="prop-name">onEditCellChange</span> | <span class="prop-type">(params: GridEditCellParams) => void</span> |   |  Callback fired when the edit cell value changed. |
 | <span class="prop-name">onEditCellChangeCommitted</span> | <span class="prop-type">(params: GridEditCellParams) => void</span> |   | Callback fired when the cell changes are committed. |

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/HideGridColMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/HideGridColMenuItem.tsx
@@ -16,7 +16,7 @@ export const HideGridColMenuItem = (props: GridFilterItemProps) => {
       onClick(event);
       // time for the transition
       timeoutRef.current = setTimeout(() => {
-        apiRef!.current.toggleColumn(column?.field, true);
+        apiRef!.current.setColumnVisibility(column?.field, true);
       }, 10);
     },
     [apiRef, column?.field, onClick],

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/HideGridColMenuItem.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/HideGridColMenuItem.tsx
@@ -16,8 +16,8 @@ export const HideGridColMenuItem = (props: GridFilterItemProps) => {
       onClick(event);
       // time for the transition
       timeoutRef.current = setTimeout(() => {
-        apiRef!.current.setColumnVisibility(column?.field, true);
-      }, 10);
+        apiRef!.current.setColumnVisibility(column?.field, false);
+      }, 100);
     },
     [apiRef, column?.field, onClick],
   );

--- a/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
@@ -46,7 +46,8 @@ export function GridColumnsPanel() {
   const toggleColumn = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       const { name } = event.target as HTMLInputElement;
-      apiRef!.current.toggleColumn(name);
+      const column = apiRef!.current.getColumnFromField(name);
+      apiRef!.current.setColumnVisibility(name, !column.hide);
     },
     [apiRef],
   );

--- a/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
@@ -47,7 +47,7 @@ export function GridColumnsPanel() {
     (event: React.MouseEvent<HTMLButtonElement>) => {
       const { name } = event.target as HTMLInputElement;
       const column = apiRef!.current.getColumnFromField(name);
-      apiRef!.current.setColumnVisibility(name, !column.hide);
+      apiRef!.current.setColumnVisibility(name, !!column.hide);
     },
     [apiRef],
   );

--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -83,3 +83,5 @@ export const GRID_SORT_MODEL_CHANGE = 'sortModelChange';
 export const GRID_FILTER_MODEL_CHANGE = 'filterModelChange';
 
 export const GRID_STATE_CHANGE = 'stateChange';
+
+export const GRID_COLUMN_VISIBILITY_CHANGE = 'columnVisibilityChange';

--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -84,4 +84,8 @@ export const GRID_FILTER_MODEL_CHANGE = 'filterModelChange';
 
 export const GRID_STATE_CHANGE = 'stateChange';
 
+/**
+ * Fired when a column visibility changes. Called with a [[GridColumnVisibilityChangeParams]] object.
+ * @event
+ */
 export const GRID_COLUMN_VISIBILITY_CHANGE = 'columnVisibilityChange';

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -168,9 +168,9 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
   ]);
 
   const setColumnVisibility = React.useCallback(
-    (field: string, hide: boolean) => {
+    (field: string, isVisible: boolean) => {
       const col = getColumnFromField(field);
-      const updatedCol = { ...col, hide };
+      const updatedCol = { ...col, hide: !isVisible };
 
       updateColumns([updatedCol]);
       forceUpdate();
@@ -178,7 +178,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
       apiRef.current.publishEvent(GRID_COLUMN_VISIBILITY_CHANGE, {
         colDef: updatedCol,
         api: apiRef,
-        hide,
+        isVisible,
       });
     },
     [apiRef, forceUpdate, getColumnFromField, updateColumns],

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -3,6 +3,7 @@ import {
   GRID_COLUMNS_UPDATED,
   GRID_COLUMN_ORDER_CHANGE,
   GRID_COLUMN_RESIZE_COMMITED,
+  GRID_COLUMN_VISIBILITY_CHANGE,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridColumnApi } from '../../../models/api/gridColumnApi';
@@ -30,6 +31,7 @@ import {
   gridColumnsMetaSelector,
   visibleGridColumnsSelector,
 } from './gridColumnsSelector';
+import { useGridApiOptionHandler } from '../../root/useGridApiEventHandler';
 
 function updateColumnsWidth(columns: GridColumns, viewportWidth: number) {
   const numberOfFluidColumns = columns.filter((column) => !!column.flex && !column.hide).length;
@@ -164,14 +166,22 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
   const updateColumn = React.useCallback((col: GridColDef) => updateColumns([col]), [
     updateColumns,
   ]);
-  const toggleColumn = React.useCallback(
-    (field: string, hide?: boolean) => {
+
+  const setColumnVisibility = React.useCallback(
+    (field: string, hide: boolean) => {
       const col = getColumnFromField(field);
-      const updatedCol = { ...col, hide: hide == null ? !col.hide : hide };
+      const updatedCol = { ...col, hide };
+
       updateColumns([updatedCol]);
       forceUpdate();
+
+      apiRef.current.publishEvent(GRID_COLUMN_VISIBILITY_CHANGE, {
+        colDef: updatedCol,
+        api: apiRef,
+        hide,
+      });
     },
-    [forceUpdate, getColumnFromField, updateColumns],
+    [apiRef, forceUpdate, getColumnFromField, updateColumns],
   );
 
   const setColumnIndex = React.useCallback(
@@ -226,7 +236,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
     getColumnsMeta,
     updateColumn,
     updateColumns,
-    toggleColumn,
+    setColumnVisibility,
     setColumnIndex,
     setColumnWidth,
   };
@@ -269,4 +279,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
     const updatedCols = updateColumnsWidth(currentColumns, gridState.viewportSizes.width);
     apiRef.current.updateColumns(updatedCols);
   }, [apiRef, gridState.viewportSizes.width, logger]);
+
+  // Grid Option Handlers
+  useGridApiOptionHandler(apiRef, GRID_COLUMN_VISIBILITY_CHANGE, options.onColumnVisibilityChange);
 }

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -176,6 +176,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
       forceUpdate();
 
       apiRef.current.publishEvent(GRID_COLUMN_VISIBILITY_CHANGE, {
+        field,
         colDef: updatedCol,
         api: apiRef,
         isVisible,

--- a/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
@@ -49,9 +49,9 @@ export interface GridColumnApi {
   /**
    * Allows to toggle a column.
    * @param field
-   * @param hide
+   * @param isVisible
    */
-  setColumnVisibility: (field: string, hide: boolean) => void;
+  setColumnVisibility: (field: string, isVisible: boolean) => void;
   /**
    * Allows to move a column to another position in the column array.
    * @param field

--- a/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
@@ -49,9 +49,9 @@ export interface GridColumnApi {
   /**
    * Allows to toggle a column.
    * @param field
-   * @param forceHide Optional value, if not provided the column will toggle.
+   * @param hide
    */
-  toggleColumn: (field: string, forceHide?: boolean) => void;
+  setColumnVisibility: (field: string, hide: boolean) => void;
   /**
    * Allows to move a column to another position in the column array.
    * @param field

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -28,6 +28,7 @@ import { GridRowScrollEndParams } from './params/gridRowScrollEndParams';
 import { GridColumnOrderChangeParams } from './params/gridColumnOrderChangeParams';
 import { GridResizeParams } from './params/gridResizeParams';
 import { GridColumnResizeParams } from './params/gridColumnResizeParams';
+import { GridColumnVisibilityChangeParams } from './params/gridColumnVisibilityChangeParams';
 
 // TODO add multiSortKey
 /**
@@ -317,6 +318,11 @@ export interface GridOptions {
    * @param param With all properties from [[GridColumnResizeParams]].
    */
   onColumnResizeCommitted?: (param: GridColumnResizeParams) => void;
+  /**
+   * Callback fired when a column visibility changes.
+   * @param param With all properties from [[GridColumnVisibilityChangeParams]].
+   */
+  onColumnVisibilityChange?: (param: GridColumnVisibilityChangeParams) => void;
   /**
    * Callback fired when the Filter model changes before the filters are applied.
    * @param param With all properties from [[GridFilterModelParams]].

--- a/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
+++ b/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
@@ -3,6 +3,10 @@
  */
 export interface GridColumnVisibilityChangeParams {
   /**
+   * The field of the column which visibility changed.
+   */
+  field: string;
+  /**
    * The column of the current header component.
    */
   colDef: any;

--- a/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
+++ b/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
@@ -13,5 +13,5 @@ export interface GridColumnVisibilityChangeParams {
   /**
    * The visibility state of the column.
    */
-  hide: boolean;
+  isVisible: boolean;
 }

--- a/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
+++ b/packages/grid/_modules_/grid/models/params/gridColumnVisibilityChangeParams.ts
@@ -1,0 +1,17 @@
+/**
+ * Object passed as parameter of the column visibility change event.
+ */
+export interface GridColumnVisibilityChangeParams {
+  /**
+   * The column of the current header component.
+   */
+  colDef: any;
+  /**
+   * API ref that let you manipulate the grid.
+   */
+  api: any;
+  /**
+   * The visibility state of the column.
+   */
+  hide: boolean;
+}


### PR DESCRIPTION
Fixes #1565 

In addition instead of adding a new `apiRef` method, I reworked the existing `toggleColumn` and renamed it to `setColumnVisibility` since it made more sense. I've updated functionality accordingly where it was being used. Technically this is a breaking change.

Also updated the docs.

The params that the `onColumnVisibilityChange` callback gets are as follows:
```ts
  /**
   * The column of the current header component.
   */
  colDef: any;
  /**
   * API ref that let you manipulate the grid.
   */
  api: any;
  /**
   * The visibility state of the column.
   */
  hide: boolean;