### PR TITLE
[docs] Align docs with EULA (source of truth)

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -112,7 +112,7 @@ See [Pricing](https://material-ui.com/store/items/material-ui-pro/) for details 
 
 ### Try XGrid for free
 
-You are free to try out `XGrid` as long as it's not used for a project intended for production.
+You are free to install and try `XGrid` as long as it is not used for development of a feature intended for production.
 Please take the component for a test run, no need to contact us.
 
 ### Invalid license


### PR DESCRIPTION
Fix the inconsistency reported in #1961

- docs: can use XGrid for development
- license warning: can't use XGrid fo development
- EULA: can't use XGrid for development

This is meant to match the policy of the existing commercial alternative solutions. We don't need to differentiate on this end. If we want to change the policy in the future, then we need to update it all at once.