### PR TITLE
[DataGrid] Fix date operators not working with date-time values

### DIFF
--- a/packages/grid/_modules_/grid/models/colDef/gridDateOperators.ts
+++ b/packages/grid/_modules_/grid/models/colDef/gridDateOperators.ts
@@ -2,6 +2,37 @@ import { GridFilterInputValue } from '../../components/panel/filterPanel/GridFil
 import { GridFilterItem } from '../gridFilterItem';
 import { GridFilterOperator } from '../gridFilterOperator';
 
+const dateRegex = /(\d+)-(\d+)-(\d+)/;
+const dateTimeRegex = /(\d+)-(\d+)-(\d+)T(\d+):(\d+)/;
+
+function buildApplyFilterFn(
+  valueToFilter: string,
+  compareFn: (value1: number, value2: number) => boolean,
+  showTime?: boolean,
+) {
+  const [year, month, day, hour, minute] = valueToFilter
+    .match(showTime ? dateTimeRegex : dateRegex)!
+    .slice(1)
+    .map(Number);
+
+  const time = new Date(year, month - 1, day, hour || 0, minute || 0).getTime();
+
+  return ({ value }): boolean => {
+    if (!value) {
+      return false;
+    }
+    // Make a copy of the date to not reset the hours in the original object
+    const valueAsDate = new Date(value instanceof Date ? value : value.toString());
+    const timeToCompare = valueAsDate.setHours(
+      showTime ? valueAsDate.getHours() : 0,
+      showTime ? valueAsDate.getMinutes() : 0,
+      0,
+      0,
+    );
+    return compareFn(timeToCompare, time);
+  };
+}
+
 export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] = (showTime) => [
   {
     value: 'is',
@@ -9,17 +40,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() === time;
-        }
-        return new Date(value.toString()).getTime() === time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 === value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
@@ -30,17 +51,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() !== time;
-        }
-        return new Date(value.toString()).getTime() !== time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 !== value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
@@ -51,17 +62,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() > time;
-        }
-        return new Date(value.toString()).getTime() > time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 > value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
@@ -72,17 +73,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() >= time;
-        }
-        return new Date(value.toString()).getTime() >= time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 >= value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
@@ -93,17 +84,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() < time;
-        }
-        return new Date(value.toString()).getTime() < time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 < value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },
@@ -114,17 +95,7 @@ export const getGridDateOperators: (showTime?: boolean) => GridFilterOperator[] 
       if (!filterItem.columnField || !filterItem.value || !filterItem.operatorValue) {
         return null;
       }
-
-      const time = new Date(filterItem.value).getTime();
-      return ({ value }): boolean => {
-        if (!value) {
-          return false;
-        }
-        if (value instanceof Date) {
-          return (value as Date).getTime() <= time;
-        }
-        return new Date(value.toString()).getTime() <= time;
-      };
+      return buildApplyFilterFn(filterItem.value, (value1, value2) => value1 <= value2, showTime);
     },
     InputComponent: GridFilterInputValue,
     InputComponentProps: { type: showTime ? 'datetime-local' : 'date' },

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -149,7 +149,7 @@ describe('<DataGrid /> - Filter', () => {
     });
   });
 
-  describe('Numeric operators', () => {
+  describe('numeric operators', () => {
     [
       { operator: '=', value: 1984, expected: [1984] },
       { operator: '!=', value: 1984, expected: [1954, 1974] },
@@ -187,23 +187,24 @@ describe('<DataGrid /> - Filter', () => {
     });
   });
 
-  describe('Date operators', function test() {
-    const isEdge = /Edg/.test(window.navigator.userAgent);
-    before(function before() {
-      if (isEdge) {
-        // We need to skip edge as it does not handle the date the same way as other browsers.
-        this.skip();
-      }
-    });
+  describe('date operators', () => {
     [
-      { operator: 'is', value: new Date(2000, 11, 1), expected: ['12/1/2000'] },
-      { operator: 'not', value: new Date(2000, 11, 1), expected: ['1/1/2001', '1/1/2002'] },
-      { operator: 'after', value: new Date(2001, 0, 1), expected: ['1/1/2002'] },
-      { operator: 'onOrAfter', value: new Date(2001, 0, 1), expected: ['1/1/2001', '1/1/2002'] },
-      { operator: 'before', value: new Date(2001, 0, 1), expected: ['12/1/2000'] },
-      { operator: 'onOrBefore', value: new Date(2001, 0, 1), expected: ['12/1/2000', '1/1/2001'] },
+      { operator: 'is', value: new Date(2000, 11, 1), expected: ['2000-12-01'] },
+      { operator: 'not', value: new Date(2000, 11, 1), expected: ['2001-01-01', '2002-01-01'] },
+      { operator: 'after', value: new Date(2001, 0, 1), expected: ['2002-01-01'] },
+      {
+        operator: 'onOrAfter',
+        value: new Date(2001, 0, 1),
+        expected: ['2001-01-01', '2002-01-01'],
+      },
+      { operator: 'before', value: new Date(2001, 0, 1), expected: ['2000-12-01'] },
+      {
+        operator: 'onOrBefore',
+        value: new Date(2001, 0, 1),
+        expected: ['2000-12-01', '2001-01-01'],
+      },
     ].forEach(({ operator, value, expected }) => {
-      it(`should allow object as value and work with valueGetter, operator: ${operator}`, function dateOpsTest() {
+      it(`should allow object as value and work with valueGetter, operator: ${operator}`, () => {
         render(
           <TestCase
             value={value.toLocaleDateString()}
@@ -222,7 +223,14 @@ describe('<DataGrid /> - Filter', () => {
                 brand: { date: new Date(2002, 0, 1) },
               },
             ]}
-            columns={[{ field: 'brand', valueGetter: (params) => params.value.date, type: 'date' }]}
+            columns={[
+              {
+                field: 'brand',
+                type: 'date',
+                valueGetter: (params) => params.value.date,
+                valueFormatter: (params) => params.value.toISOString().slice(0, 10),
+              },
+            ]}
           />,
         );
         expect(getColumnValues()).to.deep.equal(expected.map((res) => res));

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -36,7 +36,7 @@ describe('<DataGrid /> - Filter', () => {
     rows?: any[];
     columns?: any[];
     operator?: string;
-    value?: any;
+    value?: string;
     field?: string;
   }) => {
     const { operator, value, rows, columns, field = 'brand' } = props;
@@ -189,12 +189,12 @@ describe('<DataGrid /> - Filter', () => {
 
   describe('date operators', () => {
     [
-      { operator: 'is', value: new Date(2000, 11, 1), expected: ['12/1/2000'] },
-      { operator: 'not', value: new Date(2000, 11, 1), expected: ['1/1/2001', '1/1/2002'] },
-      { operator: 'after', value: new Date(2001, 0, 1), expected: ['1/1/2002'] },
-      { operator: 'onOrAfter', value: new Date(2001, 0, 1), expected: ['1/1/2001', '1/1/2002'] },
-      { operator: 'before', value: new Date(2001, 0, 1), expected: ['12/1/2000'] },
-      { operator: 'onOrBefore', value: new Date(2001, 0, 1), expected: ['12/1/2000', '1/1/2001'] },
+      { operator: 'is', value: '2000-12-01', expected: ['12/1/2000'] },
+      { operator: 'not', value: '2000-12-01', expected: ['1/1/2001', '1/1/2002'] },
+      { operator: 'after', value: '2001-01-01', expected: ['1/1/2002'] },
+      { operator: 'onOrAfter', value: '2001-01-01', expected: ['1/1/2001', '1/1/2002'] },
+      { operator: 'before', value: '2001-01-01', expected: ['12/1/2000'] },
+      { operator: 'onOrBefore', value: '2001-01-01', expected: ['12/1/2000', '1/1/2001'] },
     ].forEach(({ operator, value, expected }) => {
       it(`should allow object as value and work with valueGetter, operator: ${operator}`, () => {
         render(
@@ -226,6 +226,163 @@ describe('<DataGrid /> - Filter', () => {
           />,
         );
         expect(getColumnValues()).to.deep.equal(expected.map((res) => res));
+      });
+    });
+
+    [
+      {
+        operator: 'is',
+        value: '2000-12-01',
+        expected: ['12/1/2000, 12:00:00 AM', '12/1/2000, 8:30:00 AM'],
+      },
+      {
+        operator: 'not',
+        value: '2000-12-01',
+        expected: [
+          '1/1/2001, 12:00:00 AM',
+          '1/1/2001, 8:30:00 AM',
+          '1/1/2002, 12:00:00 AM',
+          '1/1/2002, 8:30:00 AM',
+        ],
+      },
+      {
+        operator: 'after',
+        value: '2001-01-01',
+        expected: ['1/1/2002, 12:00:00 AM', '1/1/2002, 8:30:00 AM'],
+      },
+      {
+        operator: 'onOrAfter',
+        value: '2001-01-01',
+        expected: [
+          '1/1/2001, 12:00:00 AM',
+          '1/1/2001, 8:30:00 AM',
+          '1/1/2002, 12:00:00 AM',
+          '1/1/2002, 8:30:00 AM',
+        ],
+      },
+      {
+        operator: 'before',
+        value: '2001-01-01',
+        expected: ['12/1/2000, 12:00:00 AM', '12/1/2000, 8:30:00 AM'],
+      },
+      {
+        operator: 'onOrBefore',
+        value: '2001-01-01',
+        expected: [
+          '12/1/2000, 12:00:00 AM',
+          '12/1/2000, 8:30:00 AM',
+          '1/1/2001, 12:00:00 AM',
+          '1/1/2001, 8:30:00 AM',
+        ],
+      },
+    ].forEach(({ operator, value, expected }) => {
+      it(`should work with dates at different hours, operator ${operator}`, () => {
+        render(
+          <TestCase
+            value={value}
+            operator={operator}
+            rows={[
+              {
+                id: 3,
+                brand: new Date(2000, 11, 1), // 12/1/2000, 12:00:00 AM
+              },
+              {
+                id: 4,
+                brand: new Date(2000, 11, 1, 8, 30), // 12/1/2000, 8:30:00 AM
+              },
+              {
+                id: 5,
+                brand: new Date(2001, 0, 1), // -> 1/1/2001, 12:00:00 AM
+              },
+              {
+                id: 6,
+                brand: new Date(2001, 0, 1, 8, 30), // 1/1/2001, 08:30:00 AM
+              },
+              {
+                id: 7,
+                brand: new Date(2002, 0, 1), // -> 1/1/2002, 12:00:00 AM
+              },
+              {
+                id: 8,
+                brand: new Date(2002, 0, 1, 8, 30), // 1/1/2002, 08:30:00 AM
+              },
+            ]}
+            columns={[
+              {
+                field: 'brand',
+                type: 'date',
+                valueFormatter: (params) => params.value.toLocaleString('en-US'),
+              },
+            ]}
+          />,
+        );
+        expect(getColumnValues()).to.deep.equal(expected);
+      });
+    });
+  });
+
+  describe('dateTime operators', () => {
+    [
+      {
+        operator: 'is',
+        value: '2000-12-01T08:30',
+        expected: ['12/1/2000, 8:30:15 AM'],
+      },
+      {
+        operator: 'not',
+        value: '2000-12-01T08:30',
+        expected: ['1/1/2001, 8:30:15 AM', '1/1/2002, 8:30:15 AM'],
+      },
+      {
+        operator: 'after',
+        value: '2001-01-01T08:30',
+        expected: ['1/1/2002, 8:30:15 AM'],
+      },
+      {
+        operator: 'onOrAfter',
+        value: '2001-01-01T08:30',
+        expected: ['1/1/2001, 8:30:15 AM', '1/1/2002, 8:30:15 AM'],
+      },
+      {
+        operator: 'before',
+        value: '2001-01-01T08:30',
+        expected: ['12/1/2000, 8:30:15 AM'],
+      },
+      {
+        operator: 'onOrBefore',
+        value: '2001-01-01T08:30',
+        expected: ['12/1/2000, 8:30:15 AM', '1/1/2001, 8:30:15 AM'],
+      },
+    ].forEach(({ operator, value, expected }) => {
+      it(`should work correctly with operator=${operator}`, () => {
+        render(
+          <TestCase
+            value={value}
+            operator={operator}
+            rows={[
+              {
+                id: 3,
+                brand: new Date(2000, 11, 1, 8, 30, 15, 20), // 12/1/2000, 8:30:15 AM
+              },
+              {
+                id: 4,
+                brand: new Date(2001, 0, 1, 8, 30, 15, 20), // 1/1/2001, 08:30:15 AM
+              },
+              {
+                id: 5,
+                brand: new Date(2002, 0, 1, 8, 30, 15, 20), // 1/1/2002, 08:30:15 AM
+              },
+            ]}
+            columns={[
+              {
+                field: 'brand',
+                type: 'dateTime',
+                valueFormatter: (params) => params.value.toLocaleString('en-US'),
+              },
+            ]}
+          />,
+        );
+        expect(getColumnValues()).to.deep.equal(expected);
       });
     });
   });

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -188,7 +188,6 @@ describe('<DataGrid /> - Filter', () => {
   });
 
   describe('date operators', () => {
-    const formatter = new Intl.DateTimeFormat('en');
     [
       { operator: 'is', value: new Date(2000, 11, 1), expected: ['12/1/2000'] },
       { operator: 'not', value: new Date(2000, 11, 1), expected: ['1/1/2001', '1/1/2002'] },
@@ -221,7 +220,7 @@ describe('<DataGrid /> - Filter', () => {
                 field: 'brand',
                 type: 'date',
                 valueGetter: (params) => params.value.date,
-                valueFormatter: (params) => formatter.format(params.value),
+                valueFormatter: (params) => params.value.toLocaleDateString('en-US'),
               },
             ]}
           />,

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -36,7 +36,7 @@ describe('<DataGrid /> - Filter', () => {
     rows?: any[];
     columns?: any[];
     operator?: string;
-    value?: string;
+    value?: any;
     field?: string;
   }) => {
     const { operator, value, rows, columns, field = 'brand' } = props;
@@ -188,13 +188,14 @@ describe('<DataGrid /> - Filter', () => {
   });
 
   describe('date operators', () => {
+    const formatter = new Intl.DateTimeFormat('en');
     [
-      { operator: 'is', value: '2000-12-01', expected: ['2000-12-01'] },
-      { operator: 'not', value: '2000-12-01', expected: ['2001-01-01', '2002-01-01'] },
-      { operator: 'after', value: '2001-01-01', expected: ['2002-01-01'] },
-      { operator: 'onOrAfter', value: '2001-01-01', expected: ['2001-01-01', '2002-01-01'] },
-      { operator: 'before', value: '2001-01-01', expected: ['2000-12-01'] },
-      { operator: 'onOrBefore', value: '2001-01-01', expected: ['2000-12-01', '2001-01-01'] },
+      { operator: 'is', value: new Date(2000, 11, 1), expected: ['12/1/2000'] },
+      { operator: 'not', value: new Date(2000, 11, 1), expected: ['1/1/2001', '1/1/2002'] },
+      { operator: 'after', value: new Date(2001, 0, 1), expected: ['1/1/2002'] },
+      { operator: 'onOrAfter', value: new Date(2001, 0, 1), expected: ['1/1/2001', '1/1/2002'] },
+      { operator: 'before', value: new Date(2001, 0, 1), expected: ['12/1/2000'] },
+      { operator: 'onOrBefore', value: new Date(2001, 0, 1), expected: ['12/1/2000', '1/1/2001'] },
     ].forEach(({ operator, value, expected }) => {
       it(`should allow object as value and work with valueGetter, operator: ${operator}`, () => {
         render(
@@ -204,15 +205,15 @@ describe('<DataGrid /> - Filter', () => {
             rows={[
               {
                 id: 3,
-                brand: { date: new Date('2000-12-01') },
+                brand: { date: new Date(2000, 11, 1) },
               },
               {
                 id: 4,
-                brand: { date: new Date('2001-01-01') },
+                brand: { date: new Date(2001, 0, 1) },
               },
               {
                 id: 5,
-                brand: { date: new Date('2002-01-01') },
+                brand: { date: new Date(2002, 0, 1) },
               },
             ]}
             columns={[
@@ -220,7 +221,7 @@ describe('<DataGrid /> - Filter', () => {
                 field: 'brand',
                 type: 'date',
                 valueGetter: (params) => params.value.date,
-                valueFormatter: (params) => params.value.toISOString().slice(0, 10),
+                valueFormatter: (params) => formatter.format(params.value),
               },
             ]}
           />,

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -189,38 +189,30 @@ describe('<DataGrid /> - Filter', () => {
 
   describe('date operators', () => {
     [
-      { operator: 'is', value: new Date(2000, 11, 1), expected: ['2000-12-01'] },
-      { operator: 'not', value: new Date(2000, 11, 1), expected: ['2001-01-01', '2002-01-01'] },
-      { operator: 'after', value: new Date(2001, 0, 1), expected: ['2002-01-01'] },
-      {
-        operator: 'onOrAfter',
-        value: new Date(2001, 0, 1),
-        expected: ['2001-01-01', '2002-01-01'],
-      },
-      { operator: 'before', value: new Date(2001, 0, 1), expected: ['2000-12-01'] },
-      {
-        operator: 'onOrBefore',
-        value: new Date(2001, 0, 1),
-        expected: ['2000-12-01', '2001-01-01'],
-      },
+      { operator: 'is', value: '2000-12-01', expected: ['2000-12-01'] },
+      { operator: 'not', value: '2000-12-01', expected: ['2001-01-01', '2002-01-01'] },
+      { operator: 'after', value: '2001-01-01', expected: ['2002-01-01'] },
+      { operator: 'onOrAfter', value: '2001-01-01', expected: ['2001-01-01', '2002-01-01'] },
+      { operator: 'before', value: '2001-01-01', expected: ['2000-12-01'] },
+      { operator: 'onOrBefore', value: '2001-01-01', expected: ['2000-12-01', '2001-01-01'] },
     ].forEach(({ operator, value, expected }) => {
       it(`should allow object as value and work with valueGetter, operator: ${operator}`, () => {
         render(
           <TestCase
-            value={value.toLocaleDateString()}
+            value={value}
             operator={operator}
             rows={[
               {
                 id: 3,
-                brand: { date: new Date(2000, 11, 1) },
+                brand: { date: new Date('2000-12-01') },
               },
               {
                 id: 4,
-                brand: { date: new Date(2001, 0, 1) },
+                brand: { date: new Date('2001-01-01') },
               },
               {
                 id: 5,
-                brand: { date: new Date(2002, 0, 1) },
+                brand: { date: new Date('2002-01-01') },
               },
             ]}
             columns={[


### PR DESCRIPTION
Closes #1710 
To be merged after #1708

The fix for this bug involves resetting the time components of the date value before comparing it. The components we need to reset depend on the column type:
- If `date`, then resets the hours, minutes, seconds, and milliseconds
- If `dateTime`, then resets only seconds and milliseconds.

I also took the opportunity to remove a lot of duplicated code and move it to an abstraction.