### PR TITLE
[XGrid] Prevent headers from scrolling during reordering

### DIFF
--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -14,11 +14,6 @@ export const GRID_DEBOUNCED_RESIZE = 'debouncedResize';
 /**
  * @ignore - do not document.
  */
-export const GRID_SCROLL = 'scroll';
-
-/**
- * @ignore - do not document.
- */
 export const GRID_KEYDOWN = 'keydown';
 
 // GRID events

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { GRID_SCROLL, GRID_ROWS_SCROLL } from '../../../constants/eventsConstants';
+import { GRID_ROWS_SCROLL } from '../../../constants/eventsConstants';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridVirtualizationApi } from '../../../models/api/gridVirtualizationApi';
 import { GridCellIndexCoordinates } from '../../../models/gridCell';
@@ -382,28 +382,19 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
   const preventScroll = React.useCallback((event: any) => {
     event.target.scrollLeft = 0;
     event.target.scrollTop = 0;
-    event.preventDefault();
-    event.stopPropagation();
-    return false;
   }, []);
 
-  useNativeEventListener(apiRef, windowRef, GRID_SCROLL, handleScroll, { passive: true });
+  useNativeEventListener(apiRef, windowRef, 'scroll', handleScroll, { passive: true });
   useNativeEventListener(
     apiRef,
     () => apiRef.current?.renderingZoneRef?.current?.parentElement,
-    GRID_SCROLL,
+    'scroll',
     preventScroll,
   );
   useNativeEventListener(
     apiRef,
     () => apiRef.current?.columnHeadersContainerElementRef?.current,
-    GRID_SCROLL,
-    preventScroll,
-  );
-  useNativeEventListener(
-    apiRef,
-    () => apiRef.current?.columnHeadersContainerElementRef?.current?.parentElement,
-    GRID_SCROLL,
+    'scroll',
     preventScroll,
   );
 };

--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualRows.ts
@@ -379,30 +379,31 @@ export const useGridVirtualRows = (apiRef: GridApiRef): void => {
     };
   }, []);
 
-  const preventViewportScroll = React.useCallback(
-    (event: any) => {
-      logger.debug('Using keyboard to navigate cells, converting scroll events ');
-
-      event.target.scrollLeft = 0;
-      event.target.scrollTop = 0;
-      event.preventDefault();
-      event.stopPropagation();
-      return false;
-    },
-    [logger],
-  );
+  const preventScroll = React.useCallback((event: any) => {
+    event.target.scrollLeft = 0;
+    event.target.scrollTop = 0;
+    event.preventDefault();
+    event.stopPropagation();
+    return false;
+  }, []);
 
   useNativeEventListener(apiRef, windowRef, GRID_SCROLL, handleScroll, { passive: true });
   useNativeEventListener(
     apiRef,
     () => apiRef.current?.renderingZoneRef?.current?.parentElement,
     GRID_SCROLL,
-    preventViewportScroll,
+    preventScroll,
+  );
+  useNativeEventListener(
+    apiRef,
+    () => apiRef.current?.columnHeadersContainerElementRef?.current,
+    GRID_SCROLL,
+    preventScroll,
   );
   useNativeEventListener(
     apiRef,
     () => apiRef.current?.columnHeadersContainerElementRef?.current?.parentElement,
     GRID_SCROLL,
-    preventViewportScroll,
+    preventScroll,
   );
 };


### PR DESCRIPTION
Fixes #2132 
Preview: https://deploy-preview-2154--material-ui-x.netlify.app/components/data-grid/demo/

This bug is a bit hard to reproduce. It happens almost randomly. It's caused because the `.MuiDataGrid-columnsContainer` div is, sometimes, also scrolling when dragging a column. However, its `scrollLeft` position should always be zero.

<img width="400" src="https://user-images.githubusercontent.com/42154031/125846450-208fa84d-ab82-4dc1-8226-8075e6bf6ba3.png" alt="image" style="max-width:100%;">

To be able to fix it, I had to find a reliable way to reproduce it. What I did was to change the `overflow: hidden` of `.MuiDataGrid-columnsContainer` to `overflow: auto` to see the scrollbar. Then, I did the following movement:

https://user-images.githubusercontent.com/42154031/125847679-7b8abd05-3f0b-4172-85a9-50fba44de21c.mp4