### PR TITLE
[core] Remove unused event 'cellFocusChange'

### DIFF
--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -109,6 +109,12 @@ export const GRID_CELL_FOCUS = 'cellFocus';
 export const GRID_CELL_FOCUS_OUT = 'cellFocusOut';
 
 /**
+ * Fired when the focus goes from a cell to another.
+ * @event
+ */
+export const GRID_CELL_FOCUS_CHANGE = 'cellFocusChange';
+
+/**
  * Fired when the user starts dragging a cell. It's mapped to the `dragstart` DOM event.
  * Called with a [[GridCellParams]] object.
  * @ignore - do not document.

--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -109,12 +109,6 @@ export const GRID_CELL_FOCUS = 'cellFocus';
 export const GRID_CELL_FOCUS_OUT = 'cellFocusOut';
 
 /**
- * Fired when the focus goes from a cell to another.
- * @event
- */
-export const GRID_CELL_FOCUS_CHANGE = 'cellFocusChange';
-
-/**
  * Fired when the user starts dragging a cell. It's mapped to the `dragstart` DOM event.
  * Called with a [[GridCellParams]] object.
  * @ignore - do not document.

--- a/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
@@ -1,13 +1,14 @@
 import * as React from 'react';
 import { ownerDocument } from '@material-ui/core/utils';
 import {
-    GRID_CELL_CLICK,
-    GRID_CELL_DOUBLE_CLICK,
-    GRID_CELL_MOUSE_UP,
-    GRID_CELL_FOCUS_OUT,
-    GRID_COLUMN_HEADER_BLUR,
-    GRID_COLUMN_HEADER_FOCUS,
-    GRID_CELL_MODE_CHANGE, GRID_CELL_FOCUS_CHANGE,
+  GRID_CELL_CLICK,
+  GRID_CELL_DOUBLE_CLICK,
+  GRID_CELL_MOUSE_UP,
+  GRID_CELL_FOCUS_OUT,
+  GRID_COLUMN_HEADER_BLUR,
+  GRID_COLUMN_HEADER_FOCUS,
+  GRID_CELL_MODE_CHANGE,
+  GRID_CELL_FOCUS_CHANGE,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridFocusApi } from '../../../models/api/gridFocusApi';

--- a/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { ownerDocument } from '@material-ui/core/utils';
 import {
-  GRID_CELL_CLICK,
-  GRID_CELL_DOUBLE_CLICK,
-  GRID_CELL_MOUSE_UP,
-  GRID_CELL_FOCUS_OUT,
-  GRID_COLUMN_HEADER_BLUR,
-  GRID_COLUMN_HEADER_FOCUS,
-  GRID_CELL_MODE_CHANGE,
+    GRID_CELL_CLICK,
+    GRID_CELL_DOUBLE_CLICK,
+    GRID_CELL_MOUSE_UP,
+    GRID_CELL_FOCUS_OUT,
+    GRID_COLUMN_HEADER_BLUR,
+    GRID_COLUMN_HEADER_FOCUS,
+    GRID_CELL_MODE_CHANGE, GRID_CELL_FOCUS_CHANGE,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridFocusApi } from '../../../models/api/gridFocusApi';
@@ -33,8 +33,7 @@ export const useGridFocus = (apiRef: GridApiRef): void => {
           focus: { cell: { id, field }, columnHeader: null },
         };
       });
-      // TODO replace with constant
-      apiRef.current.publishEvent('cellFocusChange');
+      apiRef.current.publishEvent(GRID_CELL_FOCUS_CHANGE);
       forceUpdate();
     },
     [apiRef, forceUpdate, logger, setGridState],
@@ -60,7 +59,7 @@ export const useGridFocus = (apiRef: GridApiRef): void => {
           focus: { columnHeader: { field }, cell: null },
         };
       });
-      apiRef.current.publishEvent('cellFocusChange');
+      apiRef.current.publishEvent(GRID_CELL_FOCUS_CHANGE);
 
       forceUpdate();
     },

--- a/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
@@ -35,7 +35,7 @@ export const useGridFocus = (apiRef: GridApiRef): void => {
       });
       forceUpdate();
     },
-    [apiRef, forceUpdate, logger, setGridState],
+    [forceUpdate, logger, setGridState],
   );
 
   const setColumnHeaderFocus = React.useCallback(

--- a/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
+++ b/packages/grid/_modules_/grid/hooks/features/focus/useGridFocus.ts
@@ -8,7 +8,6 @@ import {
   GRID_COLUMN_HEADER_BLUR,
   GRID_COLUMN_HEADER_FOCUS,
   GRID_CELL_MODE_CHANGE,
-  GRID_CELL_FOCUS_CHANGE,
 } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridFocusApi } from '../../../models/api/gridFocusApi';
@@ -34,7 +33,6 @@ export const useGridFocus = (apiRef: GridApiRef): void => {
           focus: { cell: { id, field }, columnHeader: null },
         };
       });
-      apiRef.current.publishEvent(GRID_CELL_FOCUS_CHANGE);
       forceUpdate();
     },
     [apiRef, forceUpdate, logger, setGridState],
@@ -60,7 +58,6 @@ export const useGridFocus = (apiRef: GridApiRef): void => {
           focus: { columnHeader: { field }, cell: null },
         };
       });
-      apiRef.current.publishEvent(GRID_CELL_FOCUS_CHANGE);
 
       forceUpdate();
     },


### PR DESCRIPTION
What is the use case of this event ? It is never mentioned in an issue and never used internally.
We already have a `GRID_CELL_FOCUS` which gives access to the cell being focused whereas this one just says "the focused cell has changed".