### PR TITLE
[DataGrid] Make GRID_ROWS_CLEAR private

### DIFF
--- a/docs/src/pages/components/data-grid/events/events.json
+++ b/docs/src/pages/components/data-grid/events/events.json
@@ -162,7 +162,6 @@
     "description": "Fired when the user stops resizing a column. Called with an object <code>{ field: string }</code>."
   },
   { "name": "columnOrderChange", "description": "Fired when the user ends resizing a column." },
-  { "name": "rowsClear", "description": "Fired when the grid is emptied." },
   {
     "name": "columnsChange",
     "description": "Fired when the columns state is changed.\nCalled with an array of strings correspoding to the field names."

--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -412,7 +412,10 @@ export const GRID_ROWS_UPDATE = 'rowsUpdate';
 export const GRID_ROWS_SET = 'rowsSet';
 
 /**
- * Fired when the grid is emptied.
+ * Implementation detail.
+ * Fired to reset the sortedRow when the set of rows changes.
+ * It's important as the rendered rows are coming from the sortedRow
+ * @ignore - do not document.
  * @event
  */
 export const GRID_ROWS_CLEAR = 'rowsClear';

--- a/packages/grid/_modules_/grid/hooks/features/filter/visibleGridRowsState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/visibleGridRowsState.ts
@@ -2,7 +2,6 @@ import { GridRowId } from '../../../models/gridRows';
 
 export interface VisibleGridRowsState {
   visibleRowsLookup: Record<GridRowId, boolean>;
-
   visibleRows?: GridRowId[];
 }
 

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -162,6 +162,7 @@ describe('<XGrid /> - Rows', () => {
 
     it('should allow to reset rows with setRows and render after 100ms', () => {
       render(<TestCase />);
+      expect(getColumnValues()).to.deep.equal(['Nike', 'Adidas', 'Puma']);
       const newRows = [
         {
           id: 3,
@@ -174,6 +175,14 @@ describe('<XGrid /> - Rows', () => {
       expect(getColumnValues()).to.deep.equal(['Nike', 'Adidas', 'Puma']);
       clock.tick(50);
       expect(getColumnValues()).to.deep.equal(['Asics']);
+
+      apiRef.current.setRows(baselineProps.rows);
+      // Force an update before the 100ms
+      apiRef.current.forceUpdate(() => apiRef.current.state);
+      // Tradeoff, the value is YOLO
+      expect(getColumnValues()).to.deep.equal(['Nike']);
+      clock.tick(100);
+      expect(getColumnValues()).to.deep.equal(['Nike', 'Adidas', 'Puma']);
     });
 
     it('should allow to update row data', () => {


### PR DESCRIPTION
### Breaking changes

- [DataGrid] Make GRID_ROWS_CLEAR private (#1925) @oliviertassinari 
 The `GRID_ROWS_CLEAR` event was always triggered alongside `GRID_ROWS_SET`. You can listen to the latter event only.

---

~See the rationale in https://github.com/mui-org/material-ui-x/pull/1862#discussion_r654370166. When GRID_ROWS_CLEARED triggers, `GRID_ROWS_SET` is also triggered, no need to update the sorting state **twice**.~

~Note that this makes `GRID_ROWS_CLEARED` an orphan, nobody is listening to the event.~

~If I'm missing something and is really required, then it surfaces a hole in the test suite, the CI is green.~