### PR TITLE
[DataGrid] Fix support for getRowId on cell editing

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
@@ -175,7 +175,8 @@ export function useGridEditRows(apiRef: GridApiRef) {
       logger.debug(
         `Setting cell id: ${params.id} field: ${params.field} to value: ${parsedValue?.toString()}`,
       );
-      const rowUpdate = { id: params.id };
+      const row = apiRef.current.getRow(params.id);
+      const rowUpdate = { ...row };
       rowUpdate[params.field] = parsedValue;
       apiRef.current.updateRows([rowUpdate]);
       apiRef.current.publishEvent(GRID_CELL_VALUE_CHANGE, params);

--- a/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/editRows.XGrid.test.tsx
@@ -13,6 +13,8 @@ import {
   createClientRenderStrictMode,
   // @ts-expect-error need to migrate helpers to TypeScript
   fireEvent,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  screen,
 } from 'test/utils';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -293,5 +295,28 @@ describe('<XGrid /> - Edit Rows', () => {
         year: 1961,
       },
     });
+  });
+
+  it('should support getRowId', () => {
+    render(
+      <TestCase
+        getRowId={(row) => row.code}
+        rows={baselineProps.rows.map((row) => ({ code: row.id, brand: row.brand }))}
+      />,
+    );
+    expect(screen.queryAllByRole('row')).to.have.length(4);
+    const cell = getCell(1, 0);
+    cell.focus();
+    fireEvent.doubleClick(cell);
+    const input = cell.querySelector('input')!;
+    expect(input.value).to.equal('Adidas');
+    fireEvent.change(input, { target: { value: 'n' } });
+    expect(cell.querySelector('input')!.value).to.equal('n');
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(cell).to.have.class('MuiDataGrid-cellEditable');
+    expect(cell).not.to.have.class('MuiDataGrid-cellEditing');
+    expect(cell).to.have.text('n');
+    expect(screen.queryAllByRole('row')).to.have.length(4);
   });
 });


### PR DESCRIPTION
Fixes #1914 

Preview: https://codesandbox.io/s/intelligent-silence-psosd?file=/package.json

When creating the update object to be passed to `updateRows` it was being created only with the id, but `getRowId` requires the entire row to work.