### PR TITLE
[DataGrid] Add missing localeText types

### DIFF
--- a/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridLocaleTextApi.ts
@@ -63,6 +63,8 @@ export interface GridLocaleText extends Partial<MuiComponentsLocalization> {
   filterOperatorOnOrAfter: string;
   filterOperatorBefore: string;
   filterOperatorOnOrBefore: string;
+  filterOperatorIsEmpty: string;
+  filterOperatorIsNotEmpty: string;
 
   // Filter values text
   filterValueAny: string;


### PR DESCRIPTION
This was forgotten in #1997, it happens, it's fine. More importantly, the CI should have reported the issue, it didn't because of https://github.com/mui-org/material-ui-x/pull/1913/files#r667394689, we should have never extended any. The test side of things is done in #2117, as you can see from the failing tests.