### PR TITLE
[core] Help support different documents

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -1,5 +1,5 @@
-import { capitalize } from '@material-ui/core/utils';
 import * as React from 'react';
+import { ownerDocument, capitalize } from '@material-ui/core/utils';
 import clsx from 'clsx';
 import {
   GRID_CELL_BLUR,
@@ -142,10 +142,12 @@ export const GridCell = React.memo((props: GridCellProps) => {
   };
 
   React.useLayoutEffect(() => {
+    const doc = ownerDocument(apiRef!.current.rootElementRef!.current as HTMLElement);
+
     if (
       hasFocus &&
       cellRef.current &&
-      (!document.activeElement || !cellRef.current!.contains(document.activeElement))
+      (!doc.activeElement || !cellRef.current!.contains(doc.activeElement))
     ) {
       const focusableElement = cellRef.current!.querySelector('[tabindex="0"]') as HTMLElement;
       if (focusableElement) {

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -144,7 +144,7 @@ export const useGridKeyboard = (
 
   const handleCellKeyDown = React.useCallback(
     (params: GridCellParams, event: React.KeyboardEvent) => {
-      if (!isGridCellRoot(document.activeElement)) {
+      if (!isGridCellRoot(event.target as HTMLElement)) {
         return;
       }
       if (event.isPropagationStopped()) {

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboard.ts
@@ -66,7 +66,7 @@ export const useGridKeyboard = (
   const expandSelection = React.useCallback(
     (params: GridCellParams, event: React.KeyboardEvent) => {
       const rowEl = findParentElementFromClassName(
-        document.activeElement as HTMLDivElement,
+        (event.target as HTMLElement) as HTMLDivElement,
         GRID_ROW_CSS_CLASS,
       )! as HTMLElement;
 
@@ -101,18 +101,21 @@ export const useGridKeyboard = (
     [logger, apiRef],
   );
 
-  const handleCopy = React.useCallback(() => {
-    const rowEl = getRowEl(document.activeElement)!;
-    const rowId = getIdFromRowElem(rowEl);
-    const isRowSelected = selectionState[rowId];
+  const handleCopy = React.useCallback(
+    (target: HTMLElement) => {
+      const rowEl = getRowEl(target)!;
+      const rowId = getIdFromRowElem(rowEl);
+      const isRowSelected = selectionState[rowId];
 
-    if (isRowSelected) {
-      window?.getSelection()?.selectAllChildren(rowEl);
-    } else {
-      window?.getSelection()?.selectAllChildren(document.activeElement!);
-    }
-    document.execCommand('copy');
-  }, [selectionState]);
+      if (isRowSelected) {
+        window?.getSelection()?.selectAllChildren(rowEl);
+      } else {
+        window?.getSelection()?.selectAllChildren(target);
+      }
+      document.execCommand('copy');
+    },
+    [selectionState],
+  );
 
   const handleKeyDown = React.useCallback(
     (event: KeyboardEvent) => {
@@ -173,7 +176,7 @@ export const useGridKeyboard = (
       }
 
       if (event.key.toLowerCase() === 'c' && (event.ctrlKey || event.metaKey)) {
-        handleCopy();
+        handleCopy(event.target as HTMLElement);
         return;
       }
 
@@ -187,13 +190,13 @@ export const useGridKeyboard = (
 
   const handleColumnHeaderKeyDown = React.useCallback(
     (params: GridCellParams, event: React.KeyboardEvent) => {
-      if (!isGridHeaderCellRoot(document.activeElement)) {
+      if (!isGridHeaderCellRoot(event.target as HTMLElement)) {
         return;
       }
       if (event.isPropagationStopped()) {
         return;
       }
-      if (isSpaceKey(event.key) && isGridHeaderCellRoot(document.activeElement)) {
+      if (isSpaceKey(event.key) && isGridHeaderCellRoot(event.target as HTMLElement)) {
         event.preventDefault();
       }
 


### PR DESCRIPTION
A web page can have multiple `document`. We have no guarantee that `document.activeElement` is the target the event fired on. This change is important if we assume that the usage of multiple documents (popup/iframe/shadow dom) is frequent in the finance industry. 