### PR TITLE
[DataGrid] Fix scrollToIndexes offscreen column

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualColumns.ts
@@ -80,16 +80,22 @@ export const useGridVirtualColumns = (
       if (!containerPropsRef.current) {
         return false;
       }
-      const windowWidth = containerPropsRef.current.windowSizes.width;
-      const firstCol = getColumnFromScroll(lastScrollLeftRef.current);
-      const lastCol = getColumnFromScroll(lastScrollLeftRef.current + windowWidth);
+      const firstCol = getColumnFromScroll(lastScrollLeftRef.current); // First fully visible column
+      const firstColIndex = visibleColumns.findIndex((col) => col.field === firstCol?.field);
 
-      const firstColIndex = visibleColumns.findIndex((col) => col.field === firstCol?.field) + 1;
-      const lastColIndex = visibleColumns.findIndex((col) => col.field === lastCol?.field) - 1; // We ensure the last col is completely visible
+      const { positions } = columnsMeta;
+      const windowWidth = containerPropsRef.current.windowSizes.width;
+      const spaceBeforeFirstCol = positions[firstColIndex] - lastScrollLeftRef.current;
+      const availableWidth = windowWidth - spaceBeforeFirstCol;
+      let lastColIndex = firstColIndex;
+      while (lastColIndex < positions.length - 1 && positions[lastColIndex + 1] < availableWidth) {
+        lastColIndex += 1;
+      }
+      lastColIndex -= 1; // Last fully visible column
 
       return colIndex >= firstColIndex && colIndex <= lastColIndex;
     },
-    [getColumnFromScroll, visibleColumns],
+    [columnsMeta, getColumnFromScroll, visibleColumns],
   );
 
   const updateRenderedCols: UpdateRenderedColsFnType = React.useCallback(

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -487,7 +487,7 @@ describe('<XGrid /> - Rows', () => {
         const gridWindow = document.querySelector('.MuiDataGrid-window')!;
         expect(gridWindow.scrollLeft).to.equal(0);
         apiRef.current.scrollToIndexes({ rowIndex: 0, colIndex: 2 });
-        expect(gridWindow.scrollLeft).to.equal(60);
+        expect(gridWindow.scrollLeft).to.equal(columnWidth * 3 - width);
       });
     });
   });

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -277,13 +277,18 @@ describe('<XGrid /> - Rows', () => {
 
     let apiRef: GridApiRef;
     const TestCaseVirtualization = (
-      props: Partial<XGridProps> & { nbRows?: number; nbCols?: number; height?: number },
+      props: Partial<XGridProps> & {
+        nbRows?: number;
+        nbCols?: number;
+        width?: number;
+        height?: number;
+      },
     ) => {
       apiRef = useGridApiRef();
       const data = useData(props.nbRows || 100, props.nbCols || 10);
 
       return (
-        <div style={{ width: 300, height: props.height || 300 }}>
+        <div style={{ width: props.width || 300, height: props.height || 300 }}>
           <XGrid apiRef={apiRef} columns={data.columns} rows={data.rows} {...props} />
         </div>
       );
@@ -449,7 +454,7 @@ describe('<XGrid /> - Rows', () => {
     });
 
     describe('scrollToIndexes', () => {
-      it('should scroll correctly when the given index is partially visible at the bottom', () => {
+      it('should scroll correctly when the given rowIndex is partially visible at the bottom', () => {
         const headerHeight = 40;
         const rowHeight = 50;
         const border = 1;
@@ -465,6 +470,23 @@ describe('<XGrid /> - Rows', () => {
         const gridWindow = document.querySelector('.MuiDataGrid-window')!;
         apiRef.current.scrollToIndexes({ rowIndex: 4, colIndex: 0 });
         expect(gridWindow.scrollTop).to.equal(rowHeight);
+      });
+
+      it('should scroll correctly when the given colIndex is partially visible at the right', () => {
+        const width = 300;
+        const border = 1;
+        const columnWidth = 120;
+        const rows = [{ id: 0, first: 'Mike', age: 11 }];
+        const columns = [
+          { field: 'id', width: columnWidth },
+          { field: 'first', width: columnWidth },
+          { field: 'age', width: columnWidth },
+        ];
+        render(<TestCaseVirtualization width={width + border * 2} rows={rows} columns={columns} />);
+        const gridWindow = document.querySelector('.MuiDataGrid-window')!;
+        expect(gridWindow.scrollLeft).to.equal(0);
+        apiRef.current.scrollToIndexes({ rowIndex: 0, colIndex: 2 });
+        expect(gridWindow.scrollLeft).to.equal(60);
       });
     });
   });

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -476,10 +476,11 @@ describe('<XGrid /> - Rows', () => {
         const width = 300;
         const border = 1;
         const columnWidth = 120;
-        const rows = [{ id: 0, first: 'Mike', age: 11 }];
+        const rows = [{ id: 0, firstName: 'John', lastName: 'Doe', age: 11 }];
         const columns = [
           { field: 'id', width: columnWidth },
-          { field: 'first', width: columnWidth },
+          { field: 'firstName', width: columnWidth },
+          { field: 'lastName', width: columnWidth },
           { field: 'age', width: columnWidth },
         ];
         render(<TestCaseVirtualization width={width + border * 2} rows={rows} columns={columns} />);


### PR DESCRIPTION
While #1949 fixed the bug in the y-axis, there's a similar problem in the x-axis too. It happens because we consider a column as visible if its left position is inside the viewport, without accounting the width.

In https://material-ui.com/components/data-grid/demo/

<img width="400" src="https://user-images.githubusercontent.com/42154031/123355783-c41e3480-d53c-11eb-970c-aceea773bb78.gif" alt="zRZL7b9OLy" style="max-width:100%;">

Preview: https://deploy-preview-1964--material-ui-x.netlify.app/components/data-grid/demo/