### PR TITLE
[XGrid] Rename `apiRef` methods

### DIFF
--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -22,7 +22,7 @@ export function GridColumnHeaderMenu({
   target,
 }: GridColumnHeaderMenuProps) {
   const apiRef = React.useContext(GridApiContext);
-  const currentColumn = apiRef?.current.getColumnFromField(field);
+  const currentColumn = apiRef?.current.getColumn(field);
 
   const hideMenu = React.useCallback(
     (event) => {

--- a/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridColumnsPanel.tsx
@@ -46,7 +46,7 @@ export function GridColumnsPanel() {
   const toggleColumn = React.useCallback(
     (event: React.MouseEvent<HTMLButtonElement>) => {
       const { name } = event.target as HTMLInputElement;
-      const column = apiRef!.current.getColumnFromField(name);
+      const column = apiRef!.current.getColumn(name);
       apiRef!.current.setColumnVisibility(name, !!column.hide);
     },
     [apiRef],

--- a/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
@@ -72,7 +72,7 @@ export function GridFilterForm(props: GridFilterFormProps) {
     if (!item.columnField) {
       return null;
     }
-    return apiRef!.current.getColumnFromField(item.columnField)!;
+    return apiRef!.current.getColumn(item.columnField)!;
   });
   const [currentOperator, setCurrentOperator] = React.useState<GridFilterOperator | null>(() => {
     if (!item.operatorValue || !currentColumn) {
@@ -88,7 +88,7 @@ export function GridFilterForm(props: GridFilterFormProps) {
   const changeColumn = React.useCallback(
     (event: React.ChangeEvent<{ value: unknown }>) => {
       const columnField = event.target.value as string;
-      const column = apiRef!.current.getColumnFromField(columnField)!;
+      const column = apiRef!.current.getColumn(columnField)!;
       const newOperator = column.filterOperators![0];
       setCurrentOperator(newOperator);
       setCurrentColumn(column);

--- a/packages/grid/_modules_/grid/hooks/features/columnResize/useGridColumnResize.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/columnResize/useGridColumnResize.tsx
@@ -260,7 +260,7 @@ export const useGridColumnResize = (
       GRID_HEADER_CELL_CSS_CLASS,
     ) as HTMLDivElement;
     const field = getFieldFromHeaderElem(colElementRef.current!);
-    const colDef = apiRef.current.getColumnFromField(field);
+    const colDef = apiRef.current.getColumn(field);
 
     logger.debug(`Start Resize on col ${colDef.field}`);
     apiRef.current.publishEvent(GRID_COLUMN_RESIZE_START, { field });

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -129,7 +129,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
     [logger, setGridState, forceUpdate, apiRef],
   );
 
-  const getColumnFromField: (field: string) => GridColDef = React.useCallback(
+  const getColumn: (field: string) => GridColDef = React.useCallback(
     (field) => apiRef.current.state.columns.lookup[field],
     [apiRef],
   );
@@ -169,7 +169,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
 
   const setColumnVisibility = React.useCallback(
     (field: string, isVisible: boolean) => {
-      const col = getColumnFromField(field);
+      const col = getColumn(field);
       const updatedCol = { ...col, hide: !isVisible };
 
       updateColumns([updatedCol]);
@@ -182,7 +182,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
         isVisible,
       });
     },
-    [apiRef, forceUpdate, getColumnFromField, updateColumns],
+    [apiRef, forceUpdate, getColumn, updateColumns],
   );
 
   const setColumnIndex = React.useCallback(
@@ -197,7 +197,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
       const params: GridColumnOrderChangeParams = {
         field,
         element: apiRef.current.getColumnHeaderElement(field),
-        colDef: apiRef.current.getColumnFromField(field),
+        colDef: apiRef.current.getColumn(field),
         targetIndex: targetIndexPosition,
         oldIndex: oldIndexPosition,
         api: apiRef.current,
@@ -215,7 +215,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
     (field: string, width: number) => {
       logger.debug(`Updating column ${field} width to ${width}`);
 
-      const column = apiRef.current.getColumnFromField(field);
+      const column = apiRef.current.getColumn(field);
       apiRef.current.updateColumn({ ...column, width });
 
       apiRef.current.publishEvent(GRID_COLUMN_RESIZE_COMMITTED, {
@@ -229,7 +229,7 @@ export function useGridColumns(columns: GridColumns, apiRef: GridApiRef): void {
   );
 
   const colApi: GridColumnApi = {
-    getColumnFromField,
+    getColumn,
     getAllColumns,
     getColumnIndex,
     getColumnPosition,

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -63,7 +63,7 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
         `Filtering column: ${filterItem.columnField} ${filterItem.operatorValue} ${filterItem.value} `,
       );
 
-      const column = apiRef.current.getColumnFromField(filterItem.columnField);
+      const column = apiRef.current.getColumn(filterItem.columnField);
       if (!column) {
         return;
       }
@@ -162,7 +162,7 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
         }
         if (newItem.columnField != null && newItem.operatorValue == null) {
           // we select a default operator
-          const column = apiRef!.current!.getColumnFromField(newItem.columnField);
+          const column = apiRef!.current!.getColumn(newItem.columnField);
           newItem.operatorValue = column && column!.filterOperators![0].value!;
         }
         if (options.disableMultipleColumnsFiltering && items.length > 1) {

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridParamsApi.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridParamsApi.ts
@@ -32,7 +32,7 @@ export function useGridParamsApi(apiRef: GridApiRef) {
   const getColumnHeaderParams = React.useCallback(
     (field: string): GridColumnHeaderParams => ({
       field,
-      colDef: apiRef.current.getColumnFromField(field),
+      colDef: apiRef.current.getColumn(field),
       api: apiRef!.current,
     }),
     [apiRef],
@@ -43,7 +43,7 @@ export function useGridParamsApi(apiRef: GridApiRef) {
       const params: GridRowParams = {
         id,
         columns: apiRef.current.getAllColumns(),
-        row: apiRef.current.getRowFromId(id),
+        row: apiRef.current.getRow(id),
         api: apiRef.current,
         getValue: apiRef.current.getCellValue,
       };
@@ -54,14 +54,14 @@ export function useGridParamsApi(apiRef: GridApiRef) {
 
   const getBaseCellParams = React.useCallback(
     (id: GridRowId, field: string) => {
-      const row = apiRef.current.getRowFromId(id);
+      const row = apiRef.current.getRow(id);
 
       const params: GridValueGetterParams = {
         id,
         field,
         row,
         value: row[field],
-        colDef: apiRef.current.getColumnFromField(field),
+        colDef: apiRef.current.getColumn(field),
         cellMode: apiRef.current.getCellMode(id, field),
         getValue: apiRef.current.getCellValue,
         api: apiRef.current,
@@ -76,7 +76,7 @@ export function useGridParamsApi(apiRef: GridApiRef) {
 
   const getCellParams = React.useCallback(
     (id: GridRowId, field: string) => {
-      const colDef = apiRef.current.getColumnFromField(field);
+      const colDef = apiRef.current.getColumn(field);
       const value = apiRef.current.getCellValue(id, field);
       const baseParams = getBaseCellParams(id, field);
       const params: GridCellParams = {
@@ -96,7 +96,7 @@ export function useGridParamsApi(apiRef: GridApiRef) {
 
   const getCellValue = React.useCallback(
     (id: GridRowId, field: string) => {
-      const colDef = apiRef.current.getColumnFromField(field);
+      const colDef = apiRef.current.getColumn(field);
 
       if (!warnedOnce && process.env.NODE_ENV !== 'production') {
         if (!colDef) {
@@ -105,7 +105,7 @@ export function useGridParamsApi(apiRef: GridApiRef) {
       }
 
       if (!colDef || !colDef.valueGetter) {
-        const rowModel = apiRef.current.getRowFromId(id);
+        const rowModel = apiRef.current.getRow(id);
         return rowModel[field];
       }
 

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -109,7 +109,7 @@ export const useGridRows = (
     },
     [apiRef],
   );
-  const getRowFromId = React.useCallback(
+  const getRow = React.useCallback(
     (id: GridRowId): GridRowModel => apiRef.current.state.rows.idRowsLookup[id],
     [apiRef],
   );
@@ -169,7 +169,7 @@ export const useGridRows = (
           return;
         }
 
-        const oldRow = getRowFromId(id);
+        const oldRow = getRow(id);
         if (!oldRow) {
           addedRows.push(partialRow);
           return;
@@ -197,7 +197,7 @@ export const useGridRows = (
       }
       forceUpdate(() => apiRef.current.publishEvent(GRID_ROWS_UPDATED));
     },
-    [apiRef, forceUpdate, getRowFromId, getRowIdProp, setGridState, setRows],
+    [apiRef, forceUpdate, getRow, getRowIdProp, setGridState, setRows],
   );
 
   const getRowModels = React.useCallback(
@@ -216,7 +216,7 @@ export const useGridRows = (
   const rowApi: GridRowApi = {
     getRowIndex: getRowIndexFromId,
     getRowIdFromRowIndex,
-    getRowFromId,
+    getRow,
     getRowModels,
     getRowsCount,
     getAllRowIds,

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -101,7 +101,7 @@ export const useGridSelection = (apiRef: GridApiRef): void => {
 
   const selectRow = React.useCallback(
     (id: GridRowId, isSelected = true, allowMultiple = false) => {
-      selectRowModel(id, apiRef.current.getRowFromId(id), allowMultiple, isSelected);
+      selectRowModel(id, apiRef.current.getRow(id), allowMultiple, isSelected);
     },
     [apiRef, selectRowModel],
   );

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -136,7 +136,7 @@ export const useGridSorting = (apiRef: GridApiRef, rowsProp: GridRowsProp) => {
   const buildComparatorList = React.useCallback(
     (sortModel: GridSortModel): GridFieldComparatorList => {
       const comparators = sortModel.map((item) => {
-        const column = apiRef.current.getColumnFromField(item.field);
+        const column = apiRef.current.getColumn(item.field);
         if (!column) {
           throw new Error(`Error sorting: column with field '${item.field}' not found. `);
         }

--- a/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridColumnApi.ts
@@ -9,7 +9,7 @@ export interface GridColumnApi {
    * @param field
    * @returns [[GridColDef]]
    */
-  getColumnFromField: (field: string) => GridColDef;
+  getColumn: (field: string) => GridColDef;
   /**
    * Get all the [[GridColumns]].
    * @returns An array of [[GridColDef]].

--- a/packages/grid/_modules_/grid/models/api/gridRowApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridRowApi.ts
@@ -38,8 +38,8 @@ export interface GridRowApi {
    */
   getRowIndex: (id: GridRowId) => number;
   /**
-   * Get the [[GridRowModel]] of a given rowId.
+   * Get the [[GridRowModel]] of a given id.
    * @param id
    */
-  getRowFromId: (id: GridRowId) => GridRowModel;
+  getRow: (id: GridRowId) => GridRowModel;
 }

--- a/packages/grid/x-grid/src/tests/events.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/events.XGrid.test.tsx
@@ -84,7 +84,7 @@ describe('<XGrid /> - Events Params', () => {
       fireEvent.click(ageColumnElement);
 
       expect(eventArgs!.params).to.deep.include({
-        colDef: apiRef!.current.getColumnFromField('age'),
+        colDef: apiRef!.current.getColumn('age'),
         field: 'age',
         api: apiRef.current,
       });
@@ -131,7 +131,7 @@ describe('<XGrid /> - Events Params', () => {
         formattedValue: 'Jack',
         isEditable: true,
         row: baselineProps.rows[1],
-        colDef: apiRef!.current.getColumnFromField('first'),
+        colDef: apiRef!.current.getColumn('first'),
         api: apiRef.current,
         hasFocus: false,
         tabIndex: -1,
@@ -158,7 +158,7 @@ describe('<XGrid /> - Events Params', () => {
         formattedValue: 'Jack',
         isEditable: true,
         row: baselineProps.rows[1],
-        colDef: apiRef!.current.getColumnFromField('first'),
+        colDef: apiRef!.current.getColumn('first'),
         api: apiRef.current,
         hasFocus: false,
         tabIndex: -1,

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -117,7 +117,7 @@ describe('<XGrid /> - Rows', () => {
         );
       };
       render(<Test />);
-      expect(apiRef!.current.getRowFromId('c1')).to.equal(baselineProps.rows[0]);
+      expect(apiRef!.current.getRow('c1')).to.equal(baselineProps.rows[0]);
     });
   });
 


### PR DESCRIPTION
### Breaking changes

- [XGrid] `apiRef.current.getColumnFromField` was renamed to `apiRef.current.getColumn`.
- [XGrid] `apiRef.current.getRowFromId` was renamed to `apiRef.current.getRow`.

---

Closes #1569