### PR TITLE
[DataGrid] Fix React concurrent updates

### DIFF
--- a/packages/grid/_modules_/grid/hooks/root/useGridContainerProps.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useGridContainerProps.ts
@@ -11,6 +11,7 @@ import { isDeepEqual } from '../../utils/utils';
 import { gridColumnsTotalWidthSelector } from '../features/columns/gridColumnsSelector';
 import { GridState } from '../features/core/gridState';
 import { useGridSelector } from '../features/core/useGridSelector';
+import { useEventCallback } from '../../utils/material-ui-utils';
 import { useGridState } from '../features/core/useGridState';
 import { gridDensityRowHeightSelector } from '../features/density/densitySelector';
 import { visibleGridRowCountSelector } from '../features/filter/gridFilterSelector';
@@ -230,7 +231,7 @@ export const useGridContainerProps = (apiRef: GridApiRef) => {
     [forceUpdate, setGridState],
   );
 
-  const refreshContainerSizes = React.useCallback(() => {
+  const refreshContainerSizes = useEventCallback(() => {
     logger.debug('Refreshing container sizes');
     const rowsCount = getVirtualRowCount();
     const scrollBar = getScrollBar(rowsCount);
@@ -255,14 +256,7 @@ export const useGridContainerProps = (apiRef: GridApiRef) => {
       (state) => !isDeepEqual(state.containerSizes, containerState),
       (state) => ({ ...state, containerSizes: containerState }),
     );
-  }, [
-    getContainerProps,
-    getScrollBar,
-    getViewport,
-    getVirtualRowCount,
-    logger,
-    updateStateIfChanged,
-  ]);
+  });
 
   React.useEffect(() => {
     refreshContainerSizes();

--- a/packages/storybook/src/stories/grid-rows.stories.tsx
+++ b/packages/storybook/src/stories/grid-rows.stories.tsx
@@ -916,6 +916,17 @@ export function SwitchVirtualization() {
   );
 }
 
+export function DeferRendering() {
+  const [deferRows, setRows] = React.useState<any>([]);
+  const [deferColumns] = React.useState([{ field: 'id', headerName: 'Id', width: 100 }]);
+
+  React.useEffect(() => {
+    setTimeout(() => setRows(() => [{ id: '1' }, { id: '2' }]), 0);
+  }, []);
+
+  return <XGrid autoHeight columns={deferColumns} rows={deferRows} />;
+}
+
 export const ZeroHeightGrid = () => (
   <div style={{ width: 300, height: 0 }}>
     <XGrid {...baselineProps} />

--- a/test/e2e/fixtures/DataGrid/ConcurrentReactUpdate.tsx
+++ b/test/e2e/fixtures/DataGrid/ConcurrentReactUpdate.tsx
@@ -7,8 +7,7 @@ export default function ConcurrentReactUpdate() {
   const [rows, setRows] = React.useState<GridRowModel[]>([]);
 
   React.useEffect(() => {
-    setTimeout(() => setRows([]), 0);
-    setTimeout(() => setRows([{ id: 1 }, { id: 2 }]), 1);
+    setTimeout(() => setRows([{ id: 1 }, { id: 2 }]), 0);
   }, []);
 
   return <DataGrid autoHeight columns={columns} rows={rows} />;

--- a/test/e2e/fixtures/DataGrid/ConcurrentReactUpdate.tsx
+++ b/test/e2e/fixtures/DataGrid/ConcurrentReactUpdate.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import { DataGrid, GridRowModel } from '@material-ui/data-grid';
+
+const columns = [{ field: 'id', headerName: 'Id', width: 100 }];
+
+export default function ConcurrentReactUpdate() {
+  const [rows, setRows] = React.useState<GridRowModel[]>([]);
+
+  React.useEffect(() => {
+    setTimeout(() => setRows([]), 0);
+    setTimeout(() => setRows([{ id: 1 }, { id: 2 }]), 1);
+  }, []);
+
+  return <DataGrid autoHeight columns={columns} rows={rows} />;
+}

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -105,5 +105,14 @@ describe('e2e', () => {
         await page.evaluate(() => document.activeElement?.getAttribute('data-testid')),
       ).to.equal('initial-focus');
     });
+
+    it('should display the rows', async () => {
+      await renderFixture('DataGrid/ConcurrentReactUpdate');
+      expect(
+        await page.evaluate(() =>
+          Array.from(document.querySelectorAll('[role="cell"]')).map((node) => node.textContent),
+        ),
+      ).to.deep.equal(['1', '2']);
+    });
   });
 });


### PR DESCRIPTION
fix #1784

Preview: https://deploy-preview-1831--material-ui-x.netlify.app/storybook/?path=/story/x-grid-tests-rows--defer-rendering

This method is triggered **twice** in the reproduction given in the GitHub Issue:

https://github.com/mui-org/material-ui-x/blob/4a57468f36acb3be4910693df733c0c1f5a20f85/packages/grid/_modules_/grid/hooks/root/useGridContainerProps.ts#L235

Inside this method, we schedule 3 updates, but unfortunately, React doesn't guarantee that the 3 updates (`updateStateIfChanged`) are done in the same order. What happens is that the last update that runs is not using the latest values of the state, leading to the bug. In order to solve it, we can use `useEventCallback` that is precisely meant for this problem: https://github.com/facebook/react/issues/14099#issuecomment-440013892. An alternative solution would be to read from the state directly in `updateStateIfChanged` instead of from the parent scope but it seems a lot of work to refactor.

The solution in #1807 focuses on avoiding the concurrent call to `refreshContainerSizes` to happen in the first place, wish sounds like being more efficient and that can be pursued as an independent effort to improve performance or even simplify the logic.

I have opened a new PR to emphasize what I think that we should expect from PR fixing bugs. A [failing](https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5118/workflows/3dbe811f-8e9b-4958-8f55-79e5fbc8cdcd/jobs/25623) test case (cb7d37b) that is fast to iterate on, a description of the origin of the issue. And a fix, the closer to the root cause, the better. I'm spending time on this because I think this rigor is important in order to take over the incumbent solution, in a mature market.

Preview: 