### PR TITLE
[test] Allow tests to run for up to 5 instead of 4 seconds

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -40,7 +40,7 @@ module.exports = function setKarmaConfig(config) {
     client: {
       mocha: {
         // Some BrowserStack browsers can be slow.
-        timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000,
+        timeout: (process.env.CIRCLECI === 'true' ? 5 : 2) * 1000,
       },
     },
     frameworks: ['mocha'],


### PR DESCRIPTION
We use 5 seconds in the main repository, while we have tests that are slower because they test a bigger component here. This seems like a logical step. I worked on it after seeing: https://app.circleci.com/pipelines/github/mui-org/material-ui-x/6089/workflows/f3da1253-f8e8-4876-aac0-63ffefd32ed5/jobs/32074

> Edge 85.0.564.41 (Windows 10) <DataGrid /> - Toolbar column selector should show all columns when clicking "SHOW ALL" from the column selector FAILED
	Error: Timeout of 4000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.

We could even do 6s to be honest, no real preferences.