### PR TITLE
[test] Add constraints on cell render

### DIFF
--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -222,7 +222,13 @@ describe('<XGrid /> - Sorting', () => {
     });
   });
 
-  it('should prune rendering on cells', () => {
+  it('should prune rendering on cells', function test() {
+    // The number of renders depends on the user-agent
+    if (!/HeadlessChrome/.test(window.navigator.userAgent) || !isJSDOM) {
+      this.skip();
+      return;
+    }
+
     let renderCellCount = 0;
 
     function CounterRender(props) {

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -244,12 +244,7 @@ describe('<XGrid /> - Sorting', () => {
     function Test(props) {
       return (
         <div style={{ width: 300, height: 300 }}>
-          <XGrid
-            {...baselineProps}
-            columns={columns}
-            checkboxSelection
-            {...props}
-          />
+          <XGrid {...baselineProps} columns={columns} checkboxSelection {...props} />
         </div>
       );
     }

--- a/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/sorting.XGrid.test.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { GridApiRef, GridColDef, GridSortModel, useGridApiRef } from '@material-ui/data-grid';
+import { GridApiRef, GridSortModel, useGridApiRef } from '@material-ui/data-grid';
 import { XGrid } from '@material-ui/x-grid';
 import { expect } from 'chai';
 import { useFakeTimers } from 'sinon';
-import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
+import { getColumnValues, getCell, getColumnHeaderCell } from 'test/utils/helperFn';
 import {
   createClientRenderStrictMode,
   // @ts-expect-error need to migrate helpers to TypeScript
@@ -19,6 +19,27 @@ const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
 describe('<XGrid /> - Sorting', () => {
   let clock;
+  const baselineProps = {
+    autoHeight: isJSDOM,
+    rows: [
+      {
+        id: 0,
+        brand: 'Nike',
+        year: '1940',
+      },
+      {
+        id: 1,
+        brand: 'Adidas',
+        year: '1940',
+      },
+      {
+        id: 2,
+        brand: 'Puma',
+        year: '1950',
+      },
+    ],
+    columns: [{ field: 'brand' }, { field: 'year', type: 'number' }],
+  };
 
   beforeEach(() => {
     clock = useFakeTimers();
@@ -38,28 +59,6 @@ describe('<XGrid /> - Sorting', () => {
     sortModel: GridSortModel;
     disableMultipleColumnsSorting?: boolean;
   }) => {
-    const baselineProps = {
-      autoHeight: isJSDOM,
-      rows: [
-        {
-          id: 0,
-          brand: 'Nike',
-          year: '1940',
-        },
-        {
-          id: 1,
-          brand: 'Adidas',
-          year: '1940',
-        },
-        {
-          id: 2,
-          brand: 'Puma',
-          year: '1950',
-        },
-      ],
-      columns: [{ field: 'brand' }, { field: 'year', type: 'number' }],
-    };
-
     const { sortModel, rows, disableMultipleColumnsSorting } = props;
     apiRef = useGridApiRef();
     return (
@@ -216,56 +215,52 @@ describe('<XGrid /> - Sorting', () => {
 
       const t0 = performance.now();
       fireEvent.click(header);
-      await waitFor(() =>
-        expect(document.querySelector('.MuiDataGrid-sortIcon')).to.not.equal(null),
-      );
+      await waitFor(() => expect(document.querySelector('.MuiDataGrid-sortIcon')).to.not.be.null);
       const t1 = performance.now();
       const time = Math.round(t1 - t0);
       expect(time).to.be.lessThan(300);
     });
+  });
 
-    it('should render maximum twice', async function test() {
-      let renderCellCount = 0;
-      let renderHeaderCount = 0;
-      const TestCasePerf = () => {
-        const [cols, setCols] = React.useState<GridColDef[]>([]);
-        const data = useData(10, 10);
+  it('should prune rendering on cells', () => {
+    let renderCellCount = 0;
 
-        React.useEffect(() => {
-          if (data.columns.length) {
-            const newColumns = [...data.columns];
-            newColumns[1].renderHeader = (params) => {
-              renderHeaderCount += 1;
+    function CounterRender(props) {
+      React.useEffect(() => {
+        if (props.value === 'Nike') {
+          renderCellCount += 1;
+        }
+      });
+      return props.value;
+    }
 
-              return <span>{params.field}</span>;
-            };
-            newColumns[1].renderCell = (params) => {
-              if (params.id === 0) {
-                renderCellCount += 1;
-              }
-              return <span>{params.value}</span>;
-            };
-            setCols(newColumns);
-          }
-        }, [data.columns]);
+    const columns = [
+      {
+        field: 'brand',
+        renderCell: (params) => <CounterRender value={params.value} />,
+      },
+    ];
 
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <XGrid columns={cols} rows={data.rows} />
-          </div>
-        );
-      };
-
-      render(<TestCasePerf />);
-      const header = getColumnHeaderCell(2);
-      renderHeaderCount = 0;
-      renderCellCount = 0;
-      fireEvent.click(header);
-      await waitFor(() =>
-        expect(document.querySelector('.MuiDataGrid-sortIcon')).to.not.equal(null),
+    function Test(props) {
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <XGrid
+            {...baselineProps}
+            columns={columns}
+            checkboxSelection
+            {...props}
+          />
+        </div>
       );
-      expect(renderHeaderCount).to.equal(2);
-      expect(renderCellCount).to.equal(0);
-    });
+    }
+
+    const { setProps } = render(<Test />);
+    expect(renderCellCount).to.equal(1);
+    const cell = getCell(1, 0);
+    cell.focus();
+    fireEvent.click(cell);
+    expect(renderCellCount).to.equal(2);
+    setProps({ extra: true });
+    expect(renderCellCount).to.equal(2);
   });
 });


### PR DESCRIPTION
Closes #1653, the changes:

- the filtering performance test doesn't need 10 columns to fail.
- `it('should render maximum twice', async function test() {` wasn't failing on HEAD, so I have removed it.
- Add a new test that enforces to reduce the number of cell rendering. While I very much agree with this point: https://github.com/mui-org/material-ui-x/pull/1513#discussion_r630923223, end-to-end performance is the only thing that ultimately matters, having intermediary checkpoint might also help. Performance is all about not doing the work, we don't have control over what developers are rendering inside `renderCell`, they might have expensive components, in which case, reducing renders is important. 

I was hesitating to test that sorting only calling `getCellValue` N times, but it seems unlikely to have a regression on this, so I saved myself spending time on it.