### PR TITLE
[docs] Fix small typos in the documentation

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -40,7 +40,7 @@ import { DataGrid } from '@material-ui/data-grid';
 ### Define rows
 
 Rows are key-value pair objects, mapping column names as keys with their values.
-You should also provide an id on each row to allow delta updates and better performance.
+You should also provide an `id` property on each row to allow delta updates and better performance.
 
 Here is an example
 
@@ -135,11 +135,11 @@ The enterprise components come in two plans: Pro and Premium.
 | [Column reorder](/components/data-grid/columns/#column-reorder)                           |    ❌     |              ✅               |                  ✅                   |
 | [Column pinning](/components/data-grid/columns/#column-pinning)                           |    ❌     |              🚧               |                  🚧                   |
 | [Column spanning](/components/data-grid/columns/#column-spanning)                         |    🚧     |              🚧               |                  🚧                   |
-| **Rows**                                                                                  |           |                               |                                       |
-| [Rows sorting](/components/data-grid/rows/#row-sorting)                                   |    ✅     |              ✅               |                  ✅                   |
-| [Rows height](/components/data-grid/rows/#row-height)                                     |    ✅     |              ✅               |                  ✅                   |
-| [Rows spanning](/components/data-grid/rows/#row-spanning)                                 |    🚧     |              🚧               |                  🚧                   |
-| [Rows reorder](/components/data-grid/rows/#row-reorder)                                   |    ❌     |              🚧               |                  🚧                   |
+| **Row**                                                                                  |           |                               |                                       |
+| [Row sorting](/components/data-grid/rows/#row-sorting)                                   |    ✅     |              ✅               |                  ✅                   |
+| [Row height](/components/data-grid/rows/#row-height)                                     |    ✅     |              ✅               |                  ✅                   |
+| [Row spanning](/components/data-grid/rows/#row-spanning)                                 |    🚧     |              🚧               |                  🚧                   |
+| [Row reordering](/components/data-grid/rows/#row-reorder)                                   |    ❌     |              🚧               |                  🚧                   |
 | **Selection**                                                                             |           |                               |                                       |
 | [Row selection](/components/data-grid/selection/#single-row-selection)                    |    ✅     |              ✅               |                  ✅                   |
 | [Multi-row selection](/components/data-grid/selection/#multiple-row-selection)            |    ❌     |              ✅               |                  ✅                   |
@@ -152,7 +152,7 @@ The enterprise components come in two plans: Pro and Premium.
 | [Pagination](/components/data-grid/pagination/)                                           |    ✅     |              ✅               |                  ✅                   |
 | [Pagination > 100 rows per page](/components/data-grid/pagination/#paginate-gt-100-rows)  |    ❌     |              ✅               |                  ✅                   |
 | **Editing**                                                                               |           |                               |                                       |
-| [Row edition](/components/data-grid/editing/#row-editing)                                 |    🚧     |              🚧               |                  🚧                   |
+| [Row editing](/components/data-grid/editing/#row-editing)                                 |    🚧     |              🚧               |                  🚧                   |
 | [Cell editing](/components/data-grid/editing/#cell-editing)                               |    ✅     |              ✅               |                  ✅                   |
 | **Import & export**                                                                       |           |                               |                                       |
 | [CSV export](/components/data-grid/export/#csv-export)                                    |    ✅     |              ✅               |                  ✅                   |

--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -135,11 +135,11 @@ The enterprise components come in two plans: Pro and Premium.
 | [Column reorder](/components/data-grid/columns/#column-reorder)                           |    ❌     |              ✅               |                  ✅                   |
 | [Column pinning](/components/data-grid/columns/#column-pinning)                           |    ❌     |              🚧               |                  🚧                   |
 | [Column spanning](/components/data-grid/columns/#column-spanning)                         |    🚧     |              🚧               |                  🚧                   |
-| **Row**                                                                                  |           |                               |                                       |
-| [Row sorting](/components/data-grid/rows/#row-sorting)                                   |    ✅     |              ✅               |                  ✅                   |
-| [Row height](/components/data-grid/rows/#row-height)                                     |    ✅     |              ✅               |                  ✅                   |
-| [Row spanning](/components/data-grid/rows/#row-spanning)                                 |    🚧     |              🚧               |                  🚧                   |
-| [Row reordering](/components/data-grid/rows/#row-reorder)                                   |    ❌     |              🚧               |                  🚧                   |
+| **Row**                                                                                   |           |                               |                                       |
+| [Row sorting](/components/data-grid/rows/#row-sorting)                                    |    ✅     |              ✅               |                  ✅                   |
+| [Row height](/components/data-grid/rows/#row-height)                                      |    ✅     |              ✅               |                  ✅                   |
+| [Row spanning](/components/data-grid/rows/#row-spanning)                                  |    🚧     |              🚧               |                  🚧                   |
+| [Row reordering](/components/data-grid/rows/#row-reorder)                                 |    ❌     |              🚧               |                  🚧                   |
 | **Selection**                                                                             |           |                               |                                       |
 | [Row selection](/components/data-grid/selection/#single-row-selection)                    |    ✅     |              ✅               |                  ✅                   |
 | [Multi-row selection](/components/data-grid/selection/#multiple-row-selection)            |    ❌     |              ✅               |                  ✅                   |


### PR DESCRIPTION
Hello! 👋 

I noticed there were a number of small typos in the documentation so I made a quick PR to address the ones I could find.

Preview: https://deploy-preview-2169--material-ui-x.netlify.app/components/data-grid/getting-started/#feature-comparison

Sidenote: I saw some broken links in that same page section. I'll hopefully be able to make another PR to remove the links that link to non-existent sections.

