### PR TITLE
[DataGrid] Fix scrollToIndexes offscreen row

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -235,7 +235,8 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
         const viewportHeight = gridState.viewportSizes.height;
 
         isRowIndexAbove = windowRef.current!.scrollTop > scrollPosition;
-        isRowIndexBelow = windowRef.current!.scrollTop + viewportHeight < scrollPosition;
+        isRowIndexBelow =
+          windowRef.current!.scrollTop + viewportHeight < scrollPosition + rowHeight;
 
         if (isRowIndexAbove) {
           scrollCoordinates.top = scrollPosition; // We put it at the top of the page

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -225,7 +225,7 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
       let isRowIndexAbove = false;
       let isRowIndexBelow = false;
 
-      if (params.rowIndex || params.rowIndex === 0) {
+      if (params.rowIndex != null) {
         const elementIndex = !options.pagination
           ? params.rowIndex
           : params.rowIndex - paginationState.page * paginationState.pageSize;

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -438,5 +438,25 @@ describe('<XGrid /> - Rows', () => {
         expect(virtualRowsCount).to.equal(7);
       });
     });
+
+    describe('scrollToIndexes', () => {
+      it('should scroll correctly when the given index is partially visible at the bottom', () => {
+        const headerHeight = 40;
+        const rowHeight = 50;
+        const border = 1;
+        render(
+          <TestCaseVirtualization
+            hideFooter
+            headerHeight={headerHeight}
+            height={headerHeight + 4 * rowHeight + 10 + border * 2}
+            nbCols={2}
+            rowHeight={rowHeight}
+          />,
+        );
+        const gridWindow = document.querySelector('.MuiDataGrid-window')!;
+        apiRef.current.scrollToIndexes({ rowIndex: 4, colIndex: 0 });
+        expect(gridWindow.scrollTop).to.equal(rowHeight);
+      });
+    });
   });
 });


### PR DESCRIPTION
One chunk of #1818

I have updated the logic to match [the one we use](https://github.com/mui-org/material-ui/blob/2c4dc994da164a53b253f03bcd2425a52655f175/packages/material-ui/src/useAutocomplete/useAutocomplete.js#L328-L348) in the Autocomplete component. It wasn't computed correctly.

@m4theushw I have extracted it from #1871 because closing #1818 will be a larger effort. I have also simplified the test case to be virtualization implementation **invariant**.

A live demo of the bug fixed in this PR: https://material-ui.com/components/data-grid/#commercial-version

![scroll](https://user-images.githubusercontent.com/3165635/122685346-037e1580-d20b-11eb-865e-dcb78144ece5.gif)