### PR TITLE
[DataGrid] Increase the minimum version of core v5 supported

### DIFF
--- a/packages/grid/data-grid/README.md
+++ b/packages/grid/data-grid/README.md
@@ -18,7 +18,7 @@ This component has 2 peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.22",
+  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -36,7 +36,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.22",
+    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
     "react": "^17.0.0"
   },
   "setupFiles": [

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -34,7 +34,7 @@
     "yargs": "^17.0.1"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.22",
+    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
     "react": "^17.0.0"
   },
   "setupFiles": [

--- a/packages/grid/x-grid/README.md
+++ b/packages/grid/x-grid/README.md
@@ -18,7 +18,7 @@ This component has 2 peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.22",
+  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -37,7 +37,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.22",
+    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
     "react": "^17.0.0"
   },
   "setupFiles": [


### PR DESCRIPTION
Fixes #1761 

Note: I updated to `.34` instead of `.33` which was actually [suggested](https://github.com/mui-org/material-ui-x/issues/1761#issuecomment-847112150). Is it fine?