### PR TITLE
[DataGrid] Fix fluid columns width when available `viewportWidth` < 0

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -32,6 +32,7 @@ import {
   visibleGridColumnsSelector,
 } from './gridColumnsSelector';
 import { useGridApiOptionHandler } from '../../root/useGridApiEventHandler';
+import { GRID_STRING_COL_DEF } from '../../../models/colDef/gridStringColDef';
 
 function updateColumnsWidth(columns: GridColumns, viewportWidth: number) {
   const numberOfFluidColumns = columns.filter((column) => !!column.flex && !column.hide).length;
@@ -50,14 +51,19 @@ function updateColumnsWidth(columns: GridColumns, viewportWidth: number) {
   }
 
   let newColumns = columns;
-  if (viewportWidth > 0 && numberOfFluidColumns) {
+  if (numberOfFluidColumns) {
     const flexMultiplier = viewportWidth / flexDivider;
-    newColumns = columns.map((column) => {
-      return {
-        ...column,
-        width: column.flex! ? Math.floor(flexMultiplier * column.flex!) : column.width,
-      };
-    });
+    newColumns = columns.map((column) =>
+      viewportWidth > 0
+        ? {
+            ...column,
+            width: column.flex! ? Math.floor(flexMultiplier * column.flex!) : column.width,
+          }
+        : {
+            ...column,
+            width: column.flex! ? GRID_STRING_COL_DEF.width : column.width,
+          },
+    );
   }
   return newColumns;
 }

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -53,17 +53,16 @@ function updateColumnsWidth(columns: GridColumns, viewportWidth: number) {
   let newColumns = columns;
   if (numberOfFluidColumns) {
     const flexMultiplier = viewportWidth / flexDivider;
-    newColumns = columns.map((column) =>
-      viewportWidth > 0
-        ? {
-            ...column,
-            width: column.flex! ? Math.floor(flexMultiplier * column.flex!) : column.width,
-          }
-        : {
-            ...column,
-            width: column.flex! ? GRID_STRING_COL_DEF.width : column.width,
-          },
-    );
+    newColumns = columns.map((column) => {
+      if (!column.flex) {
+        return column;
+      }
+      return {
+        ...column,
+        width:
+          viewportWidth > 0 ? Math.floor(flexMultiplier * column.flex!) : GRID_STRING_COL_DEF.width,
+      };
+    });
   }
   return newColumns;
 }


### PR DESCRIPTION
Fixes #1582 

Reproduction: https://codesandbox.io/s/material-demo-forked-y2xj0 (when the grid loads start resizing the window to make it small to a point where the last column dissapears)

The problem was that when resizing and space was not enough the fluid columns did not default to the base width of `100px`.

https://user-images.githubusercontent.com/5858539/120652536-87ed3c00-c488-11eb-810b-0de3d1a07101.mov