### PR TITLE
[test] Sync Karma config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ jobs:
   test_browser:
     <<: *defaults
     docker:
-      - image: mcr.microsoft.com/playwright@sha256:bca4179f0a1a0d39efc206917b1d6b0670e93b0d74873c02ee25662a84d11fc0
+      - image: mcr.microsoft.com/playwright@sha256:1700531ce01a3d974cc440bb8efcf43d31d58ee5f1d354fc21563ea5fe4291e6
         environment:
           NODE_ENV: development # Needed if playwright is in `devDependencies`
     steps:

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -5,8 +5,12 @@ const CI = Boolean(process.env.CI);
 
 let build = `material-ui-x local ${new Date().toISOString()}`;
 
-if (process.env.CIRCLE_BUILD_URL) {
-  build = process.env.CIRCLE_BUILD_URL;
+if (process.env.CIRCLECI) {
+  const buildPrefix =
+    process.env.CIRCLE_PR_NUMBER !== undefined
+      ? process.env.CIRCLE_PR_NUMBER
+      : process.env.CIRCLE_BRANCH;
+  build = `${buildPrefix}: ${process.env.CIRCLE_BUILD_URL}`;
 }
 
 const browserStack = {
@@ -14,7 +18,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 4 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 6 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
Sync the Karma config to use the same timeout used in the core: https://github.com/mui-org/material-ui/blob/8039e8506fc0377fac2b7c6772e551e982450037/test/karma.conf.js#L21