### PR TITLE
[DataGrid] Add `valueParser` to parse values entered by the user

### DIFF
--- a/docs/src/pages/components/data-grid/columns/ValueFormatterGrid.js
+++ b/docs/src/pages/components/data-grid/columns/ValueFormatterGrid.js
@@ -1,14 +1,6 @@
 import * as React from 'react';
 import { DataGrid } from '@material-ui/data-grid';
 
-const columns = [
-  {
-    field: 'date',
-    headerName: 'Year',
-    valueFormatter: (params) => params.value.getFullYear(),
-  },
-];
-
 const rows = [
   {
     id: 1,
@@ -16,18 +8,29 @@ const rows = [
   },
   {
     id: 2,
-    date: new Date(1984, 1, 1),
+    date: new Date(1984, 0, 1),
   },
   {
     id: 3,
-    date: new Date(1992, 2, 1),
+    date: new Date(1992, 0, 1),
   },
 ];
 
 export default function ValueFormatterGrid() {
   return (
     <div style={{ height: 300, width: '100%' }}>
-      <DataGrid rows={rows} columns={columns} />
+      <DataGrid
+        rows={rows}
+        columns={[
+          {
+            type: 'number',
+            field: 'date',
+            headerName: 'Year',
+            width: 150,
+            valueFormatter: (params) => params.value.getFullYear(),
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/columns/ValueParserGrid.js
+++ b/docs/src/pages/components/data-grid/columns/ValueParserGrid.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DataGrid, GridValueFormatterParams } from '@material-ui/data-grid';
+import { DataGrid } from '@material-ui/data-grid';
 
 const rows = [
   {
@@ -16,7 +16,7 @@ const rows = [
   },
 ];
 
-export default function ValueFormatterGrid() {
+export default function ValueParserGrid() {
   return (
     <div style={{ height: 300, width: '100%' }}>
       <DataGrid
@@ -27,8 +27,8 @@ export default function ValueFormatterGrid() {
             field: 'date',
             headerName: 'Year',
             width: 150,
-            valueFormatter: (params: GridValueFormatterParams) =>
-              (params.value as Date).getFullYear(),
+            valueFormatter: (params) => params.value.getFullYear(),
+            valueParser: (value) => new Date(Number(value), 0, 1),
           },
         ]}
       />

--- a/docs/src/pages/components/data-grid/columns/ValueParserGrid.tsx
+++ b/docs/src/pages/components/data-grid/columns/ValueParserGrid.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DataGrid, GridValueFormatterParams } from '@material-ui/data-grid';
+import { DataGrid, GridCellValue } from '@material-ui/data-grid';
 
 const rows = [
   {
@@ -16,7 +16,7 @@ const rows = [
   },
 ];
 
-export default function ValueFormatterGrid() {
+export default function ValueParserGrid() {
   return (
     <div style={{ height: 300, width: '100%' }}>
       <DataGrid
@@ -27,8 +27,8 @@ export default function ValueFormatterGrid() {
             field: 'date',
             headerName: 'Year',
             width: 150,
-            valueFormatter: (params: GridValueFormatterParams) =>
-              (params.value as Date).getFullYear(),
+            valueFormatter: (params) => (params.value as Date).getFullYear(),
+            valueParser: (value: GridCellValue) => new Date(Number(value), 0, 1),
           },
         ]}
       />

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -122,23 +122,26 @@ The value generated is used for filtering, sorting, rendering, etc unless overri
 
 ### Value formatter
 
-The value formatters allow you to format values for display as a string.
-For instance, you can use it to format a JavaScript `Date` object.
+The value formatter allows you to convert the value before displaying it.
+Common use cases include converting a JavaScript `Date` object to a date string or a `Number` into a formatted number (e.g. "1.000,50").
 
-```tsx
-const columns: GridColDef[] = [
-  {
-    field: 'date',
-    headerName: 'Year',
-    valueFormatter: (params: ValueFormatterParams) =>
-      (params.value as Date).getFullYear(),
-  },
-];
-```
+In the following demo, a formatter is used to display only the year of a JavaScript `Date` object.
 
 {{"demo": "pages/components/data-grid/columns/ValueFormatterGrid.js", "bg": "inline"}}
 
-The value generated is used for filtering, sorting, rendering in the cell and outside, etc unless overridden by a more specific configuration.
+The value generated is only used for rendering purposes.
+Filtering and sorting will not relay on the formatted value.
+Use the [`valueParser`](/components/data-grid/columns#value-parser) to support filtering.
+
+### Value parser
+
+The value parser allows you to convert the user-entered value to another one used for filtering or editing.
+Common use cases include parsing date strings to JavaScript `Date` objects or formatted numbers (e.g. "1.000,50") into `Number`.
+It can be understood as the inverse of [`valueFormatter`](/components/data-grid/columns#value-formatter).
+
+In the following demo, the user can filter for a year while a `Date` is used internally.
+
+{{"demo": "pages/components/data-grid/columns/ValueParserGrid.js", "bg": "inline"}}
 
 ### Render cell
 

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.js
@@ -42,7 +42,7 @@ RatingInputValue.propTypes = {
     columnField: PropTypes.string,
     id: PropTypes.number,
     operatorValue: PropTypes.string,
-    value: PropTypes.string,
+    value: PropTypes.any,
   }).isRequired,
 };
 

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.js
@@ -42,7 +42,7 @@ RatingInputValue.propTypes = {
     columnField: PropTypes.string,
     id: PropTypes.number,
     operatorValue: PropTypes.string,
-    value: PropTypes.string,
+    value: PropTypes.any,
   }).isRequired,
 };
 

--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -36,7 +36,7 @@ export interface GridCellProps {
   value?: GridCellValue;
   width: number;
   cellMode?: GridCellMode;
-  children: React.ReactElement | null;
+  children: React.ReactNode;
   tabIndex: 0 | -1;
 }
 

--- a/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
@@ -78,7 +78,7 @@ export const GridRowCells = React.memo((props: RowCellsProps) => {
     }
 
     const editCellState = editRowState && editRowState[column.field];
-    let cellComponent: React.ReactElement | null = null;
+    let cellComponent: React.ReactNode = null;
 
     if (editCellState == null && column.renderCell) {
       cellComponent = column.renderCell(cellParams);

--- a/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaderItem.tsx
+++ b/packages/grid/_modules_/grid/components/columnHeaders/GridColumnHeaderItem.tsx
@@ -76,7 +76,7 @@ export const GridColumnHeaderItem = React.memo(
     // todo refactor to a prop on col isNumeric or ?? ie: coltype===price wont work
     const isColumnNumeric = column.type === GRID_NUMBER_COLUMN_TYPE;
 
-    let headerComponent: React.ReactElement | null = null;
+    let headerComponent: React.ReactNode = null;
     if (column.renderHeader && apiRef!.current) {
       headerComponent = column.renderHeader(apiRef!.current.getColumnHeaderParams(column.field));
     }

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -59,30 +59,36 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
       if (!filterItem.columnField || !filterItem.operatorValue || !filterItem.value) {
         return;
       }
-      logger.debug(
-        `Filtering column: ${filterItem.columnField} ${filterItem.operatorValue} ${filterItem.value} `,
-      );
 
       const column = apiRef.current.getColumn(filterItem.columnField);
       if (!column) {
         return;
       }
-      const filterOperators = column.filterOperators;
 
+      const parsedValue = column.valueParser
+        ? column.valueParser(filterItem.value)
+        : filterItem.value;
+      const newFilterItem = { ...filterItem, value: parsedValue };
+
+      logger.debug(
+        `Filtering column: ${newFilterItem.columnField} ${newFilterItem.operatorValue} ${newFilterItem.value} `,
+      );
+
+      const filterOperators = column.filterOperators;
       if (!filterOperators?.length) {
         throw new Error(`Material-UI: No filter operators found for column '${column.field}'.`);
       }
-      const filterOperator = filterOperators.find(
-        (operator) => operator.value === filterItem.operatorValue,
-      )!;
 
+      const filterOperator = filterOperators.find(
+        (operator) => operator.value === newFilterItem.operatorValue,
+      )!;
       if (!filterOperator) {
         throw new Error(
-          `Material-UI: No filter operator found for column '${column.field}' and operator value '${filterItem.operatorValue}'.`,
+          `Material-UI: No filter operator found for column '${column.field}' and operator value '${newFilterItem.operatorValue}'.`,
         );
       }
 
-      const applyFilterOnRow = filterOperator.getApplyFilterFn(filterItem, column)!;
+      const applyFilterOnRow = filterOperator.getApplyFilterFn(newFilterItem, column)!;
 
       setGridState((state) => {
         const visibleRowsLookup = { ...state.visibleRows.visibleRowsLookup };
@@ -92,7 +98,7 @@ export const useGridFilter = (apiRef: GridApiRef, rowsProp: GridRowsProp): void 
         const rows = sortedGridRowsSelector(state);
 
         rows.forEach((row: GridRowModel, id: GridRowId) => {
-          const params = apiRef.current.getCellParams(id, filterItem.columnField!);
+          const params = apiRef.current.getCellParams(id, newFilterItem.columnField!);
 
           const isShown = applyFilterOnRow(params);
           if (visibleRowsLookup[id] == null) {

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
@@ -171,13 +171,15 @@ export function useGridEditRows(apiRef: GridApiRef) {
 
   const setCellValue = React.useCallback(
     (params: GridEditCellValueParams) => {
+      const column = apiRef.current.getColumn(params.field);
+      const parsedValue = column.valueParser
+        ? column.valueParser(params.value, apiRef.current.getCellParams(params.id, params.field))
+        : params.value;
       logger.debug(
-        `Setting cell id: ${params.id} field: ${
-          params.field
-        } to value: ${params.value?.toString()}`,
+        `Setting cell id: ${params.id} field: ${params.field} to value: ${parsedValue?.toString()}`,
       );
       const rowUpdate = { id: params.id };
-      rowUpdate[params.field] = params.value;
+      rowUpdate[params.field] = parsedValue;
       apiRef.current.updateRows([rowUpdate]);
       apiRef.current.publishEvent(GRID_CELL_VALUE_CHANGE, params);
     },

--- a/packages/grid/_modules_/grid/models/colDef/gridColDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/gridColDef.ts
@@ -100,12 +100,12 @@ export interface GridColDef {
    * Allows to override the component rendered as cell for this column.
    * @param params
    */
-  renderCell?: (params: GridCellParams) => React.ReactElement;
+  renderCell?: (params: GridCellParams) => React.ReactNode;
   /**
    * Allows to override the component rendered in edit cell mode for this column.
    * @param params
    */
-  renderEditCell?: (params: GridCellParams) => React.ReactElement;
+  renderEditCell?: (params: GridCellParams) => React.ReactNode;
   /**
    * Class name that will be added in the column header cell.
    */
@@ -114,7 +114,7 @@ export interface GridColDef {
    * Allows to render a component in the column header cell.
    * @param params
    */
-  renderHeader?: (params: GridColumnHeaderParams) => React.ReactElement;
+  renderHeader?: (params: GridColumnHeaderParams) => React.ReactNode;
   /**
    * Header cell element alignment.
    */

--- a/packages/grid/_modules_/grid/models/colDef/gridColDef.ts
+++ b/packages/grid/_modules_/grid/models/colDef/gridColDef.ts
@@ -81,9 +81,17 @@ export interface GridColDef {
   valueGetter?: (params: GridValueGetterParams) => GridCellValue;
   /**
    * Function that allows to apply a formatter before rendering its value.
-   * @param params
+   * @param {GridValueFormatterParams} params Object contaning parameters for the formatter.
+   * @returns {GridCellValue} The formatted value.
    */
   valueFormatter?: (params: GridValueFormatterParams) => GridCellValue;
+  /**
+   * Function that takes the user-entered value and converts it to a value used internally.
+   * @param {GridCellValue} value The user-entered value.
+   * @param {GridCellParams} params The params when called before saving the value.
+   * @returns {GridCellValue} The converted value to use internally.
+   */
+  valueParser?: (value: GridCellValue, params?: GridCellParams) => GridCellValue;
   /**
    * Class name that will be added in cells for that column.
    */

--- a/packages/grid/_modules_/grid/models/gridFilterItem.ts
+++ b/packages/grid/_modules_/grid/models/gridFilterItem.ts
@@ -1,7 +1,7 @@
 export interface GridFilterItem {
   id?: number;
   columnField?: string;
-  value?: string;
+  value?: any;
   operatorValue?: string;
 }
 

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -36,7 +36,7 @@ describe('<DataGrid /> - Filter', () => {
     rows?: any[];
     columns?: any[];
     operatorValue?: string;
-    value?: string;
+    value?: any;
     field?: string;
   }) => {
     const { operatorValue, value, rows, columns, field = 'brand' } = props;
@@ -573,5 +573,33 @@ describe('<DataGrid /> - Filter', () => {
       );
     };
     render(<Test />);
+  });
+
+  it('should apply the valueParser onto the filter value', () => {
+    render(
+      <TestCase
+        rows={[
+          {
+            id: 1,
+            amount: 0.5,
+          },
+          {
+            id: 2,
+            amount: 1,
+          },
+        ]}
+        columns={[
+          {
+            field: 'amount',
+            type: 'number',
+            valueParser: (value) => (value as number) / 100,
+          },
+        ]}
+        operatorValue={'='}
+        value={50}
+        field={'amount'}
+      />,
+    );
+    expect(getColumnValues()).to.deep.equal(['0.5']);
   });
 });


### PR DESCRIPTION
Closes #1118

I'm not sure about the signature of `valueParser`. It's called with the user-entered value and the cell params. However, when applying it to the filter value I don't have a cell, so no params.