### PR TITLE
[XGrid] Add option to select only visible rows on the current page

### DIFF
--- a/docs/pages/api-docs/data-grid/data-grid.md
+++ b/docs/pages/api-docs/data-grid/data-grid.md
@@ -20,7 +20,6 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
-| <span class="prop-name">checkboxSelectionVisibleOnly</span> | <span class="prop-type">boolean</span> | false | To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page. |
 | <span class="prop-name">classes</span> | <span class="prop-type">GridClasses</span> |   | Override or extend the styles applied to the component. See [CSS API](/api/data-grid/data-grid/#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | CSS classname to add on the outer container. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |

--- a/docs/pages/api-docs/data-grid/data-grid.md
+++ b/docs/pages/api-docs/data-grid/data-grid.md
@@ -20,6 +20,7 @@ import { DataGrid } from '@material-ui/data-grid';
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
+| <span class="prop-name">checkboxSelectionVisibleOnly</span> | <span class="prop-type">boolean</span> | false | To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page. |
 | <span class="prop-name">classes</span> | <span class="prop-type">GridClasses</span> |   | Override or extend the styles applied to the component. See [CSS API](/api/data-grid/data-grid/#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | CSS classname to add on the outer container. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |

--- a/docs/pages/api-docs/data-grid/x-grid.md
+++ b/docs/pages/api-docs/data-grid/x-grid.md
@@ -21,6 +21,7 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
+| <span class="prop-name">checkboxSelectionVisibleOnly</span> | <span class="prop-type">boolean</span> | false | To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page. |
 | <span class="prop-name">classes</span> | <span class="prop-type">GridClasses</span> |   | Override or extend the styles applied to the component. See [CSS API](/api/data-grid/x-grid/#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | CSS classname to add on the outer container. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |

--- a/docs/pages/api-docs/data-grid/x-grid.md
+++ b/docs/pages/api-docs/data-grid/x-grid.md
@@ -21,7 +21,7 @@ import { XGrid } from '@material-ui/x-grid';
 | <span class="prop-name">autoHeight</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid height is dynamic and follow the number of rows in the grid. |
 | <span class="prop-name">autoPageSize</span> | <span class="prop-type">boolean</span> | false | If `true`, the pageSize is calculated according to the container size and the max number of rows to avoid rendering a vertical scroll bar. |
 | <span class="prop-name">checkboxSelection</span> | <span class="prop-type">boolean</span> | false | If `true`, the grid get a first column with a checkbox that allows to select rows. |
-| <span class="prop-name">checkboxSelectionVisibleOnly</span> | <span class="prop-type">boolean</span> | false | To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page. |
+| <span class="prop-name">checkboxSelectionVisibleOnly</span> | <span class="prop-type">boolean</span> | false | If `true`, the "Select All" header checkbox selects only the rows on the current page. To be used in combination with `checkboxSelection`. |
 | <span class="prop-name">classes</span> | <span class="prop-type">GridClasses</span> |   | Override or extend the styles applied to the component. See [CSS API](/api/data-grid/x-grid/#css) below for more details. |
 | <span class="prop-name">className</span> | <span class="prop-type">string</span> |   | CSS classname to add on the outer container. |
 | <span class="prop-name">columnBuffer</span> | <span class="prop-type">number</span> | 2 | Number of columns rendered outside the grid viewport. |

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -4,6 +4,7 @@ import {
   GRID_SELECTION_CHANGE,
 } from '../../constants/eventsConstants';
 import { useGridSelector } from '../../hooks/features/core/useGridSelector';
+import { gridPaginatedVisibleSortedGridRowIdsSelector } from '../../hooks/features/pagination/gridPaginationSelector';
 import { visibleSortedGridRowIdsSelector } from '../../hooks/features/filter/gridFilterSelector';
 import { gridTabIndexColumnHeaderSelector } from '../../hooks/features/focus/gridFocusStateSelector';
 import { gridRowCountSelector } from '../../hooks/features/rows/gridRowsSelector';
@@ -11,13 +12,19 @@ import { selectedGridRowsCountSelector } from '../../hooks/features/selection/gr
 import { GridColumnHeaderParams } from '../../models/params/gridColumnHeaderParams';
 import { isNavigationKey, isSpaceKey } from '../../utils/keyboardUtils';
 import { useGridApiContext } from '../../hooks/root/useGridApiContext';
+import { optionsSelector } from '../../hooks/utils/optionsSelector';
 
 export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderParams>(
   function GridHeaderCheckbox(props, ref) {
     const [, forceUpdate] = React.useState(false);
     const apiRef = useGridApiContext();
+    const { checkboxSelectionVisibleOnly } = useGridSelector(apiRef, optionsSelector);
     const visibleRowIds = useGridSelector(apiRef, visibleSortedGridRowIdsSelector);
     const tabIndexState = useGridSelector(apiRef, gridTabIndexColumnHeaderSelector);
+    const paginatedVisibleRowIds = useGridSelector(
+      apiRef,
+      gridPaginatedVisibleSortedGridRowIdsSelector,
+    );
 
     const totalSelectedRows = useGridSelector(apiRef, selectedGridRowsCountSelector);
     const totalRows = useGridSelector(apiRef, gridRowCountSelector);
@@ -28,7 +35,10 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const checked = event.target.checked;
-      apiRef!.current.selectRows(visibleRowIds, checked, !event.target.indeterminate);
+      const rowsToBeSelected = checkboxSelectionVisibleOnly
+        ? paginatedVisibleRowIds
+        : visibleRowIds;
+      apiRef!.current.selectRows(rowsToBeSelected, checked, !event.target.indeterminate);
     };
 
     const tabIndex = tabIndexState !== null && tabIndexState.field === props.field ? 0 : -1;

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -18,7 +18,7 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
   function GridHeaderCheckbox(props, ref) {
     const [, forceUpdate] = React.useState(false);
     const apiRef = useGridApiContext();
-    const { checkboxSelectionVisibleOnly } = useGridSelector(apiRef, optionsSelector);
+    const options = useGridSelector(apiRef, optionsSelector);
     const tabIndexState = useGridSelector(apiRef, gridTabIndexColumnHeaderSelector);
     const totalSelectedRows = useGridSelector(apiRef, selectedGridRowsCountSelector);
     const totalRows = useGridSelector(apiRef, gridRowCountSelector);
@@ -29,7 +29,7 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const checked = event.target.checked;
-      const rowsToBeSelected = checkboxSelectionVisibleOnly
+      const rowsToBeSelected = options.checkboxSelectionVisibleOnly
         ? gridPaginatedVisibleSortedGridRowIdsSelector(apiRef.current.getState())
         : visibleSortedGridRowIdsSelector(apiRef.current.getState());
       apiRef!.current.selectRows(rowsToBeSelected, checked, !event.target.indeterminate);

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -19,13 +19,7 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
     const [, forceUpdate] = React.useState(false);
     const apiRef = useGridApiContext();
     const { checkboxSelectionVisibleOnly } = useGridSelector(apiRef, optionsSelector);
-    const visibleRowIds = useGridSelector(apiRef, visibleSortedGridRowIdsSelector);
     const tabIndexState = useGridSelector(apiRef, gridTabIndexColumnHeaderSelector);
-    const paginatedVisibleRowIds = useGridSelector(
-      apiRef,
-      gridPaginatedVisibleSortedGridRowIdsSelector,
-    );
-
     const totalSelectedRows = useGridSelector(apiRef, selectedGridRowsCountSelector);
     const totalRows = useGridSelector(apiRef, gridRowCountSelector);
 
@@ -36,8 +30,8 @@ export const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnH
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const checked = event.target.checked;
       const rowsToBeSelected = checkboxSelectionVisibleOnly
-        ? paginatedVisibleRowIds
-        : visibleRowIds;
+        ? gridPaginatedVisibleSortedGridRowIdsSelector(apiRef.current.getState())
+        : visibleSortedGridRowIdsSelector(apiRef.current.getState());
       apiRef!.current.selectRows(rowsToBeSelected, checked, !event.target.indeterminate);
     };
 

--- a/packages/grid/_modules_/grid/hooks/features/pagination/gridPaginationSelector.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/gridPaginationSelector.ts
@@ -1,3 +1,19 @@
+import { createSelector } from 'reselect';
 import { GridPaginationState } from './gridPaginationState';
+import { GridState } from '../core/gridState';
+import { GridRowId } from '../../../models/gridRows';
+import { visibleSortedGridRowIdsSelector } from '../filter/gridFilterSelector';
 
 export const gridPaginationSelector = (state: any): GridPaginationState => state.pagination;
+
+export const gridPaginatedVisibleSortedGridRowIdsSelector = createSelector<
+  GridState,
+  GridPaginationState,
+  GridRowId[],
+  GridRowId[]
+>(gridPaginationSelector, visibleSortedGridRowIdsSelector, (paginationState, visibleSortedRows) => {
+  const firstSelectedRowIndex = paginationState.page * paginationState.pageSize;
+  const lastSelectedRowIndex = firstSelectedRowIndex + paginationState.pageSize;
+
+  return visibleSortedRows.slice(firstSelectedRowIndex, lastSelectedRowIndex);
+});

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -56,7 +56,7 @@ export interface GridOptions {
    */
   checkboxSelection?: boolean;
   /**
-   * If `true`, the "Select All" header checkbox selects only the rows on the current page. To be used in combination with `checkboxSelection`. 
+   * If `true`, the "Select All" header checkbox selects only the rows on the current page. To be used in combination with `checkboxSelection`.
    * @default false
    */
   checkboxSelectionVisibleOnly?: boolean;

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -56,6 +56,11 @@ export interface GridOptions {
    */
   checkboxSelection?: boolean;
   /**
+   * To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page.
+   * @default false
+   */
+  checkboxSelectionVisibleOnly?: boolean;
+  /**
    * Number of columns rendered outside the grid viewport.
    * @default 2
    */

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -56,7 +56,7 @@ export interface GridOptions {
    */
   checkboxSelection?: boolean;
   /**
-   * To be used in combination with `checkboxSelection`. If `true`, `Select All` selects only the rows on the current page.
+   * If `true`, the "Select All" header checkbox selects only the rows on the current page. To be used in combination with `checkboxSelection`. 
    * @default false
    */
   checkboxSelectionVisibleOnly?: boolean;

--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -12,6 +12,7 @@ const FORCED_PROPS: Partial<GridComponentProps> = {
   pagination: true,
   apiRef: undefined,
   onRowsScrollEnd: undefined,
+  checkboxSelectionVisibleOnly: false,
 };
 
 export type DataGridProps = Omit<
@@ -27,6 +28,7 @@ export type DataGridProps = Omit<
   | 'pagination'
   | 'onRowsScrollEnd'
   | 'scrollEndThreshold'
+  | 'checkboxSelectionVisibleOnly'
 > & {
   disableColumnResize?: true;
   disableColumnReorder?: true;
@@ -36,6 +38,7 @@ export type DataGridProps = Omit<
   pagination?: true;
   apiRef?: undefined;
   onRowsScrollEnd?: undefined;
+  checkboxSelectionVisibleOnly?: false;
 };
 
 const MAX_PAGE_SIZE = 100;
@@ -204,6 +207,19 @@ DataGrid.propTypes = {
         [
           `Material-UI: \`<DataGrid scrollEndThreshold={${props.scrollEndThreshold}} />\` is not a valid prop.`,
           'scrollEndThreshold is not available in the MIT version.',
+          '',
+          'You need to upgrade to the XGrid component to unlock this feature.',
+        ].join('\n'),
+      );
+    }
+    return null;
+  }),
+  checkboxSelectionVisibleOnly: chainPropTypes(PropTypes.bool, (props: any) => {
+    if (props.checkboxSelectionVisibleOnly === true) {
+      return new Error(
+        [
+          `Material-UI: \`<DataGrid checkboxSelectionVisibleOnly={true} />\` is not a valid prop.`,
+          'Selecting all columns only on the current page is not available in the MIT version.',
           '',
           'You need to upgrade to the XGrid component to unlock this feature.',
         ].join('\n'),

--- a/packages/grid/data-grid/src/DataGrid.tsx
+++ b/packages/grid/data-grid/src/DataGrid.tsx
@@ -17,28 +17,28 @@ const FORCED_PROPS: Partial<GridComponentProps> = {
 
 export type DataGridProps = Omit<
   GridComponentProps,
+  | 'apiRef'
+  | 'checkboxSelectionVisibleOnly'
   | 'disableColumnResize'
   | 'disableColumnReorder'
   | 'disableMultipleColumnsFiltering'
   | 'disableMultipleColumnsSorting'
   | 'disableMultipleSelection'
   | 'licenseStatus'
-  | 'apiRef'
   | 'options'
-  | 'pagination'
   | 'onRowsScrollEnd'
+  | 'pagination'
   | 'scrollEndThreshold'
-  | 'checkboxSelectionVisibleOnly'
 > & {
+  apiRef?: undefined;
+  checkboxSelectionVisibleOnly?: false;
   disableColumnResize?: true;
   disableColumnReorder?: true;
   disableMultipleColumnsFiltering?: true;
   disableMultipleColumnsSorting?: true;
   disableMultipleSelection?: true;
-  pagination?: true;
-  apiRef?: undefined;
   onRowsScrollEnd?: undefined;
-  checkboxSelectionVisibleOnly?: false;
+  pagination?: true;
 };
 
 const MAX_PAGE_SIZE = 100;
@@ -76,6 +76,19 @@ DataGrid.propTypes = {
         [
           `Material-UI: \`apiRef\` is not a valid prop.`,
           'GridApiRef is not available in the MIT version.',
+          '',
+          'You need to upgrade to the XGrid component to unlock this feature.',
+        ].join('\n'),
+      );
+    }
+    return null;
+  }),
+  checkboxSelectionVisibleOnly: chainPropTypes(PropTypes.bool, (props: any) => {
+    if (props.checkboxSelectionVisibleOnly === true) {
+      return new Error(
+        [
+          `Material-UI: \`<DataGrid checkboxSelectionVisibleOnly={true} />\` is not a valid prop.`,
+          'Selecting all columns only on the current page is not available in the MIT version.',
           '',
           'You need to upgrade to the XGrid component to unlock this feature.',
         ].join('\n'),
@@ -161,6 +174,19 @@ DataGrid.propTypes = {
     }
     return null;
   }),
+  onRowsScrollEnd: chainPropTypes(PropTypes.any, (props: any) => {
+    if (props.onRowsScrollEnd != null) {
+      return new Error(
+        [
+          `Material-UI: \`onRowsScrollEnd\` is not a valid prop.`,
+          'onRowsScrollEnd is not available in the MIT version.',
+          '',
+          'You need to upgrade to the XGrid component to unlock this feature.',
+        ].join('\n'),
+      );
+    }
+    return null;
+  }),
   pageSize: chainPropTypes(PropTypes.number, (props: any) => {
     if (props.pageSize && props.pageSize > MAX_PAGE_SIZE) {
       return new Error(
@@ -187,19 +213,6 @@ DataGrid.propTypes = {
     }
     return null;
   },
-  onRowsScrollEnd: chainPropTypes(PropTypes.any, (props: any) => {
-    if (props.onRowsScrollEnd != null) {
-      return new Error(
-        [
-          `Material-UI: \`onRowsScrollEnd\` is not a valid prop.`,
-          'onRowsScrollEnd is not available in the MIT version.',
-          '',
-          'You need to upgrade to the XGrid component to unlock this feature.',
-        ].join('\n'),
-      );
-    }
-    return null;
-  }),
   rows: PropTypes.array.isRequired,
   scrollEndThreshold: chainPropTypes(PropTypes.number, (props: any) => {
     if (props.scrollEndThreshold) {
@@ -207,19 +220,6 @@ DataGrid.propTypes = {
         [
           `Material-UI: \`<DataGrid scrollEndThreshold={${props.scrollEndThreshold}} />\` is not a valid prop.`,
           'scrollEndThreshold is not available in the MIT version.',
-          '',
-          'You need to upgrade to the XGrid component to unlock this feature.',
-        ].join('\n'),
-      );
-    }
-    return null;
-  }),
-  checkboxSelectionVisibleOnly: chainPropTypes(PropTypes.bool, (props: any) => {
-    if (props.checkboxSelectionVisibleOnly === true) {
-      return new Error(
-        [
-          `Material-UI: \`<DataGrid checkboxSelectionVisibleOnly={true} />\` is not a valid prop.`,
-          'Selecting all columns only on the current page is not available in the MIT version.',
           '',
           'You need to upgrade to the XGrid component to unlock this feature.',
         ].join('\n'),

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -134,35 +134,6 @@ describe('<DataGrid /> - Selection', () => {
       expect(getRow(1)).to.have.class('Mui-selected');
     });
 
-    it('should only select visible rows on the current page', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-              {
-                id: 1,
-                brand: 'Puma',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            checkboxSelection
-            checkboxSelectionVisibleOnly
-            pagination
-            pageSize={1}
-          />
-        </div>,
-      );
-      const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
-      fireEvent.click(selectAllCheckbox);
-      expect(getRow(0)).to.have.class('Mui-selected');
-      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      expect(getRow(1)).not.to.have.class('Mui-selected');
-    });
-
     it('with no rows, the checkbox should not be checked', () => {
       render(
         <div style={{ width: 300, height: 300 }}>

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -106,6 +106,63 @@ describe('<DataGrid /> - Selection', () => {
       expect(checkbox).to.have.property('checked', false);
     });
 
+    it('should select all visible rows regardless of pagination', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            rows={[
+              {
+                id: 0,
+                brand: 'Nike',
+              },
+              {
+                id: 1,
+                brand: 'Puma',
+              },
+            ]}
+            columns={[{ field: 'brand', width: 100 }]}
+            checkboxSelection
+            pagination
+            pageSize={1}
+          />
+        </div>,
+      );
+      const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
+      fireEvent.click(selectAllCheckbox);
+      expect(getRow(0)).to.have.class('Mui-selected');
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(getRow(1)).to.have.class('Mui-selected');
+    });
+
+    it('should only select visible rows on the current page', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            rows={[
+              {
+                id: 0,
+                brand: 'Nike',
+              },
+              {
+                id: 1,
+                brand: 'Puma',
+              },
+            ]}
+            columns={[{ field: 'brand', width: 100 }]}
+            checkboxSelection
+            checkboxSelectionVisibleOnly
+            pagination
+            pageSize={1}
+          />
+        </div>,
+      );
+      const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
+      fireEvent.click(selectAllCheckbox);
+      expect(getRow(0)).to.have.class('Mui-selected');
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(getRow(1)).not.to.have.class('Mui-selected');
+    });
+
     it('with no rows, the checkbox should not be checked', () => {
       render(
         <div style={{ width: 300, height: 300 }}>

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getColumnValues } from 'test/utils/helperFn';
+import { getColumnValues, getRow } from 'test/utils/helperFn';
 import {
   // @ts-expect-error need to migrate helpers to TypeScript
   screen,
@@ -161,5 +161,34 @@ describe('<XGrid /> - Selection', () => {
     expect(getSelectedRows(apiRef)).to.deep.equal([2]);
     fireEvent.click(selectAll);
     expect(getSelectedRows(apiRef)).to.deep.equal([]);
+  });
+
+  it('should only select visible rows on the current page', () => {
+    render(
+      <div style={{ width: 300, height: 300 }}>
+        <XGrid
+          rows={[
+            {
+              id: 0,
+              brand: 'Nike',
+            },
+            {
+              id: 1,
+              brand: 'Puma',
+            },
+          ]}
+          columns={[{ field: 'brand', width: 100 }]}
+          checkboxSelection
+          checkboxSelectionVisibleOnly
+          pagination
+          pageSize={1}
+        />
+      </div>,
+    );
+    const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
+    fireEvent.click(selectAllCheckbox);
+    expect(getRow(0)).to.have.class('Mui-selected');
+    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+    expect(getRow(1)).not.to.have.class('Mui-selected');
   });
 });


### PR DESCRIPTION
Fixes #605 

Added `checkboxSelectionVisibleOnly` that when `true`, Select All will only select rows visible on the current paginated page.

ToDo:

- [x] Docs
- [x] Tests