### PR TITLE
[core] Support `docs:api` script in Windows OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "yarn docs:dev",
     "docs:dev": "yarn workspace docs dev",
     "docs:api": "yarn docs:api:build",
-    "docs:api:build": "cross-env BABEL_ENV=development babel-node --config-file ./docs/babel.config.js -i '/node_modules/(?!@material-ui)/' -x .ts,.tsx,.js ./docs/scripts/buildApi.ts ./docs/pages/api-docs/data-grid",
+    "docs:api:build": "cross-env BABEL_ENV=development babel-node --config-file ./docs/babel.config.js -i \"/node_modules/(?!@material-ui)/\" -x .ts,.tsx,.js ./docs/scripts/buildApi.ts ./docs/pages/api-docs/data-grid",
     "docs:build": "yarn workspace docs build",
     "docs:export": "yarn workspace docs export",
     "docs:typescript:formatted": "yarn workspace docs typescript:transpile",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "start": "yarn docs:dev",
     "docs:dev": "yarn workspace docs dev",
     "docs:api": "yarn docs:api:build",
-    "docs:api:build": "cross-env BABEL_ENV=development babel-node --config-file ./docs/babel.config.js -i \"/node_modules/(?!@material-ui)/\" -x .ts,.tsx,.js ./docs/scripts/buildApi.ts ./docs/pages/api-docs/data-grid",
+    "docs:api:build": "cross-env BABEL_ENV=development babel-node -x .ts,.tsx,.js ./docs/scripts/buildApi.ts ./docs/pages/api-docs/data-grid",
     "docs:build": "yarn workspace docs build",
     "docs:export": "yarn workspace docs export",
     "docs:typescript:formatted": "yarn workspace docs typescript:transpile",


### PR DESCRIPTION
I was running this script on Windows OS and I got `/' was unexpected at this time` error.
Apparently, Windows platforms do not support single quotes on the command line, so escaping it in double quotes.

This works in all OS.