### PR TITLE
[DataGrid] Allow to customize GridToolbarExport's CSV export

### DIFF
--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
@@ -42,7 +42,7 @@ export const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbar
 
     const handleMenuOpen = (event) => setAnchorEl(event.currentTarget);
     const handleMenuClose = () => setAnchorEl(null);
-    const handleExport = (option: GridExportFormatOption) => () => {
+    const handleExport = (option: GridExportOption) => () => {
       if (option.format === 'csv') {
         apiRef!.current.exportDataAsCsv(option.formatOptions);
       }

--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
@@ -12,7 +12,7 @@ import { GridExportOption, GridExportFormat, GridExportConfiguration } from '../
 type GridToolbarExportProps = ButtonProps & { exportConfiguration?: GridExportConfiguration };
 
 export const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportProps>(
-  function GridToolbarExport({ exportConfiguration, ...buttonProps }, ref) {
+  function GridToolbarExport({ exportConfiguration, ...other }, ref) {
     const apiRef = React.useContext(GridApiContext);
     const exportButtonId = useId();
     const exportMenuId = useId();
@@ -21,30 +21,17 @@ export const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbar
 
     const ExportOptions: Array<GridExportOption> = [];
 
-    if (exportConfiguration) {
-      if (!exportConfiguration.csv?.disabled) {
-        ExportOptions.push({
-          label: apiRef!.current.getLocaleText('toolbarExportCSV'),
-          format: {
-            name: 'csv',
-            options: exportConfiguration.csv,
-          },
-        });
-      }
-    } else {
-      ExportOptions.push({
-        label: apiRef!.current.getLocaleText('toolbarExportCSV'),
-        format: {
-          name: 'csv',
-        },
-      });
-    }
+    ExportOptions.push({
+      label: apiRef!.current.getLocaleText('toolbarExportCSV'),
+      format: 'csv',
+      options: exportConfiguration?.csv,
+    });
 
     const handleExportSelectorOpen = (event) => setAnchorEl(event.currentTarget);
     const handleExportSelectorClose = () => setAnchorEl(null);
-    const handleExport = (format: GridExportFormat, fileName?: string) => {
-      if (format.name === 'csv') {
-        apiRef!.current.exportDataAsCsv(format.options, fileName);
+    const handleExport = (option: GridExportFormat, fileName?: string) => {
+      if (option.format === 'csv') {
+        apiRef!.current.exportDataAsCsv(option.options, fileName);
       }
 
       setAnchorEl(null);
@@ -60,10 +47,7 @@ export const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbar
     };
 
     const renderExportOptions: Array<React.ReactElement> = ExportOptions.map((option, index) => (
-      <MenuItem
-        key={index}
-        onClick={() => handleExport(option.format, exportConfiguration?.fileName)}
-      >
+      <MenuItem key={index} onClick={() => handleExport(option, exportConfiguration?.fileName)}>
         {option.label}
       </MenuItem>
     ));
@@ -80,7 +64,7 @@ export const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbar
           aria-haspopup="menu"
           aria-labelledby={exportMenuId}
           id={exportButtonId}
-          {...buttonProps}
+          {...other}
         >
           {apiRef!.current.getLocaleText('toolbarExport')}
         </Button>

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -37,7 +37,7 @@ export const useGridCsvExport = (apiRef: GridApiRef): void => {
         type: 'text/csv',
       });
 
-      exportAs(blob, 'csv', options?.fileName?.length ? options.fileName : undefined);
+      exportAs(blob, 'csv', options?.fileName);
     },
     [logger, getDataAsCsv],
   );

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -5,7 +5,7 @@ import { useGridSelector } from '../core/useGridSelector';
 import { visibleGridColumnsSelector } from '../columns';
 import { visibleSortedGridRowsSelector } from '../filter';
 import { gridSelectionStateSelector } from '../selection';
-import { GridCsvExportApi } from '../../../models';
+import { GridCsvExportApi, GridExportCsvOptions } from '../../../models';
 import { useLogger } from '../../utils/useLogger';
 import { exportAs } from '../../../utils';
 import { buildCSV } from './seralizers/csvSeraliser';
@@ -22,13 +22,19 @@ export const useGridCsvExport = (apiRef: GridApiRef): void => {
     return buildCSV(visibleColumns, visibleSortedRows, selection, apiRef.current.getCellValue);
   }, [logger, visibleColumns, visibleSortedRows, selection, apiRef]);
 
-  const exportDataAsCsv = React.useCallback((): void => {
-    logger.debug(`Export data as CSV`);
-    const csv = getDataAsCsv();
-    const blob = new Blob([csv], { type: 'text/csv' });
+  const exportDataAsCsv = React.useCallback(
+    (options?: GridExportCsvOptions, fileName: string = 'data'): void => {
+      logger.debug(`Export data as CSV`);
+      const csv = getDataAsCsv();
 
-    exportAs(blob, 'csv', 'data');
-  }, [logger, getDataAsCsv]);
+      const blob = new Blob([options?.utf8WithBom ? new Uint8Array([0xef, 0xbb, 0xbf]) : '', csv], {
+        type: 'text/csv',
+      });
+
+      exportAs(blob, 'csv', fileName.length ? fileName : 'data');
+    },
+    [logger, getDataAsCsv],
+  );
 
   const csvExportApi: GridCsvExportApi = {
     getDataAsCsv,

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -5,7 +5,8 @@ import { useGridSelector } from '../core/useGridSelector';
 import { visibleGridColumnsSelector } from '../columns';
 import { visibleSortedGridRowsSelector } from '../filter';
 import { gridSelectionStateSelector } from '../selection';
-import { GridCsvExportApi, GridExportCsvOptions } from '../../../models';
+import { GridCsvExportApi } from '../../../models/api/gridCsvExportApi';
+import { GridExportCsvOptions } from '../../../models/gridExport';
 import { useLogger } from '../../utils/useLogger';
 import { exportAs } from '../../../utils';
 import { buildCSV } from './seralizers/csvSeraliser';
@@ -16,22 +17,27 @@ export const useGridCsvExport = (apiRef: GridApiRef): void => {
   const visibleSortedRows = useGridSelector(apiRef, visibleSortedGridRowsSelector);
   const selection = useGridSelector(apiRef, gridSelectionStateSelector);
 
-  const getDataAsCsv = React.useCallback((): string => {
-    logger.debug(`Get data as CSV`);
+  const getDataAsCsv = React.useCallback(
+    // TODO remove once we use the options
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    (options?: GridExportCsvOptions): string => {
+      logger.debug(`Get data as CSV`);
 
-    return buildCSV(visibleColumns, visibleSortedRows, selection, apiRef.current.getCellValue);
-  }, [logger, visibleColumns, visibleSortedRows, selection, apiRef]);
+      return buildCSV(visibleColumns, visibleSortedRows, selection, apiRef.current.getCellValue);
+    },
+    [logger, visibleColumns, visibleSortedRows, selection, apiRef],
+  );
 
   const exportDataAsCsv = React.useCallback(
-    (options?: GridExportCsvOptions, fileName?: string): void => {
+    (options?: GridExportCsvOptions): void => {
       logger.debug(`Export data as CSV`);
-      const csv = getDataAsCsv();
+      const csv = getDataAsCsv(options);
 
       const blob = new Blob([options?.utf8WithBom ? new Uint8Array([0xef, 0xbb, 0xbf]) : '', csv], {
         type: 'text/csv',
       });
 
-      exportAs(blob, 'csv', fileName?.length ? fileName : undefined);
+      exportAs(blob, 'csv', options?.fileName?.length ? options.fileName : undefined);
     },
     [logger, getDataAsCsv],
   );

--- a/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/export/useGridCsvExport.tsx
@@ -23,7 +23,7 @@ export const useGridCsvExport = (apiRef: GridApiRef): void => {
   }, [logger, visibleColumns, visibleSortedRows, selection, apiRef]);
 
   const exportDataAsCsv = React.useCallback(
-    (options?: GridExportCsvOptions, fileName: string = 'data'): void => {
+    (options?: GridExportCsvOptions, fileName?: string): void => {
       logger.debug(`Export data as CSV`);
       const csv = getDataAsCsv();
 
@@ -31,7 +31,7 @@ export const useGridCsvExport = (apiRef: GridApiRef): void => {
         type: 'text/csv',
       });
 
-      exportAs(blob, 'csv', fileName.length ? fileName : 'data');
+      exportAs(blob, 'csv', fileName?.length ? fileName : undefined);
     },
     [logger, getDataAsCsv],
   );

--- a/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
@@ -7,14 +7,13 @@ export interface GridCsvExportApi {
   /**
    * Returns the grid data as a CSV string.
    * This method is used internally by `exportDataAsCsv`.
-   * @params GridExportCsvOptions The options to apply on the export.
+   * @param {GridExportCsvOptions} options The options to apply on the export.
    * @returns string
    */
   getDataAsCsv: (options?: GridExportCsvOptions) => string;
   /**
    * Downloads and exports a CSV of the grid's data.
-   * @params GridExportCsvOptions The options to apply on the export.
-   * @returns void
+   * @param {GridExportCsvOptions} options The options to apply on the export.
    */
   exportDataAsCsv: (options?: GridExportCsvOptions) => void;
 }

--- a/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
@@ -1,16 +1,20 @@
 import { GridExportCsvOptions } from '../gridExport';
 
 /**
- * The csv export API interface that is available in the grid [[apiRef]].
+ * The CSV export API interface that is available in the grid [[apiRef]].
  */
 export interface GridCsvExportApi {
   /**
-   * Returns the grid data formatted as CSV.
-   * @returns {string} The data as CSV.
+   * Returns the grid data as a CSV string.
+   * This method is used internally by `exportDataAsCsv`.
+   * @params GridExportCsvOptions The options to apply on the export.
+   * @returns string
    */
-  getDataAsCsv: () => string;
+  getDataAsCsv: (options?: GridExportCsvOptions) => string;
   /**
-   * Exports the grid data as CSV and sends it to the user.
+   * Downloads and exports a CSV of the grid's data.
+   * @params GridExportCsvOptions The options to apply on the export.
+   * @returns void
    */
-  exportDataAsCsv: (options?: GridExportCsvOptions, fileName?: string) => void;
+  exportDataAsCsv: (options?: GridExportCsvOptions) => void;
 }

--- a/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridCsvExportApi.ts
@@ -1,3 +1,5 @@
+import { GridExportCsvOptions } from '../gridExport';
+
 /**
  * The csv export API interface that is available in the grid [[apiRef]].
  */
@@ -10,5 +12,5 @@ export interface GridCsvExportApi {
   /**
    * Exports the grid data as CSV and sends it to the user.
    */
-  exportDataAsCsv: () => void;
+  exportDataAsCsv: (options?: GridExportCsvOptions, fileName?: string) => void;
 }

--- a/packages/grid/_modules_/grid/models/gridExport.ts
+++ b/packages/grid/_modules_/grid/models/gridExport.ts
@@ -1,7 +1,21 @@
+export interface GridExportCsvOptions {
+  utf8WithBom?: boolean;
+  disabled?: boolean;
+}
+export interface GridExportFormatCsv {
+  name: 'csv';
+  options?: GridExportCsvOptions;
+}
+
 /**
  * Available export formats. To be extended in future.
  */
-export type GridExportFormat = 'csv';
+export type GridExportFormatExtension = 'csv';
+export type GridExportFormat = GridExportFormatCsv;
+export interface GridExportConfiguration {
+  fileName?: string;
+  csv?: GridExportCsvOptions;
+}
 
 /**
  * Export option interface

--- a/packages/grid/_modules_/grid/models/gridExport.ts
+++ b/packages/grid/_modules_/grid/models/gridExport.ts
@@ -1,9 +1,8 @@
 export interface GridExportCsvOptions {
   utf8WithBom?: boolean;
-  disabled?: boolean;
 }
 export interface GridExportFormatCsv {
-  name: 'csv';
+  format: 'csv';
   options?: GridExportCsvOptions;
 }
 
@@ -20,7 +19,6 @@ export interface GridExportConfiguration {
 /**
  * Export option interface
  */
-export interface GridExportOption {
+export type GridExportOption = GridExportFormat & {
   label: React.ReactNode;
-  format: GridExportFormat;
-}
+};

--- a/packages/grid/_modules_/grid/models/gridExport.ts
+++ b/packages/grid/_modules_/grid/models/gridExport.ts
@@ -1,24 +1,12 @@
+/**
+ * The options to apply on the CSV export.
+ */
 export interface GridExportCsvOptions {
+  fileName?: string;
   utf8WithBom?: boolean;
 }
-export interface GridExportFormatCsv {
-  format: 'csv';
-  options?: GridExportCsvOptions;
-}
 
 /**
- * Available export formats. To be extended in future.
+ * Available export formats.
  */
-export type GridExportFormatExtension = 'csv';
-export type GridExportFormat = GridExportFormatCsv;
-export interface GridExportConfiguration {
-  fileName?: string;
-  csv?: GridExportCsvOptions;
-}
-
-/**
- * Export option interface
- */
-export type GridExportOption = GridExportFormat & {
-  label: React.ReactNode;
-};
+export type GridExportFormat = 'csv';

--- a/packages/grid/_modules_/grid/utils/exportAs.ts
+++ b/packages/grid/_modules_/grid/utils/exportAs.ts
@@ -1,4 +1,4 @@
-import { GridExportFormat } from '../models/gridExport';
+import { GridExportFormatExtension } from '../models/gridExport';
 
 /**
  * I have hesitate to use https://github.com/eligrey/FileSaver.js.
@@ -12,7 +12,7 @@ import { GridExportFormat } from '../models/gridExport';
  */
 export function exportAs(
   blob: Blob,
-  extension: GridExportFormat = 'csv',
+  extension: GridExportFormatExtension = 'csv',
   filename: string = document.title,
 ): void {
   const fullName = `${filename}.${extension}`;

--- a/packages/grid/_modules_/grid/utils/exportAs.ts
+++ b/packages/grid/_modules_/grid/utils/exportAs.ts
@@ -1,4 +1,4 @@
-import { GridExportFormatExtension } from '../models/gridExport';
+import { GridExportFormat } from '../models/gridExport';
 
 /**
  * I have hesitate to use https://github.com/eligrey/FileSaver.js.
@@ -12,7 +12,7 @@ import { GridExportFormatExtension } from '../models/gridExport';
  */
 export function exportAs(
   blob: Blob,
-  extension: GridExportFormatExtension = 'csv',
+  extension: GridExportFormat = 'csv',
   filename: string = document.title,
 ): void {
   const fullName = `${filename}.${extension}`;


### PR DESCRIPTION
This feature allows to:
    - set the file name
    - set flag utf8WithBom to generate csv file as UTF-8 with BOM

It may be extended with further options in the future

Example how to use:

```tsx
import { GridToolbarExport, GridExportCsvOptions } from '@material-ui/data-grid';

<GridToolbarExport
  csvOptions={{
    fileName: 'csvWithBom',
    utf8WithBom: true,
  } as GridExportCsvOptions}
/>
```

It generate file "csvWithBom.csv" with sequence of bytes (0xEF, 0xBB, 0xBF) at the beginning.

One iteration on #1440