### PR TITLE
[XGrid] Display the number of filtered rows in the footer

### DIFF
--- a/packages/grid/_modules_/grid/components/GridFooter.tsx
+++ b/packages/grid/_modules_/grid/components/GridFooter.tsx
@@ -3,6 +3,7 @@ import { useGridSelector } from '../hooks/features/core/useGridSelector';
 import { gridPaginationSelector } from '../hooks/features/pagination/gridPaginationSelector';
 import { gridRowCountSelector } from '../hooks/features/rows/gridRowsSelector';
 import { selectedGridRowsCountSelector } from '../hooks/features/selection/gridSelectionSelector';
+import { visibleGridRowCountSelector } from '../hooks/features/filter/gridFilterSelector';
 import { optionsSelector } from '../hooks/utils/optionsSelector';
 import { GridApiContext } from './GridApiContext';
 import { GridRowCount } from './GridRowCount';
@@ -16,6 +17,7 @@ export const GridFooter = React.forwardRef<HTMLDivElement, GridFooterContainerPr
     const options = useGridSelector(apiRef, optionsSelector);
     const selectedRowCount = useGridSelector(apiRef, selectedGridRowsCountSelector);
     const pagination = useGridSelector(apiRef, gridPaginationSelector);
+    const visibleRowCount = useGridSelector(apiRef, visibleGridRowCountSelector);
 
     const SelectedRowCountElement =
       !options.hideFooterSelectedRowCount && selectedRowCount > 0 ? (
@@ -26,7 +28,7 @@ export const GridFooter = React.forwardRef<HTMLDivElement, GridFooterContainerPr
 
     const RowCountElement =
       !options.hideFooterRowCount && !options.pagination ? (
-        <GridRowCount rowCount={totalRowCount} />
+        <GridRowCount rowCount={totalRowCount} visibleRowCount={visibleRowCount} />
       ) : null;
 
     const PaginationComponent =

--- a/packages/grid/_modules_/grid/components/GridRowCount.tsx
+++ b/packages/grid/_modules_/grid/components/GridRowCount.tsx
@@ -25,7 +25,7 @@ export const GridRowCount = React.forwardRef<HTMLDivElement, GridRowCountProps>(
 
     return (
       <div ref={ref} className={clsx('MuiDataGrid-rowCount', className)} {...other}>
-        {`${apiRef!.current.getLocaleText('footerTotalRows')} ${text}`}
+        {apiRef!.current.getLocaleText('footerTotalRows')} {text}
       </div>
     );
   },

--- a/packages/grid/_modules_/grid/components/GridRowCount.tsx
+++ b/packages/grid/_modules_/grid/components/GridRowCount.tsx
@@ -4,22 +4,28 @@ import { GridApiContext } from './GridApiContext';
 
 interface RowCountProps {
   rowCount: number;
+  visibleRowCount: number;
 }
 
 type GridRowCountProps = React.HTMLAttributes<HTMLDivElement> & RowCountProps;
 
 export const GridRowCount = React.forwardRef<HTMLDivElement, GridRowCountProps>(
   function GridRowCount(props, ref) {
-    const { className, rowCount, ...other } = props;
+    const { className, rowCount, visibleRowCount, ...other } = props;
     const apiRef = React.useContext(GridApiContext);
 
     if (rowCount === 0) {
       return null;
     }
 
+    const text =
+      visibleRowCount < rowCount
+        ? apiRef!.current.getLocaleText('footerTotalVisibleRows')(visibleRowCount, rowCount)
+        : rowCount.toLocaleString();
+
     return (
       <div ref={ref} className={clsx('MuiDataGrid-rowCount', className)} {...other}>
-        {`${apiRef!.current.getLocaleText('footerTotalRows')} ${rowCount.toLocaleString()}`}
+        {`${apiRef!.current.getLocaleText('footerTotalRows')} ${text}`}
       </div>
     );
   },

--- a/packages/grid/_modules_/grid/constants/localeTextConstants.ts
+++ b/packages/grid/_modules_/grid/constants/localeTextConstants.ts
@@ -88,6 +88,10 @@ export const GRID_DEFAULT_LOCALE_TEXT: GridLocaleText = {
   // Total rows footer text
   footerTotalRows: 'Total Rows:',
 
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Checkbox selection',
 

--- a/packages/grid/_modules_/grid/locales/bgBG.ts
+++ b/packages/grid/_modules_/grid/locales/bgBG.ts
@@ -77,6 +77,10 @@ const bgBGGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Общо Rедове:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const bgBG: Localization = getGridLocalization(bgBGGrid, bgBGCore);

--- a/packages/grid/_modules_/grid/locales/csCZ.ts
+++ b/packages/grid/_modules_/grid/locales/csCZ.ts
@@ -109,6 +109,10 @@ const csCZKGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Celkem řádků:',
 
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Výběr řádku',
 

--- a/packages/grid/_modules_/grid/locales/deDE.ts
+++ b/packages/grid/_modules_/grid/locales/deDE.ts
@@ -79,6 +79,10 @@ const deDEGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Gesamt:',
+
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} von ${totalCount.toLocaleString()}`,
 };
 
 export const deDE: Localization = getGridLocalization(deDEGrid, deDECore);

--- a/packages/grid/_modules_/grid/locales/elGR.ts
+++ b/packages/grid/_modules_/grid/locales/elGR.ts
@@ -83,6 +83,10 @@ const elGRGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Σύνολο Γραμμών:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const elGR: Localization = getGridLocalization(elGRGrid);

--- a/packages/grid/_modules_/grid/locales/esES.ts
+++ b/packages/grid/_modules_/grid/locales/esES.ts
@@ -84,6 +84,10 @@ const esESGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Filas Totales:',
+
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} de ${totalCount.toLocaleString()}`,
 };
 
 export const esES: Localization = getGridLocalization(esESGrid, esESCore);

--- a/packages/grid/_modules_/grid/locales/frFR.ts
+++ b/packages/grid/_modules_/grid/locales/frFR.ts
@@ -80,6 +80,10 @@ const frFRGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Lignes totales :',
 
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} sur ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Sélection',
 };

--- a/packages/grid/_modules_/grid/locales/itIT.ts
+++ b/packages/grid/_modules_/grid/locales/itIT.ts
@@ -80,6 +80,10 @@ const itITGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Record totali :',
 
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} di ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Seleziona',
 };

--- a/packages/grid/_modules_/grid/locales/jaJP.ts
+++ b/packages/grid/_modules_/grid/locales/jaJP.ts
@@ -79,6 +79,10 @@ const jaJPGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: '総行数:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const jaJP: Localization = getGridLocalization(jaJPGrid, jaJPCore);

--- a/packages/grid/_modules_/grid/locales/nlNL.ts
+++ b/packages/grid/_modules_/grid/locales/nlNL.ts
@@ -79,6 +79,10 @@ const nlNLGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Totaal:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const nlNL: Localization = getGridLocalization(nlNLGrid, nlNLCore);

--- a/packages/grid/_modules_/grid/locales/plPL.ts
+++ b/packages/grid/_modules_/grid/locales/plPL.ts
@@ -79,6 +79,10 @@ export const plPLGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Łączna liczba wierszy:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const plPL: Localization = getGridLocalization(plPLGrid, plPLCore);

--- a/packages/grid/_modules_/grid/locales/ptBR.ts
+++ b/packages/grid/_modules_/grid/locales/ptBR.ts
@@ -80,6 +80,10 @@ const ptBRGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Total de linhas:',
 
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount, totalCount) =>
+    `${visibleCount.toLocaleString()} de ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Seleção',
 

--- a/packages/grid/_modules_/grid/locales/ruRU.ts
+++ b/packages/grid/_modules_/grid/locales/ruRU.ts
@@ -117,6 +117,10 @@ export const ruRUGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Всего строк:',
 
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Выбор флажка',
 

--- a/packages/grid/_modules_/grid/locales/skSK.ts
+++ b/packages/grid/_modules_/grid/locales/skSK.ts
@@ -109,6 +109,10 @@ export const skSKGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Riadkov spolu:',
 
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Výber riadku',
 

--- a/packages/grid/_modules_/grid/locales/trTR.ts
+++ b/packages/grid/_modules_/grid/locales/trTR.ts
@@ -83,6 +83,10 @@ const trTRGrid: Partial<GridLocaleText> = {
 
   // Total rows footer text
   footerTotalRows: 'Toplam Satır:',
+
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
 };
 
 export const trTR: Localization = getGridLocalization(trTRGrid, trTRCore);

--- a/packages/grid/_modules_/grid/locales/ukUA.ts
+++ b/packages/grid/_modules_/grid/locales/ukUA.ts
@@ -90,6 +90,10 @@ export const ukUAGrid: Partial<GridLocaleText> = {
   // Total rows footer text
   footerTotalRows: 'Всього рядків:',
 
+  // Total visible rows footer text
+  // footerTotalVisibleRows: (visibleCount, totalCount) =>
+  //   `${visibleCount.toLocaleString()} of ${totalCount.toLocaleString()}`,
+
   // Checkbox selection text
   checkboxSelectionHeaderName: 'Вибір прапорця',
 

--- a/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
@@ -84,6 +84,9 @@ export interface GridLocaleText {
   // Total rows footer text
   footerTotalRows: React.ReactNode;
 
+  // Total visible rows footer text
+  footerTotalVisibleRows: (visibleCount: number, totalCount: number) => React.ReactNode;
+
   // Checkbox selection text
   checkboxSelectionHeaderName: string;
 

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -417,4 +417,11 @@ describe('<XGrid /> - Filter', () => {
       expect(filterForms).to.have.length(2);
     });
   });
+
+  it('should display the number of results in the footer', () => {
+    const { setProps } = render(<TestCase />);
+    expect(screen.getByText('Total Rows: 3')).not.to.equal(null);
+    setProps({ filterModel: model });
+    expect(screen.getByText('Total Rows: 2 of 3')).not.to.equal(null);
+  });
 });


### PR DESCRIPTION
Fixes #1802

Preview: https://deploy-preview-1830--material-ui-x.netlify.app/components/data-grid/filtering/#multi-column-filtering

I'm only displaying the number of filtered rows when the pagination is disabled. 

DataTables also displays it in the pagination: 

<img width="400" src="https://user-images.githubusercontent.com/42154031/120874373-ba786100-c57c-11eb-8ad0-dd5ff8403873.png" alt="image" style="max-width:100%;">