### PR TITLE
[DataGrid] Use Intl.Collator for string comparison

### DIFF
--- a/packages/grid/_modules_/grid/models/colDef/gridStringOperators.ts
+++ b/packages/grid/_modules_/grid/models/colDef/gridStringOperators.ts
@@ -27,12 +27,9 @@ export const getGridStringOperators: () => GridFilterOperator[] = () => [
       if (!filterItem.value) {
         return null;
       }
+      const collator = new Intl.Collator(undefined, { sensitivity: 'base', usage: 'search' });
       return ({ value }): boolean => {
-        return (
-          filterItem.value?.localeCompare((value && value.toString()) || '', undefined, {
-            sensitivity: 'base',
-          }) === 0
-        );
+        return collator.compare(filterItem.value, (value && value.toString()) || '') === 0;
       };
     },
     InputComponent: GridFilterInputValue,

--- a/packages/grid/_modules_/grid/utils/sortingUtils.ts
+++ b/packages/grid/_modules_/grid/utils/sortingUtils.ts
@@ -23,6 +23,8 @@ export const gridNillComparer = (v1: GridCellValue, v2: GridCellValue): number |
   return null;
 };
 
+const collator = new Intl.Collator();
+
 export const gridStringNumberComparer: GridComparatorFn = (
   value1: GridCellValue,
   value2: GridCellValue,
@@ -33,7 +35,7 @@ export const gridStringNumberComparer: GridComparatorFn = (
   }
 
   if (typeof value1 === 'string') {
-    return value1.localeCompare(value2!.toString());
+    return collator.compare(value1!.toString(), value2!.toString());
   }
   return (value1 as any) - (value2 as any);
 };


### PR DESCRIPTION
Closes #1968 
Preview: https://deploy-preview-2155--material-ui-x.netlify.app/components/data-grid/#commercial-version
Benchmark: https://material-ui.com/components/data-grid/#commercial-version

#### Sorting

localeCompare / Intl.Collator

<img width="550" src="https://user-images.githubusercontent.com/42154031/125885098-3b963a5d-29eb-48af-8e12-b5031b5bac36.png" alt="image" style="max-width:100%;">

#### Filtering (equals)

localeCompare / Intl.Collator

<img width="550" src="https://user-images.githubusercontent.com/42154031/125885499-1fa0b87a-0daf-4cb0-a71e-220f779bde37.png" alt="image" style="max-width:100%;">