### PR TITLE
[core] Add @material-ui/lab as peer dependency

### DIFF
--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -23,7 +23,6 @@
   },
   "dependencies": {
     "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "^4.0.0-alpha.54",
     "@types/chance": "^1.1.0",
     "chance": "^1.1.6",
     "clsx": "^1.0.4",
@@ -35,6 +34,7 @@
   },
   "peerDependencies": {
     "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+    "@material-ui/lab": "^4.0.0-alpha.56 || ^5.0.0-alpha.39",
     "react": "^17.0.0"
   },
   "setupFiles": [

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -22,7 +22,6 @@
     "build": "cd ../ && rollup --config rollup.x-grid-data-generator.config.js"
   },
   "dependencies": {
-    "@material-ui/icons": "^4.9.1",
     "@types/chance": "^1.1.0",
     "chance": "^1.1.6",
     "clsx": "^1.0.4",
@@ -33,8 +32,9 @@
     "yargs": "^17.0.1"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
-    "@material-ui/lab": "^4.0.0-alpha.56 || ^5.0.0-alpha.39",
+    "@material-ui/core": "^4.11.2 || ^5.0.0-beta.0",
+    "@material-ui/lab": "^4.0.0-alpha.58 || ^5.0.0-alpha.39",
+    "@material-ui/icons": "^4.11.2 || ^5.0.0-beta.0",
     "react": "^17.0.0"
   },
   "setupFiles": [


### PR DESCRIPTION
Fixes #1878 

Noticed while debugging #1993 that demos depending in `@material-ui/x-grid-data-generator` won't work with MUI v5 because the version of the lab is fixed in v4. This PR makes the lab a peer dependency.

<img width="400" src="https://user-images.githubusercontent.com/42154031/124202741-6eeca080-dab1-11eb-8c05-d54cd241c108.png" alt="image" style="max-width:100%;">

Before: https://codesandbox.io/s/material-demo-forked-1vzw6?file=/package.json

After: https://codesandbox.io/s/material-demo-forked-nzqjp?file=/package.json

---

I'm aware that clicking in any cell to edit crashes the demo. I'll fix this in another PR. The first step was to make them at least run with v5.

<img width="400" src="https://user-images.githubusercontent.com/42154031/124203600-78770800-dab3-11eb-9d49-f95777283301.png" alt="image" style="max-width:100%;">