### PR TITLE
[core] Remove implicit :scope

### DIFF
--- a/packages/grid/_modules_/grid/utils/domUtils.ts
+++ b/packages/grid/_modules_/grid/utils/domUtils.ts
@@ -46,7 +46,7 @@ export function findGridCellElementsFromCol(col: HTMLElement): NodeListOf<Elemen
   if (!root) {
     throw new Error('Material-UI: The root element is not found.');
   }
-  const cells = root.querySelectorAll(`:scope .${GRID_CELL_CSS_CLASS}[data-field="${field}"]`);
+  const cells = root.querySelectorAll(`.${GRID_CELL_CSS_CLASS}[data-field="${field}"]`);
   return cells;
 }
 
@@ -62,7 +62,7 @@ export function getGridColumnHeaderElement(root: Element, field: string) {
 
 export function getGridRowElement(root: Element, id: GridRowId) {
   return root.querySelector(
-    `:scope .${GRID_ROW_CSS_CLASS}[data-id="${escapeOperandAttributeSelector(String(id))}"]`,
+    `.${GRID_ROW_CSS_CLASS}[data-id="${escapeOperandAttributeSelector(String(id))}"]`,
   ) as HTMLDivElement;
 }
 


### PR DESCRIPTION
This is a continuation of https://github.com/mui-org/material-ui-x/pull/2033#discussion_r666030447. `:scope` is documented in https://developer.mozilla.org/en-US/docs/Web/CSS/:scope#direct_children. AFAIK, we don't need it.