### PR TITLE
[core] Fix missing git source in packages

### DIFF
--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -29,6 +29,11 @@
     "typescript": "tsc -p tsconfig.json",
     "build": "cd ../ && rollup --config rollup.data-grid.config.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui-x.git",
+    "directory": "packages/grid/data-grid"
+  },
   "dependencies": {
     "@material-ui/utils": "^5.0.0-alpha.14",
     "clsx": "^1.0.4",

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -10,6 +10,10 @@
     "dist/*"
   ],
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui-x/issues"
+  },
+  "homepage": "https://material-ui.com/components/data-grid/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -10,6 +10,10 @@
     "dist/*"
   ],
   "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui-x/issues"
+  },
+  "homepage": "https://material-ui.com/components/data-grid/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/grid/x-grid-data-generator/package.json
+++ b/packages/grid/x-grid-data-generator/package.json
@@ -21,6 +21,11 @@
     "typescript": "tsc -p tsconfig.json",
     "build": "cd ../ && rollup --config rollup.x-grid-data-generator.config.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui-x.git",
+    "directory": "packages/grid/x-grid-data-generator"
+  },
   "dependencies": {
     "@types/chance": "^1.1.0",
     "chance": "^1.1.6",

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -10,6 +10,10 @@
     "dist/*"
   ],
   "license": "See LICENSE file",
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui-x/issues"
+  },
+  "homepage": "https://material-ui.com/components/data-grid/",
   "sideEffects": false,
   "publishConfig": {
     "access": "public"

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -29,6 +29,11 @@
     "typescript": "tsc -p tsconfig.json",
     "build": "cd ../ && rollup --config rollup.x-grid.config.js"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui-x.git",
+    "directory": "packages/grid/x-grid"
+  },
   "dependencies": {
     "@material-ui/utils": "^5.0.0-alpha.14",
     "@material-ui/x-license": "4.0.0-alpha.33",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -10,6 +10,11 @@
     "export": "mv dist ../../docs/export/storybook",
     "typescript": "tsc -p tsconfig.json"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui-x.git",
+    "directory": "packages/storybook"
+  },
   "dependencies": {
     "@material-ui/core": "^4.9.12",
     "@material-ui/data-grid": "4.0.0-alpha.33",

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -18,6 +18,10 @@
   "files": [
     "dist/*"
   ],
+  "bugs": {
+    "url": "https://github.com/mui-org/material-ui-x/issues"
+  },
+  "homepage": "https://material-ui.com/components/data-grid/",
   "license": "See LICENSE file",
   "sideEffects": false,
   "publishConfig": {

--- a/packages/x-license/package.json
+++ b/packages/x-license/package.json
@@ -10,6 +10,11 @@
     "typescript": "tsc -p tsconfig.json",
     "build": "rollup -c"
   },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/mui-org/material-ui-x.git",
+    "directory": "packages/x-license"
+  },
   "files": [
     "dist/*"
   ],


### PR DESCRIPTION
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.
We've identified that the following packages published to NPM do not report where sources can be found, typically accomplished by including a link to your GitHub repository in your `package.json` REPOSITORY field. This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	*@material-ui/data-grid