### PR TITLE
[DataGrid] Support style prop

### DIFF
--- a/packages/grid/_modules_/grid/GridComponentProps.ts
+++ b/packages/grid/_modules_/grid/GridComponentProps.ts
@@ -76,4 +76,8 @@ export interface GridComponentProps extends GridOptionsProp {
    * Set the whole state of the grid.
    */
   state?: Partial<GridState>;
+  /**
+   * @ignore
+   */
+  style?: React.CSSProperties;
 }

--- a/packages/grid/_modules_/grid/components/containers/GridRoot.tsx
+++ b/packages/grid/_modules_/grid/components/containers/GridRoot.tsx
@@ -20,7 +20,6 @@ export const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function
   const classes = useStyles();
   const apiRef = useGridApiContext();
   const rootProps = React.useContext(GridRootPropsContext)!;
-  const { className } = rootProps;
   const { children, className: classNameProp, ...other } = props;
   const visibleColumnsLength = useGridSelector(apiRef, visibleGridColumnsLengthSelector);
   const [gridState] = useGridState(apiRef!);
@@ -33,7 +32,7 @@ export const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function
     <NoSsr>
       <div
         ref={handleRef}
-        className={clsx(classes.root, options.classes?.root, className, classNameProp, {
+        className={clsx(classes.root, options.classes?.root, rootProps.className, classNameProp, {
           'MuiDataGrid-autoHeight': gridState.options.autoHeight,
         })}
         role="grid"
@@ -42,6 +41,7 @@ export const GridRoot = React.forwardRef<HTMLDivElement, GridRootProps>(function
         aria-multiselectable={!gridState.options.disableMultipleSelection}
         aria-label={rootProps['aria-label']}
         aria-labelledby={rootProps['aria-labelledby']}
+        style={rootProps.style}
         {...other}
       >
         {children}

--- a/packages/grid/x-grid/src/tests/layout.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/layout.XGrid.test.tsx
@@ -58,7 +58,26 @@ describe('<XGrid /> - Layout', () => {
         </div>,
       );
 
-      expect(document.querySelector(`.${className}`)).to.equal(container.firstChild.firstChild);
+      expect(container.firstChild.firstChild).to.have.class(className);
+      expect(container.firstChild.firstChild).to.have.class('MuiDataGrid-root');
+    });
+
+    it('applies the style to the root component', () => {
+      render(
+        <div style={{ width: 300, height: 300 }}>
+          <XGrid
+            {...baselineProps}
+            style={{
+              border: 0,
+            }}
+          />
+        </div>,
+      );
+
+      // @ts-expect-error need to migrate helpers to TypeScript
+      expect(document.querySelector('.MuiDataGrid-root')).toHaveInlineStyle({
+        border: '0px',
+      });
     });
   });
 });

--- a/packages/grid/x-grid/src/tests/layout.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/layout.XGrid.test.tsx
@@ -68,7 +68,7 @@ describe('<XGrid /> - Layout', () => {
           <XGrid
             {...baselineProps}
             style={{
-              border: 0,
+              mixBlendMode: 'darken',
             }}
           />
         </div>,
@@ -76,7 +76,7 @@ describe('<XGrid /> - Layout', () => {
 
       // @ts-expect-error need to migrate helpers to TypeScript
       expect(document.querySelector('.MuiDataGrid-root')).toHaveInlineStyle({
-        border: '0px',
+        mixBlendMode: 'darken',
       });
     });
   });


### PR DESCRIPTION
If we support the `className` prop, then it makes sense to support the `style` prop too. I got trapped in https://github.com/mui-org/material-ui/pull/27196.