### PR TITLE
[DataGrid] Use binary search to find column indexes in virtualization

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -26,7 +26,7 @@ type UseVirtualColumnsReturnType = [
   UpdateRenderedColsFnType,
 ];
 
-// Uses binary search to avoid looping through all positions
+// Uses binary search to avoid looping through all possible positions
 function getIdxFromScroll(
   offset: number,
   positions: number[],
@@ -35,17 +35,15 @@ function getIdxFromScroll(
 ): number {
   if (positions.length <= 0) {
     return -1;
-  }
-
-  if (sliceStart >= sliceEnd) {
+  } else if (sliceStart >= sliceEnd) {
     return sliceStart;
+  } else {
+    const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
+    const itemOffset = positions[pivot];
+    return offset <= itemOffset
+      ? getIdxFromScroll(offset, positions, sliceStart, pivot)
+      : getIdxFromScroll(offset, positions, pivot + 1, sliceEnd);
   }
-
-  const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
-  const itemOffset = positions[pivot];
-  return offset <= itemOffset
-    ? getIdxFromScroll(offset, positions, sliceStart, pivot)
-    : getIdxFromScroll(offset, positions, pivot + 1, sliceEnd);
 }
 
 export const useGridVirtualColumns = (

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -43,7 +43,7 @@ export const useGridVirtualColumns = (
   const getColumnIdxFromScroll = React.useMemo(() => {
     // Since we have an ordered list of positions, we can use a binary search
     // to find the intersecting column
-    const _getColumnIdxFromScroll = (
+    const binSearchColumnIdcFromScroll = (
       offset: number,
       sliceStart = 0,
       sliceEnd = columnsMeta.positions.length,
@@ -59,10 +59,10 @@ export const useGridVirtualColumns = (
       const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
       const itemOffset = columnsMeta.positions[pivot];
       return offset <= itemOffset
-        ? _getColumnIdxFromScroll(offset, sliceStart, pivot)
-        : _getColumnIdxFromScroll(offset, pivot + 1, sliceEnd);
+        ? binSearchColumnIdcFromScroll(offset, sliceStart, pivot)
+        : binSearchColumnIdcFromScroll(offset, pivot + 1, sliceEnd);
     };
-    return _getColumnIdxFromScroll;
+    return binSearchColumnIdcFromScroll;
   }, [columnsMeta.positions, visibleColumnCount]);
 
   const getColumnFromScroll = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -35,15 +35,17 @@ function getIdxFromScroll(
 ): number {
   if (positions.length <= 0) {
     return -1;
-  } else if (sliceStart >= sliceEnd) {
-    return sliceStart;
-  } else {
-    const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
-    const itemOffset = positions[pivot];
-    return offset <= itemOffset
-      ? getIdxFromScroll(offset, positions, sliceStart, pivot)
-      : getIdxFromScroll(offset, positions, pivot + 1, sliceEnd);
   }
+
+  if (sliceStart >= sliceEnd) {
+    return sliceStart;
+  }
+
+  const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
+  const itemOffset = positions[pivot];
+  return offset <= itemOffset
+    ? getIdxFromScroll(offset, positions, sliceStart, pivot)
+    : getIdxFromScroll(offset, positions, pivot + 1, sliceEnd);
 }
 
 export const useGridVirtualColumns = (

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -43,7 +43,7 @@ export const useGridVirtualColumns = (
   const getColumnIdxFromScroll = React.useMemo(() => {
     // Since we have an ordered list of positions, we can use a binary search
     // to find the intersecting column
-    const binSearchColumnIdcFromScroll = (
+    const binSearchColumnIdxFromScroll = (
       offset: number,
       sliceStart = 0,
       sliceEnd = columnsMeta.positions.length,
@@ -59,10 +59,10 @@ export const useGridVirtualColumns = (
       const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
       const itemOffset = columnsMeta.positions[pivot];
       return offset <= itemOffset
-        ? binSearchColumnIdcFromScroll(offset, sliceStart, pivot)
-        : binSearchColumnIdcFromScroll(offset, pivot + 1, sliceEnd);
+        ? binSearchColumnIdxFromScroll(offset, sliceStart, pivot)
+        : binSearchColumnIdxFromScroll(offset, pivot + 1, sliceEnd);
     };
-    return binSearchColumnIdcFromScroll;
+    return binSearchColumnIdxFromScroll;
   }, [columnsMeta.positions, visibleColumnCount]);
 
   const getColumnFromScroll = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -13,7 +13,6 @@ import { useGridApiMethod } from '../../root/useGridApiMethod';
 import { useGridApiEventHandler } from '../../root/useGridApiEventHandler';
 import {
   gridColumnsMetaSelector,
-  visibleGridColumnsLengthSelector,
   visibleGridColumnsSelector,
 } from '../columns/gridColumnsSelector';
 import { useGridSelector } from '../core/useGridSelector';
@@ -27,6 +26,28 @@ type UseVirtualColumnsReturnType = [
   UpdateRenderedColsFnType,
 ];
 
+// Uses binary search to avoid looping through all positions
+function getIdxFromScroll(
+  offset: number,
+  positions: number[],
+  sliceStart = 0,
+  sliceEnd = positions.length,
+): number {
+  if (positions.length <= 0) {
+    return -1;
+  }
+
+  if (sliceStart >= sliceEnd) {
+    return sliceStart;
+  }
+
+  const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
+  const itemOffset = positions[pivot];
+  return offset <= itemOffset
+    ? getIdxFromScroll(offset, positions, sliceStart, pivot)
+    : getIdxFromScroll(offset, positions, pivot + 1, sliceEnd);
+}
+
 export const useGridVirtualColumns = (
   options: GridOptions,
   apiRef: GridApiRef,
@@ -37,33 +58,12 @@ export const useGridVirtualColumns = (
   const containerPropsRef = React.useRef<GridContainerProps | null>(null);
   const lastScrollLeftRef = React.useRef<number>(0);
   const columnsMeta = useGridSelector(apiRef, gridColumnsMetaSelector);
-  const visibleColumnCount = useGridSelector(apiRef, visibleGridColumnsLengthSelector);
   const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
 
-  const getColumnIdxFromScroll = React.useMemo(() => {
-    // Since we have an ordered list of positions, we can use a binary search
-    // to find the intersecting column
-    const binSearchColumnIdxFromScroll = (
-      offset: number,
-      sliceStart = 0,
-      sliceEnd = columnsMeta.positions.length,
-    ): number => {
-      if (!visibleColumnCount) {
-        return -1;
-      }
-
-      if (sliceStart >= sliceEnd) {
-        return sliceStart;
-      }
-
-      const pivot = sliceStart + Math.floor((sliceEnd - sliceStart) / 2);
-      const itemOffset = columnsMeta.positions[pivot];
-      return offset <= itemOffset
-        ? binSearchColumnIdxFromScroll(offset, sliceStart, pivot)
-        : binSearchColumnIdxFromScroll(offset, pivot + 1, sliceEnd);
-    };
-    return binSearchColumnIdxFromScroll;
-  }, [columnsMeta.positions, visibleColumnCount]);
+  const getColumnIdxFromScroll = React.useCallback(
+    (left: number) => getIdxFromScroll(left, columnsMeta.positions),
+    [columnsMeta.positions],
+  );
 
   const getColumnFromScroll = React.useCallback(
     (left: number) => {


### PR DESCRIPTION
Noticed when playing around with the [virtualization demo](https://material-ui.com/components/data-grid/virtualization/#column-virtualization) in codesandbox that when I tried 100,000 columns, it would hit codesandbox infinite loop detection. Having worked on my own [toy implementation](https://mui-plus.vercel.app/components/DataGrid/virtualization) of a virtualized Material UI datagrid, I realized it was looping through all possible columns to find viewport intersection. Since it has to search an ordered array, a binary search is possible here and drastically reduces iterations on high column counts. I reviewed the Material UI Datagrid implementation and found that [my implementation](https://github.com/Janpot/mui-plus/blob/03b78402418b9772ccb3bfea52a1e986fc2be520/packages/mui-plus/src/utils/virtualization.ts#L11) was easy to port. Quick measurement of performance showed about a 200x performance improvement of the `getColumnFromScroll` function execution time on 100,000 columns (~10ms => ~0.05ms). 
I realize ofcourse that wanting to render 100k columns is very much an edge-case, so feel free to discard this PR if the added complexity isn't worth it. On 1000 columns, like in the current example, the performance improvement is much less dramatic.

