### PR TITLE
[DataGrid] Do not emit GRID_FILTER_MODEL_CHANGE event in applyFilterLinkOperator when called from another filter update method

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -245,20 +245,27 @@ export const useGridFilter = (
     apiRef?.current.hidePreferences();
   }, [apiRef, logger]);
 
-  const applyFilterLinkOperator = React.useCallback(
-    (linkOperator: GridLinkOperator = GridLinkOperator.And, emit = true) => {
-      logger.debug('Applying filter link operator');
-      setGridState((state) => ({
-        ...state,
-        filter: { ...state.filter, linkOperator },
-      }));
-      applyFilters();
+  const setFilterLinkOperation = React.useCallback(
+      (linkOperator: GridLinkOperator = GridLinkOperator.And, emit: boolean = true) => {
+          logger.debug('Applying filter link operator');
+          setGridState((state) => ({
+              ...state,
+              filter: { ...state.filter, linkOperator },
+          }));
+          applyFilters();
 
-      if (emit) {
-          apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
-      }
+          if (emit) {
+              apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
+          }
+      },
+      [apiRef, applyFilters, getFilterModelParams, logger, setGridState],
+  );
+
+  const applyFilterLinkOperator = React.useCallback(
+    (linkOperator: GridLinkOperator) => {
+      setFilterLinkOperation(linkOperator)
     },
-    [apiRef, applyFilters, getFilterModelParams, logger, setGridState],
+    [setFilterLinkOperation],
   );
 
   const clearFilterModel = React.useCallback(() => {
@@ -271,7 +278,7 @@ export const useGridFilter = (
     (model: GridFilterModel) => {
       clearFilterModel();
       logger.debug('Setting filter model');
-      applyFilterLinkOperator(model.linkOperator, false);
+        setFilterLinkOperation(model.linkOperator, false);
       model.items.forEach((item) => upsertFilter(item));
       apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
     },

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -246,14 +246,17 @@ export const useGridFilter = (
   }, [apiRef, logger]);
 
   const applyFilterLinkOperator = React.useCallback(
-    (linkOperator: GridLinkOperator = GridLinkOperator.And) => {
+    (linkOperator: GridLinkOperator = GridLinkOperator.And, emit = true) => {
       logger.debug('Applying filter link operator');
       setGridState((state) => ({
         ...state,
         filter: { ...state.filter, linkOperator },
       }));
       applyFilters();
-      apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
+
+      if (emit) {
+          apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
+      }
     },
     [apiRef, applyFilters, getFilterModelParams, logger, setGridState],
   );
@@ -268,7 +271,7 @@ export const useGridFilter = (
     (model: GridFilterModel) => {
       clearFilterModel();
       logger.debug('Setting filter model');
-      applyFilterLinkOperator(model.linkOperator);
+      applyFilterLinkOperator(model.linkOperator, false);
       model.items.forEach((item) => upsertFilter(item));
       apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
     },

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -246,24 +246,24 @@ export const useGridFilter = (
   }, [apiRef, logger]);
 
   const setFilterLinkOperation = React.useCallback(
-      (linkOperator: GridLinkOperator = GridLinkOperator.And, emit: boolean = true) => {
-          logger.debug('Applying filter link operator');
-          setGridState((state) => ({
-              ...state,
-              filter: { ...state.filter, linkOperator },
-          }));
-          applyFilters();
+    (linkOperator: GridLinkOperator = GridLinkOperator.And, emit: boolean = true) => {
+      logger.debug('Applying filter link operator');
+      setGridState((state) => ({
+        ...state,
+        filter: { ...state.filter, linkOperator },
+      }));
+      applyFilters();
 
-          if (emit) {
-              apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
-          }
-      },
-      [apiRef, applyFilters, getFilterModelParams, logger, setGridState],
+      if (emit) {
+        apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
+      }
+    },
+    [apiRef, applyFilters, getFilterModelParams, logger, setGridState],
   );
 
   const applyFilterLinkOperator = React.useCallback(
     (linkOperator: GridLinkOperator) => {
-      setFilterLinkOperation(linkOperator)
+      setFilterLinkOperation(linkOperator);
     },
     [setFilterLinkOperation],
   );
@@ -278,7 +278,7 @@ export const useGridFilter = (
     (model: GridFilterModel) => {
       clearFilterModel();
       logger.debug('Setting filter model');
-        setFilterLinkOperation(model.linkOperator, false);
+      setFilterLinkOperation(model.linkOperator, false);
       model.items.forEach((item) => upsertFilter(item));
       apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
     },

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -282,7 +282,7 @@ export const useGridFilter = (
       model.items.forEach((item) => upsertFilter(item));
       apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, getFilterModelParams());
     },
-    [apiRef, applyFilterLinkOperator, clearFilterModel, getFilterModelParams, logger, upsertFilter],
+    [apiRef, setFilterLinkOperation, clearFilterModel, getFilterModelParams, logger, upsertFilter],
   );
 
   const getVisibleRowModels = React.useCallback(

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -224,7 +224,7 @@ describe('<XGrid /> - Filter', () => {
       />,
     );
     // TODO should equal 0, the state doesn't change
-    expect(onFilterModelChange.callCount).to.equal(4);
+    expect(onFilterModelChange.callCount).to.equal(3);
     expect(getColumnValues()).to.deep.equal([]);
     onFilterModelChange.callCount = 0;
 

--- a/packages/storybook/src/stories/grid-filter.stories.tsx
+++ b/packages/storybook/src/stories/grid-filter.stories.tsx
@@ -279,10 +279,6 @@ export function ServerFilterViaProps() {
 
   const onFilterChange = React.useCallback(
     (params: GridFilterModelParams) => {
-      console.log(
-        'Filter model in Story onFilterChange',
-        JSON.stringify(params.filterModel, null, 2),
-      );
       const hasChanged = params.filterModel.items[0].value !== filterModel.items[0].value;
       setLoading(hasChanged);
       if (!hasChanged) {
@@ -299,8 +295,6 @@ export function ServerFilterViaProps() {
   React.useEffect(() => {
     applyFilters();
   }, [applyFilters, demoServer.data.rows]);
-
-  console.log('Filter model in Story render', JSON.stringify(filterModel, null, 2));
 
   return (
     <div className="grid-container">

--- a/packages/storybook/src/stories/grid-filter.stories.tsx
+++ b/packages/storybook/src/stories/grid-filter.stories.tsx
@@ -279,6 +279,7 @@ export function ServerFilterViaProps() {
 
   const onFilterChange = React.useCallback(
     (params: GridFilterModelParams) => {
+      console.log('Filter model in Story onFilterChange', JSON.stringify(params.filterModel, null, 2))
       const hasChanged = params.filterModel.items[0].value !== filterModel.items[0].value;
       setLoading(hasChanged);
       if (!hasChanged) {
@@ -295,6 +296,8 @@ export function ServerFilterViaProps() {
   React.useEffect(() => {
     applyFilters();
   }, [applyFilters, demoServer.data.rows]);
+
+  console.log('Filter model in Story render', JSON.stringify(filterModel, null, 2))
 
   return (
     <div className="grid-container">

--- a/packages/storybook/src/stories/grid-filter.stories.tsx
+++ b/packages/storybook/src/stories/grid-filter.stories.tsx
@@ -279,7 +279,10 @@ export function ServerFilterViaProps() {
 
   const onFilterChange = React.useCallback(
     (params: GridFilterModelParams) => {
-      console.log('Filter model in Story onFilterChange', JSON.stringify(params.filterModel, null, 2))
+      console.log(
+        'Filter model in Story onFilterChange',
+        JSON.stringify(params.filterModel, null, 2),
+      );
       const hasChanged = params.filterModel.items[0].value !== filterModel.items[0].value;
       setLoading(hasChanged);
       if (!hasChanged) {
@@ -297,7 +300,7 @@ export function ServerFilterViaProps() {
     applyFilters();
   }, [applyFilters, demoServer.data.rows]);
 
-  console.log('Filter model in Story render', JSON.stringify(filterModel, null, 2))
+  console.log('Filter model in Story render', JSON.stringify(filterModel, null, 2));
 
   return (
     <div className="grid-container">


### PR DESCRIPTION
Fixes #2013 