### PR TITLE
[test] Improve pagination tests

### DIFF
--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -315,14 +315,7 @@ describe('<DataGrid /> - Pagination', () => {
         const columns = [{ field: 'x', type: 'number' }];
         render(
           <div style={{ height: 300, width: 400 }}>
-            <DataGrid
-              autoHeight={isJSDOM}
-              pagination
-              autoPageSize
-              rows={rows}
-              columns={columns}
-              page={2}
-            />
+            <DataGrid pagination autoPageSize rows={rows} columns={columns} page={2} />
           </div>,
         );
         expect(getColumnValues(0)).to.deep.equal(['7', '8']);

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -17,6 +17,8 @@ import { getColumnValues } from 'test/utils/helperFn';
 import { spy } from 'sinon';
 import { useData } from 'packages/storybook/src/hooks/useData';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Pagination', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
@@ -40,13 +42,6 @@ describe('<DataGrid /> - Pagination', () => {
   };
 
   describe('pagination', () => {
-    before(function beforeHook() {
-      if (/jsdom/.test(window.navigator.userAgent)) {
-        // Need layouting
-        this.skip();
-      }
-    });
-
     it('should apply the page prop correctly', () => {
       render(
         <div style={{ width: 300, height: 300 }}>
@@ -213,6 +208,17 @@ describe('<DataGrid /> - Pagination', () => {
       expect(getColumnValues()).to.deep.equal(['Nike 1']);
     });
 
+    it('should not change the page when clicking on the next page and a page prop is provided', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid {...baselineProps} page={0} pageSize={1} />
+        </div>,
+      );
+      expect(getColumnValues()).to.deep.equal(['Nike']);
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(getColumnValues()).to.deep.equal(['Nike']);
+    });
+
     it('should show filtered data if the user applies filter on an intermediate page and the resulted filter data is less than the rows per page', () => {
       const TestCasePaginationFilteredData = () => {
         const data = useData(200, 2);
@@ -220,6 +226,7 @@ describe('<DataGrid /> - Pagination', () => {
         return (
           <div style={{ width: 300, height: 300 }}>
             <DataGrid
+              autoHeight={isJSDOM}
               columns={data.columns}
               rows={data.rows}
               pagination
@@ -243,6 +250,13 @@ describe('<DataGrid /> - Pagination', () => {
     });
 
     describe('prop: autoPageSize', () => {
+      before(function beforeHook() {
+        if (/jsdom/.test(window.navigator.userAgent)) {
+          // Need layouting
+          this.skip();
+        }
+      });
+
       it('should always render the same amount of rows and fit the viewport', () => {
         const TestCaseAutoPageSize = (props: { nbRows: number; height?: number }) => {
           const data = useData(props.nbRows, 10);
@@ -301,7 +315,14 @@ describe('<DataGrid /> - Pagination', () => {
         const columns = [{ field: 'x', type: 'number' }];
         render(
           <div style={{ height: 300, width: 400 }}>
-            <DataGrid pagination autoPageSize rows={rows} columns={columns} page={2} />
+            <DataGrid
+              autoHeight={isJSDOM}
+              pagination
+              autoPageSize
+              rows={rows}
+              columns={columns}
+              page={2}
+            />
           </div>,
         );
         expect(getColumnValues(0)).to.deep.equal(['7', '8']);

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -251,7 +251,7 @@ describe('<DataGrid /> - Pagination', () => {
 
     describe('prop: autoPageSize', () => {
       before(function beforeHook() {
-        if (/jsdom/.test(window.navigator.userAgent)) {
+        if (isJSDOM) {
           // Need layouting
           this.skip();
         }


### PR DESCRIPTION
Closes #223

This PR adds a test case to ensure that when clicking on the next page and there's a `page` prop it will not change the current page. I also fixed the suite to run more tests in JSDOM, when possible.