### PR TITLE
[DataGrid] Fix force reflow on scroll start and end

### DIFF
--- a/packages/grid/_modules_/grid/hooks/utils/useGridScrollFn.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useGridScrollFn.ts
@@ -1,4 +1,3 @@
-import { debounce } from '@material-ui/core/utils';
 import * as React from 'react';
 import { GridScrollFn, GridScrollParams } from '../../models/params/gridScrollParams';
 import { useLogger } from './useLogger';
@@ -10,16 +9,6 @@ export function useGridScrollFn(
   const logger = useLogger('useGridScrollFn');
   const previousValue = React.useRef<GridScrollParams>();
 
-  const debouncedResetPointerEvents = React.useMemo(
-    () =>
-      debounce(() => {
-        if (renderingZoneElementRef.current != null) {
-          renderingZoneElementRef.current!.style.pointerEvents = 'unset';
-        }
-      }, 300),
-    [renderingZoneElementRef],
-  );
-
   const scrollTo: (v: GridScrollParams) => void = React.useCallback(
     (v) => {
       if (v.left === previousValue.current?.left && v.top === previousValue.current.top) {
@@ -28,24 +17,14 @@ export function useGridScrollFn(
 
       if (renderingZoneElementRef && renderingZoneElementRef.current) {
         logger.debug(`Moving ${renderingZoneElementRef.current.className} to: ${v.left}-${v.top}`);
-        if (renderingZoneElementRef.current!.style.pointerEvents !== 'none') {
-          renderingZoneElementRef.current!.style.pointerEvents = 'none';
-        }
         // Force the creation of a layer, avoid paint when changing the transform value.
         renderingZoneElementRef.current!.style.transform = `translate3d(-${v.left}px, -${v.top}px, 0)`;
         columnHeadersElementRef.current!.style.transform = `translate3d(-${v.left}px, 0, 0)`;
-        debouncedResetPointerEvents();
         previousValue.current = v;
       }
     },
-    [renderingZoneElementRef, logger, columnHeadersElementRef, debouncedResetPointerEvents],
+    [renderingZoneElementRef, logger, columnHeadersElementRef],
   );
-
-  React.useEffect(() => {
-    return () => {
-      debouncedResetPointerEvents.clear();
-    };
-  }, [renderingZoneElementRef, debouncedResetPointerEvents]);
 
   return [scrollTo];
 }


### PR DESCRIPTION
Following conversation from https://github.com/mui-org/material-ui-x/issues/1812#issuecomment-853267525

Preview: https://deploy-preview-1829--material-ui-x.netlify.app/components/data-grid/#commercial-version

**Before**

<img width="556" alt="Capture d’écran 2021-06-04 à 13 25 37" src="https://user-images.githubusercontent.com/3165635/120794370-6d729b80-c538-11eb-8032-5b4ac9b45f2c.png">

https://codesandbox.io/s/material-demo-forked-7s1vw

**After**

<img width="555" alt="Capture d’écran 2021-06-04 à 13 25 53" src="https://user-images.githubusercontent.com/3165635/120794377-6fd4f580-c538-11eb-9e76-eda5fd8e5199.png">

https://codesandbox.io/s/material-demo-forked-90ccn