### PR TITLE
[core] Add support bot

### DIFF
--- a/.github/support.yml
+++ b/.github/support.yml
@@ -1,0 +1,23 @@
+# Configuration for support-requests - https://github.com/dessant/support-requests
+
+# Label used to mark issues as support requests
+supportLabel: support
+
+# Comment to post on issues marked as support requests. Add a link
+# to a support page, or set to `false` to disable
+supportComment: |
+  👋 Thanks for using Material-UI!
+
+  We use GitHub issues exclusively as a bug and feature requests tracker, however,
+  this issue appears to be a support request.
+
+  For support, please check out https://material-ui.com/getting-started/support/. Thanks!
+
+  If you have a question on StackOverflow, you are welcome to link to it here, it might help others.
+  If your issue is subsequently confirmed as a bug,  and the report follows the issue template, it can be reopened.
+
+# Whether to close issues marked as support requests
+close: true
+
+# Whether to lock issues marked as support requests
+lock: false


### PR DESCRIPTION
I was expecting the bot we have in the core repo to close #2096 as soon as I left the "support" label but it didn't happen. We didn't configure the bot here, so it seems normal.