### PR TITLE
Correct readme and package.json Peer Dependencies

### DIFF
--- a/packages/grid/data-grid/README.md
+++ b/packages/grid/data-grid/README.md
@@ -19,7 +19,7 @@ This component has two peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+  "@material-ui/core": "^4.9.12",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -45,7 +45,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+    "@material-ui/core": "^4.9.12",
     "react": "^17.0.0"
   },
   "setupFiles": [

--- a/packages/grid/x-grid/README.md
+++ b/packages/grid/x-grid/README.md
@@ -19,7 +19,7 @@ This component has two peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+  "@material-ui/core": "^4.9.12",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -46,7 +46,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+    "@material-ui/core": "^4.9.12",
     "react": "^17.0.0"
   },
   "setupFiles": [


### PR DESCRIPTION
#1234 Notes that x-grid and data-grid don't actually work with Material 5.

This corrects `package.json` and readme files to take this into account.