### PR TITLE
[DataGrid] Fix double-click issue

### DIFF
--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -24,7 +24,8 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
     const totalRows = useGridSelector(apiRef, gridRowCountSelector);
 
     const isIndeterminate = totalSelectedRows > 0 && totalSelectedRows !== totalRows;
-    const isChecked = totalSelectedRows === totalRows || isIndeterminate;
+    // TODO core v5 remove || isIndeterminate, no longer has any effect
+    const isChecked = (totalSelectedRows > 0 && totalSelectedRows === totalRows) || isIndeterminate;
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const checked = event.target.checked;

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -23,24 +23,12 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
     const totalSelectedRows = useGridSelector(apiRef, selectedGridRowsCountSelector);
     const totalRows = useGridSelector(apiRef, gridRowCountSelector);
 
-    const [isIndeterminate, setIsIndeterminate] = React.useState(
-      totalSelectedRows > 0 && totalSelectedRows !== totalRows,
-    );
-    const [isChecked, setChecked] = React.useState(
-      totalSelectedRows === totalRows || isIndeterminate,
-    );
-
-    React.useEffect(() => {
-      const isNewIndeterminate = totalSelectedRows > 0 && totalSelectedRows !== totalRows;
-      const isNewChecked = (totalRows > 0 && totalSelectedRows === totalRows) || isIndeterminate;
-      setChecked(isNewChecked);
-      setIsIndeterminate(isNewIndeterminate);
-    }, [isIndeterminate, totalRows, totalSelectedRows]);
+    const isIndeterminate = totalSelectedRows > 0 && totalSelectedRows !== totalRows;
+    const isChecked = totalSelectedRows === totalRows || isIndeterminate;
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const checked = event.target.checked;
-      setChecked(checked);
-      apiRef!.current.selectRows(visibleRowIds, checked);
+      apiRef!.current.selectRows(visibleRowIds, checked, !event.target.indeterminate);
     };
 
     const tabIndex = tabIndexState !== null && tabIndexState.field === props.field ? 0 : -1;

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -13,6 +13,10 @@ import { GridApiRef, GridComponentProps, useGridApiRef, XGrid } from '@material-
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
+function getSelectedRows(apiRef) {
+  return Array.from(apiRef.current.getSelectedRows().keys());
+}
+
 describe('<XGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
@@ -122,7 +126,7 @@ describe('<XGrid /> - Selection', () => {
 
   it('should clean the selected ids when the rows prop changes', () => {
     const { setProps } = render(<Test selectionModel={[0, 1, 2]} checkboxSelection />);
-    expect(apiRef.current.getSelectedRows()).to.have.keys([0, 1, 2]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([0, 1, 2]);
     setProps({
       rows: [
         {
@@ -131,7 +135,7 @@ describe('<XGrid /> - Selection', () => {
         },
       ],
     });
-    expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([0]);
   });
 
   it('should select only filtered rows after filter is applied', () => {
@@ -151,12 +155,12 @@ describe('<XGrid /> - Selection', () => {
     expect(getColumnValues(1)).to.deep.equal(['Puma']);
     fireEvent.click(selectAll);
     // TODO fix, should be only 2
-    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([0, 1, 2]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([0, 1, 2]);
     fireEvent.click(selectAll);
-    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([]);
     fireEvent.click(selectAll);
-    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([2]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([2]);
     fireEvent.click(selectAll);
-    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([]);
+    expect(getSelectedRows(apiRef)).to.deep.equal([]);
   });
 });

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -1,7 +1,14 @@
 import * as React from 'react';
-import { createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
+import { getColumnValues } from 'test/utils/helperFn';
+import {
+  // @ts-expect-error need to migrate helpers to TypeScript
+  screen,
+  createClientRenderStrictMode,
+  // @ts-expect-error need to migrate helpers to TypeScript
+  fireEvent,
+} from 'test/utils';
 import { GridApiRef, GridComponentProps, useGridApiRef, XGrid } from '@material-ui/x-grid';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -125,5 +132,31 @@ describe('<XGrid /> - Selection', () => {
       ],
     });
     expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
+  });
+
+  it('should select only filtered rows after filter is applied', () => {
+    render(<Test checkboxSelection />);
+    const selectAll = screen.getByRole('checkbox', {
+      name: /select all rows checkbox/i,
+    });
+    apiRef.current.setFilterModel({
+      items: [
+        {
+          columnField: 'brand',
+          operatorValue: 'contains',
+          value: 'Puma',
+        },
+      ],
+    });
+    expect(getColumnValues(1)).to.deep.equal(['Puma']);
+    fireEvent.click(selectAll);
+    // TODO fix, should be only 2
+    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([0, 1, 2]);
+    fireEvent.click(selectAll);
+    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([]);
+    fireEvent.click(selectAll);
+    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([2]);
+    fireEvent.click(selectAll);
+    expect(Array.from(apiRef.current.getSelectedRows().keys())).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
Fix the double click issue: https://github.com/mui-org/material-ui-x/issues/1141#issuecomment-798547109. In the recording, you can see that I click twice, and the state stays the same. *checked indeterminate* is the **same state** as *unchecked indeterminate*. In core v5 we removed the visual distinction to match screen readers.

Note that the fix is mostly removing code we don't need* (*assuming it's better to not react to clicks on the checkbox when there are no rows).

I worked on this because #1879 didn't seem to go in a rigorous direction. I'm mostly interested in the test case and isolation. I'm a believer that the quality of the tests ultimately drives the quality of the code.