### PR TITLE
[test] Increase Browserstack worker timeout from 2.5 to 4 minutes

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -14,7 +14,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 4 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -14,7 +14,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 2.5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 5 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
It doesn't seem to be enough

This PR workflows :

- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5774/workflows/7d39c3e8-0ac0-4b28-b1b5-e7f4e5879518/jobs/29973

#2008 workflows (old timeout) :

- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5772/workflows/8554a64a-e189-4061-8d37-1caf63b45f6c
- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5772/workflows/ad3a635c-5ebb-4e12-ad1b-1aef6d2f5a71
- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5772/workflows/2dda8897-9da8-4ee7-8a37-ed08024f12c6


#2034 workflows (old timeout) :

- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5753/workflows/f530e51a-5dfb-4460-9005-4e5d232d3c8f/jobs/29824
- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5753/workflows/7970ee1b-2e0c-47d4-a4fd-cd9bc0f1f9fb/jobs/29939
- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5753/workflows/5d2a373a-8e0a-4d39-b144-cd9dcbbb7e90/jobs/29955
- https://app.circleci.com/pipelines/github/mui-org/material-ui-x/5753/workflows/fd09ae4f-0c03-47fe-a205-747d9d7d160d/jobs/29965

Each time it's a timeout