### PR TITLE
[docs] Clean demos components

### DIFF
--- a/docs/pages/api-docs/data-grid.md
+++ b/docs/pages/api-docs/data-grid.md
@@ -159,7 +159,7 @@ Api of the `components` props of type `GridSlotsComponent`
 |  | <span class="prop-name">.MuiDataGrid-viewport</span> | Styles applied to the viewport element.|
 |  | <span class="prop-name">.MuiDataGrid-row</span> | Styles applied to the row element.|
 |  | <span class="prop-name">.Mui-selected</span> | Styles applied to the selected row element.|
-|  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customized cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
 |  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|

--- a/docs/pages/api-docs/x-grid.md
+++ b/docs/pages/api-docs/x-grid.md
@@ -166,7 +166,7 @@ Api of the `components` props of type `GridSlotsComponent`
 |  | <span class="prop-name">.MuiDataGrid-viewport</span> | Styles applied to the viewport element.|
 |  | <span class="prop-name">.MuiDataGrid-row</span> | Styles applied to the row element.|
 |  | <span class="prop-name">.Mui-selected</span> | Styles applied to the selected row element.|
-|  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customised cell element.|
+|  | <span class="prop-name">.MuiDataGrid-cellWithRenderer</span> | Styles applied to the customized cell element.|
 |  | <span class="prop-name">.MuiDataGrid-withBorder</span> | Styles applied to the cell element that has right border displayed.|
 |  | <span class="prop-name">.MuiDataGrid-cellLeft</span> | Styles applied to the aligned left cell element.|
 |  | <span class="prop-name">.MuiDataGrid-cellRight</span> | Styles applied to the aligned right cell element.|

--- a/docs/src/pages/components/data-grid/components/CustomColumnMenu.js
+++ b/docs/src/pages/components/data-grid/components/CustomColumnMenu.js
@@ -85,29 +85,23 @@ export default function CustomColumnMenu() {
   const [color, setColor] = React.useState('primary');
   const apiRef = useGridApiRef();
 
-  React.useEffect(() => {
-    apiRef.current.showColumnMenu('default');
-  }, [apiRef, color]);
-
   return (
     <div
       style={{
-        height: 300,
         width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
       }}
     >
-      <div style={{ alignSelf: 'center' }}>
-        <Button
-          color={color}
-          onClick={() =>
-            setColor((current) => (current === 'primary' ? 'secondary' : 'primary'))
-          }
-        >
-          Toggle menu background
-        </Button>
-      </div>
+      <Button
+        color={color}
+        variant="outlined"
+        onClick={(event) => {
+          event.stopPropagation();
+          setColor((current) => (current === 'primary' ? 'secondary' : 'primary'));
+          apiRef.current.showColumnMenu('default');
+        }}
+      >
+        Toggle menu background
+      </Button>
       <div style={{ height: 250, width: '100%', marginTop: 16 }}>
         <XGrid
           apiRef={apiRef}

--- a/docs/src/pages/components/data-grid/components/CustomColumnMenu.tsx
+++ b/docs/src/pages/components/data-grid/components/CustomColumnMenu.tsx
@@ -79,29 +79,23 @@ export default function CustomColumnMenu() {
   const [color, setColor] = React.useState<'primary' | 'secondary'>('primary');
   const apiRef = useGridApiRef();
 
-  React.useEffect(() => {
-    apiRef.current.showColumnMenu('default');
-  }, [apiRef, color]);
-
   return (
     <div
       style={{
-        height: 300,
         width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
       }}
     >
-      <div style={{ alignSelf: 'center' }}>
-        <Button
-          color={color}
-          onClick={() =>
-            setColor((current) => (current === 'primary' ? 'secondary' : 'primary'))
-          }
-        >
-          Toggle menu background
-        </Button>
-      </div>
+      <Button
+        color={color}
+        variant="outlined"
+        onClick={(event) => {
+          event.stopPropagation();
+          setColor((current) => (current === 'primary' ? 'secondary' : 'primary'));
+          apiRef.current.showColumnMenu('default');
+        }}
+      >
+        Toggle menu background
+      </Button>
       <div style={{ height: 250, width: '100%', marginTop: 16 }}>
         <XGrid
           apiRef={apiRef}

--- a/docs/src/pages/components/data-grid/components/CustomFooter.js
+++ b/docs/src/pages/components/data-grid/components/CustomFooter.js
@@ -10,16 +10,13 @@ const useStyles = makeStyles(() => ({
   root: {
     padding: 10,
     display: 'flex',
-    alignItems: 'flex-end',
-    flexDirection: 'column',
-    '& .status-container': {
-      display: 'flex',
-    },
   },
   connected: {
+    marginRight: 2,
     color: '#4caf50',
   },
   disconnected: {
+    marginRight: 2,
     color: '#d9182e',
   },
 }));
@@ -29,10 +26,8 @@ function CustomFooterStatusComponent(props) {
 
   return (
     <div className={classes.root}>
-      <div className="status-container">
-        Status {props.status}
-        <FiberManualRecordIcon fontSize="small" className={classes[props.status]} />
-      </div>
+      <FiberManualRecordIcon fontSize="small" className={classes[props.status]} />
+      Status {props.status}
     </div>
   );
 }
@@ -54,25 +49,10 @@ export default function CustomFooter() {
   return (
     <div
       style={{
-        height: 400,
         width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
       }}
     >
-      <div style={{ alignSelf: 'center' }}>
-        <Button
-          color="primary"
-          onClick={() =>
-            setStatus((current) =>
-              current === 'connected' ? 'disconnected' : 'connected',
-            )
-          }
-        >
-          {status === 'connected' ? 'Disconnect' : 'Connect'}
-        </Button>
-      </div>
-      <div style={{ height: 350, width: '100%', marginTop: 16 }}>
+      <div style={{ height: 350, width: '100%', marginBottom: 16 }}>
         <DataGrid
           {...data}
           components={{
@@ -83,6 +63,17 @@ export default function CustomFooter() {
           }}
         />
       </div>
+      <Button
+        color="primary"
+        variant="contained"
+        onClick={() =>
+          setStatus((current) =>
+            current === 'connected' ? 'disconnected' : 'connected',
+          )
+        }
+      >
+        {status === 'connected' ? 'Disconnect' : 'Connect'}
+      </Button>
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/components/CustomFooter.tsx
+++ b/docs/src/pages/components/data-grid/components/CustomFooter.tsx
@@ -9,16 +9,13 @@ const useStyles = makeStyles(() => ({
   root: {
     padding: 10,
     display: 'flex',
-    alignItems: 'flex-end',
-    flexDirection: 'column',
-    '& .status-container': {
-      display: 'flex',
-    },
   },
   connected: {
+    marginRight: 2,
     color: '#4caf50',
   },
   disconnected: {
+    marginRight: 2,
     color: '#d9182e',
   },
 }));
@@ -30,10 +27,8 @@ export function CustomFooterStatusComponent(props: {
 
   return (
     <div className={classes.root}>
-      <div className="status-container">
-        Status {props.status}
-        <FiberManualRecordIcon fontSize="small" className={classes[props.status]} />
-      </div>
+      <FiberManualRecordIcon fontSize="small" className={classes[props.status]} />
+      Status {props.status}
     </div>
   );
 }
@@ -48,25 +43,10 @@ export default function CustomFooter() {
   return (
     <div
       style={{
-        height: 400,
         width: '100%',
-        display: 'flex',
-        flexDirection: 'column',
       }}
     >
-      <div style={{ alignSelf: 'center' }}>
-        <Button
-          color="primary"
-          onClick={() =>
-            setStatus((current) =>
-              current === 'connected' ? 'disconnected' : 'connected',
-            )
-          }
-        >
-          {status === 'connected' ? 'Disconnect' : 'Connect'}
-        </Button>
-      </div>
-      <div style={{ height: 350, width: '100%', marginTop: 16 }}>
+      <div style={{ height: 350, width: '100%', marginBottom: 16 }}>
         <DataGrid
           {...data}
           components={{
@@ -77,6 +57,17 @@ export default function CustomFooter() {
           }}
         />
       </div>
+      <Button
+        color="primary"
+        variant="contained"
+        onClick={() =>
+          setStatus((current) =>
+            current === 'connected' ? 'disconnected' : 'connected',
+          )
+        }
+      >
+        {status === 'connected' ? 'Disconnect' : 'Connect'}
+      </Button>
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/components/CustomSortIcons.js
+++ b/docs/src/pages/components/data-grid/components/CustomSortIcons.js
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { XGrid } from '@material-ui/x-grid';
+import { DataGrid } from '@material-ui/data-grid';
 
 export function SortedDescendingIcon() {
   return <ExpandMoreIcon className="icon" />;
@@ -11,26 +11,30 @@ export function SortedAscendingIcon() {
   return <ExpandLessIcon className="icon" />;
 }
 
+const rows = [
+  {
+    id: 1,
+    name: 'Material-UI',
+    stars: 28000,
+  },
+  {
+    id: 2,
+    name: 'DataGrid',
+    stars: 15000,
+  },
+];
+
+const columns = [
+  { field: 'name', width: 150 },
+  { field: 'stars', width: 150 },
+];
+
 export default function CustomSortIcons() {
   return (
     <div style={{ height: 250, width: '100%' }}>
-      <XGrid
-        columns={[
-          { field: 'name', width: 150 },
-          { field: 'stars', width: 150 },
-        ]}
-        rows={[
-          {
-            id: 1,
-            name: 'Material-UI',
-            stars: 28000,
-          },
-          {
-            id: 2,
-            name: 'XGrid',
-            stars: 15000,
-          },
-        ]}
+      <DataGrid
+        columns={columns}
+        rows={rows}
         sortModel={[
           { field: 'name', sort: 'asc' },
           { field: 'stars', sort: 'desc' },

--- a/docs/src/pages/components/data-grid/components/CustomSortIcons.tsx
+++ b/docs/src/pages/components/data-grid/components/CustomSortIcons.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import ExpandLessIcon from '@material-ui/icons/ExpandLess';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
-import { XGrid } from '@material-ui/x-grid';
+import { DataGrid } from '@material-ui/data-grid';
 
 export function SortedDescendingIcon() {
   return <ExpandMoreIcon className="icon" />;
@@ -11,26 +11,30 @@ export function SortedAscendingIcon() {
   return <ExpandLessIcon className="icon" />;
 }
 
+const rows = [
+  {
+    id: 1,
+    name: 'Material-UI',
+    stars: 28000,
+  },
+  {
+    id: 2,
+    name: 'DataGrid',
+    stars: 15000,
+  },
+];
+
+const columns = [
+  { field: 'name', width: 150 },
+  { field: 'stars', width: 150 },
+];
+
 export default function CustomSortIcons() {
   return (
     <div style={{ height: 250, width: '100%' }}>
-      <XGrid
-        columns={[
-          { field: 'name', width: 150 },
-          { field: 'stars', width: 150 },
-        ]}
-        rows={[
-          {
-            id: 1,
-            name: 'Material-UI',
-            stars: 28000,
-          },
-          {
-            id: 2,
-            name: 'XGrid',
-            stars: 15000,
-          },
-        ]}
+      <DataGrid
+        columns={columns}
+        rows={rows}
         sortModel={[
           { field: 'name', sort: 'asc' },
           { field: 'stars', sort: 'desc' },

--- a/docs/src/pages/components/data-grid/components/components.md
+++ b/docs/src/pages/components/data-grid/components/components.md
@@ -34,13 +34,13 @@ As an example, you could override the column menu and pass additional props as b
 ### Getting props
 
 While overriding component slots, you might need to access the grid data.
-Therefore, the grid exposes a `useGridSlotComponentProps` hook which allows to retrieve the following props.
+Therefore, the grid exposes a `useGridSlotComponentProps` hook which allows retrieving the following props.
 
 - `state`: the current grid state.
 - `rows`: the current rows in the grid.
 - `columns`: the current columns in the grid.
 - `options`: the current set of options in the grid.
-- `apiRef`<span class="pro"></span>: the `GridApi` ref that allows to manipulate the grid.
+- `apiRef`<span class="pro"></span>: the `GridApi` ref that allows manipulating the grid.
 - `rootElement`: the root DOM element.
 
 It can be used as below:
@@ -55,9 +55,9 @@ function CustomRowCounter() {
 
 ## Components
 
-The full list of overridable components can be found in the [`GridSlotsComponent`](/api/data-grid/#slots) API page.
+The full list of overridable components can be found on the [`GridSlotsComponent`](/api/data-grid/#slots) API page.
 
-### ColumnMenu
+### Column menu
 
 As mentioned above, the column menu is a component slot that can be recomposed easily and customized on each column as in the demo below.
 
@@ -142,17 +142,6 @@ In the following demo, an illustration is added on top of the default "No Rows" 
 
 ### Icons
 
-As any component slot, every icon can be customised. However, it is not yet possible to use the `componentsProps` with icons.
+As any component slot, every icon can be customized. However, it is not yet possible to use the `componentsProps` with icons.
 
 {{"demo": "pages/components/data-grid/components/CustomSortIcons.js", "bg": "inline"}}
-
-```jsx
-<DataGrid
-  rows={rows}
-  columns={columns}
-  components={{
-    ColumnSortedDescendingIcon: SortedDescendingIcon,
-    ColumnSortedAscendingIcon: SortedAscendingIcon,
-  }}
-/>
-```


### PR DESCRIPTION
A follow-up on #1382. Preview: https://deploy-preview-1681--material-ui-x.netlify.app/components/data-grid/components/

- en-US, again

<img width="190" alt="Screenshot 2021-05-16 at 11 10 44" src="https://user-images.githubusercontent.com/3165635/118391982-5fb3af80-b637-11eb-93df-a357190c0447.png">

- Use inline demos as much as possible

<img width="806" alt="Screenshot 2021-05-16 at 11 10 18" src="https://user-images.githubusercontent.com/3165635/118391976-54608400-b637-11eb-86ed-b8ae1e787a66.png">

- Use DataGrid over XGrid as much as possible

<img width="601" alt="Screenshot 2021-05-16 at 11 11 23" src="https://user-images.githubusercontent.com/3165635/118392002-7ce87e00-b637-11eb-8264-88a0adf23530.png">

- Keep headers consistent with the page

<img width="175" alt="Screenshot 2021-05-16 at 11 10 58" src="https://user-images.githubusercontent.com/3165635/118391992-69d5ae00-b637-11eb-86c2-c86138960776.png">

- Improve button visibility and placement
- Only display the column menu when the button is clicked, keep it open, and fix the color flash