### PR TITLE
[core] Remove `withStyles` dependency on `@material-ui/core/styles`

### DIFF
--- a/packages/storybook/src/stories/playground/customComponents.tsx
+++ b/packages/storybook/src/stories/playground/customComponents.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import { green } from '@material-ui/core/colors';
 import Checkbox, { CheckboxProps } from '@material-ui/core/Checkbox';
 import LinearProgress from '@material-ui/core/LinearProgress';

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -2,7 +2,8 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import { useFakeTimers } from 'sinon';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
+import { createTheme } from '@material-ui/data-grid';
 
 const styles = (theme) => ({
   root: {
@@ -119,4 +120,5 @@ TestViewer.propTypes = {
   dataGridContainer: PropTypes.bool.isRequired,
 };
 
-export default withStyles(styles)(TestViewer);
+const defaultTheme = createTheme();
+export default withStyles(styles, { defaultTheme })(TestViewer);

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import { LicenseInfo } from '@material-ui/x-grid';
-import { withStyles } from '@material-ui/core/styles';
+import { withStyles } from '@material-ui/styles';
 import webfontloader from 'webfontloader';
 import TestViewer from 'test/regressions/TestViewer';
 import { useFakeTimers } from 'sinon';


### PR DESCRIPTION
Follow up after https://github.com/mui-org/material-ui-x/pull/1627 The same is done for the `withStyles` dependency. I think we will be able to remove them once this one is finished.