### PR TITLE
[DataGrid] Fix cell height after changing grid's density

### DIFF
--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -67,6 +67,7 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
             columns={visibleColumns}
             row={row}
             id={id}
+            height={rowHeight}
             firstColIdx={renderState.renderContext!.firstColIdx!}
             lastColIdx={renderState.renderContext!.lastColIdx!}
             hasScrollX={scrollBarState.hasScrollX}

--- a/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridRowCells.tsx
@@ -11,8 +11,6 @@ import {
 import { GridCell, GridCellProps } from './GridCell';
 import { GridApiContext } from '../GridApiContext';
 import { isFunction } from '../../utils/index';
-import { gridDensityRowHeightSelector } from '../../hooks/features/density/densitySelector';
-import { useGridSelector } from '../../hooks/features/core/useGridSelector';
 import { GRID_CSS_CLASS_PREFIX } from '../../constants/cssClassesConstants';
 
 interface RowCellsProps {
@@ -23,6 +21,7 @@ interface RowCellsProps {
   id: GridRowId;
   hasScrollX: boolean;
   hasScrollY: boolean;
+  height: number;
   getCellClassName?: (params: GridCellParams) => string;
   lastColIdx: number;
   row: GridRowModel;
@@ -40,6 +39,7 @@ export const GridRowCells = React.memo((props: RowCellsProps) => {
     firstColIdx,
     hasScrollX,
     hasScrollY,
+    height,
     id,
     getCellClassName,
     lastColIdx,
@@ -53,8 +53,6 @@ export const GridRowCells = React.memo((props: RowCellsProps) => {
     ...other
   } = props;
   const apiRef = React.useContext(GridApiContext);
-  const rowHeight = useGridSelector(apiRef, gridDensityRowHeightSelector);
-
   const cellsProps = columns.slice(firstColIdx, lastColIdx + 1).map((column, colIdx) => {
     const colIndex = firstColIdx + colIdx;
     const isLastColumn = colIndex === columns.length - 1;
@@ -100,7 +98,7 @@ export const GridRowCells = React.memo((props: RowCellsProps) => {
       field: column.field,
       width: column.width!,
       rowId: id,
-      height: rowHeight,
+      height,
       showRightBorder,
       formattedValue: cellParams.formattedValue,
       align: column.align || 'left',

--- a/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/toolbar.DataGrid.test.tsx
@@ -68,6 +68,11 @@ describe('<DataGrid /> - Toolbar', () => {
       expect(screen.getAllByRole('row')[1]).toHaveInlineStyle({
         maxHeight: `${Math.floor(rowHeight * COMPACT_DENSITY_FACTOR)}px`,
       });
+
+      // @ts-expect-error need to migrate helpers to TypeScript
+      expect(screen.getAllByRole('cell')[1]).toHaveInlineStyle({
+        maxHeight: `${Math.floor(rowHeight * COMPACT_DENSITY_FACTOR)}px`,
+      });
     });
 
     it('should decrease grid density when selecting comfortable density', () => {
@@ -91,6 +96,11 @@ describe('<DataGrid /> - Toolbar', () => {
       expect(screen.getAllByRole('row')[1]).toHaveInlineStyle({
         maxHeight: `${Math.floor(rowHeight * COMFORTABLE_DENSITY_FACTOR)}px`,
       });
+
+      // @ts-expect-error need to migrate helpers to TypeScript
+      expect(screen.getAllByRole('cell')[1]).toHaveInlineStyle({
+        maxHeight: `${Math.floor(rowHeight * COMFORTABLE_DENSITY_FACTOR)}px`,
+      });
     });
 
     it('should increase grid density even if toolbar is not enabled', () => {
@@ -105,6 +115,11 @@ describe('<DataGrid /> - Toolbar', () => {
       expect(screen.getAllByRole('row')[1]).toHaveInlineStyle({
         maxHeight: `${Math.floor(rowHeight * COMPACT_DENSITY_FACTOR)}px`,
       });
+
+      // @ts-expect-error need to migrate helpers to TypeScript
+      expect(screen.getAllByRole('cell')[1]).toHaveInlineStyle({
+        maxHeight: `${Math.floor(rowHeight * COMPACT_DENSITY_FACTOR)}px`,
+      });
     });
 
     it('should decrease grid density even if toolbar is not enabled', () => {
@@ -117,6 +132,11 @@ describe('<DataGrid /> - Toolbar', () => {
 
       // @ts-expect-error need to migrate helpers to TypeScript
       expect(screen.getAllByRole('row')[1]).toHaveInlineStyle({
+        maxHeight: `${Math.floor(rowHeight * COMFORTABLE_DENSITY_FACTOR)}px`,
+      });
+
+      // @ts-expect-error need to migrate helpers to TypeScript
+      expect(screen.getAllByRole('cell')[1]).toHaveInlineStyle({
         maxHeight: `${Math.floor(rowHeight * COMFORTABLE_DENSITY_FACTOR)}px`,
       });
     });


### PR DESCRIPTION
Fixes #1776 

The problem was related to grabbing the height from the state inside `GridRowCells` component which is memoized. Passing it as a prop solves the issue. I extended the existing density tests to cover that case.

 Preview: https://deploy-preview-1819--material-ui-x.netlify.app/components/data-grid/accessibility/#density-selector