### PR TITLE
[DataGrid] Improve updateRows performance

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -187,9 +187,8 @@ export const useGridRows = (
       });
       if (updatedLookup) {
         internalRowsState.current.idRowsLookup = updatedLookup;
+        setGridState((state) => ({ ...state, rows: { ...internalRowsState.current } }));
       }
-
-      setGridState((state) => ({ ...state, rows: { ...internalRowsState.current } }));
 
       if (deletedRowIds.length > 0 || addedRows.length > 0) {
         deletedRowIds.forEach((id) => {

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -162,6 +162,7 @@ export const useGridRows = (
       const addedRows: GridRowModel[] = [];
       const deletedRowIds: GridRowId[] = [];
 
+      let updatedLookup: null | {} = null;
       Object.entries<GridRowModel>(uniqUpdates).forEach(([id, partialRow]) => {
         // eslint-disable-next-line no-underscore-dangle
         if (partialRow._action === 'delete') {
@@ -174,14 +175,19 @@ export const useGridRows = (
           addedRows.push(partialRow);
           return;
         }
-        const lookup = { ...internalRowsState.current.idRowsLookup };
 
-        lookup[id] = {
+        if (!updatedLookup) {
+          updatedLookup = { ...internalRowsState.current.idRowsLookup };
+        }
+
+        updatedLookup[id] = {
           ...oldRow,
           ...partialRow,
         };
-        internalRowsState.current.idRowsLookup = lookup;
       });
+      if (updatedLookup) {
+        internalRowsState.current.idRowsLookup = updatedLookup;
+      }
 
       setGridState((state) => ({ ...state, rows: { ...internalRowsState.current } }));
 


### PR DESCRIPTION
Given `n` total rows and `m` row updates, reduces asymptotic complexity of `updateRows` from `O(n*m)` to `O(n+m)`.

We do this by performing all updates together, instead of each one individually.