### PR TITLE
[DataGrid] Better fix the scrollToIndexes logic

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -217,33 +217,21 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
         }
       }
 
-      let isRowIndexAbove = false;
-      let isRowIndexBelow = false;
-
       if (params.rowIndex != null) {
         const elementIndex = !options.pagination
           ? params.rowIndex
           : params.rowIndex - paginationState.page * paginationState.pageSize;
 
-        const currentRowPage = elementIndex / gridState.containerSizes!.viewportPageSize;
-        const scrollPosition = currentRowPage * gridState!.viewportSizes.height;
-        const viewportHeight = gridState.viewportSizes.height;
-
-        isRowIndexAbove = windowRef.current!.scrollTop > scrollPosition;
-        isRowIndexBelow =
-          windowRef.current!.scrollTop + viewportHeight < scrollPosition + rowHeight;
-
-        if (isRowIndexAbove) {
-          scrollCoordinates.top = scrollPosition; // We put it at the top of the page
-          logger.debug(`Row is above, setting top to ${scrollCoordinates.top}`);
-        } else if (isRowIndexBelow) {
-          // We make sure the row is not half visible
-          scrollCoordinates.top = scrollPosition - viewportHeight + rowHeight;
-          logger.debug(`Row is below, setting top to ${scrollCoordinates.top}`);
+        const scrollBottom = windowRef.current!.clientHeight + windowRef.current!.scrollTop;
+        const elementBottom = rowHeight * elementIndex + rowHeight;
+        if (elementBottom > scrollBottom) {
+          scrollCoordinates.top = elementBottom - windowRef.current!.clientHeight;
+        } else if (rowHeight * elementIndex < windowRef.current!.scrollTop) {
+          scrollCoordinates.top = rowHeight * elementIndex;
         }
       }
 
-      const needScroll = !isColVisible || isRowIndexAbove || isRowIndexBelow;
+      const needScroll = !isColVisible || scrollCoordinates.top !== windowRef.current!.clientHeight;
       if (needScroll) {
         apiRef.current.scroll(scrollCoordinates);
       }

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -232,7 +232,7 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
         }
       }
 
-      const needScroll = !isColVisible || scrollCoordinates.top !== windowRef.current!.clientHeight;
+      const needScroll = !isColVisible || typeof scrollCoordinates.top !== undefined;
       if (needScroll) {
         apiRef.current.scroll(scrollCoordinates);
       }

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -217,6 +217,7 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
         }
       }
 
+      // Logic copied from https://www.w3.org/TR/wai-aria-practices/examples/listbox/js/listbox.js
       if (params.rowIndex != null) {
         const elementIndex = !options.pagination
           ? params.rowIndex

--- a/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/rows.XGrid.test.tsx
@@ -452,19 +452,44 @@ describe('<XGrid /> - Rows', () => {
       it('should scroll correctly when the given index is partially visible at the bottom', () => {
         const headerHeight = 40;
         const rowHeight = 50;
+        const offset = 10;
         const border = 1;
         render(
           <TestCaseVirtualization
             hideFooter
             headerHeight={headerHeight}
-            height={headerHeight + 4 * rowHeight + 10 + border * 2}
+            height={headerHeight + 4 * rowHeight + offset + border * 2}
             nbCols={2}
             rowHeight={rowHeight}
           />,
         );
         const gridWindow = document.querySelector('.MuiDataGrid-window')!;
         apiRef.current.scrollToIndexes({ rowIndex: 4, colIndex: 0 });
-        expect(gridWindow.scrollTop).to.equal(rowHeight);
+        expect(gridWindow.scrollTop).to.equal(rowHeight - offset);
+      });
+
+      it('should scroll correctly when the given index is partially visible at the top', () => {
+        const headerHeight = 40;
+        const rowHeight = 50;
+        const offset = 10;
+        const border = 1;
+        render(
+          <TestCaseVirtualization
+            hideFooter
+            headerHeight={headerHeight}
+            height={headerHeight + 4 * rowHeight + border + border * 2}
+            nbCols={2}
+            rowHeight={rowHeight}
+          />,
+        );
+        const gridWindow = document.querySelector('.MuiDataGrid-window')!;
+        gridWindow.scrollTop = offset;
+        apiRef.current.scrollToIndexes({ rowIndex: 2, colIndex: 0 });
+        expect(gridWindow.scrollTop).to.equal(offset);
+        apiRef.current.scrollToIndexes({ rowIndex: 1, colIndex: 0 });
+        expect(gridWindow.scrollTop).to.equal(offset);
+        apiRef.current.scrollToIndexes({ rowIndex: 0, colIndex: 0 });
+        expect(gridWindow.scrollTop).to.equal(0);
       });
     });
   });


### PR DESCRIPTION
This is a follow-up https://github.com/mui-org/material-ui-x/pull/1949#issuecomment-866995274, I'm pushing the quality of the solution one step further, by doing a plain copy & paste of the `Autocomplete`'s logic.

The previous behavior: https://codesandbox.io/s/material-demo-forked-j7i1x?file=/package.json.

https://user-images.githubusercontent.com/3165635/123521590-e8525080-d6b7-11eb-94db-3e259e36a549.mp4

The new behavior: https://codesandbox.io/s/material-demo-forked-nzkwd?file=/package.json

https://user-images.githubusercontent.com/3165635/123521674-63b40200-d6b8-11eb-8e7d-8e945eacefd8.mp4

