### PR TITLE
[DataGrid] Canonical controlled state behavior

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/core/useGridControlState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/core/useGridControlState.ts
@@ -1,13 +1,13 @@
 import React from 'react';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridControlStateApi } from '../../../models/api/gridControlStateApi';
-import { ControlStateItem } from '../../../models/controlStateItem';
+import { GridControlStateItem } from '../../../models/controlStateItem';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
 
 export function useGridControlState(apiRef: GridApiRef) {
-  const controlStateMapRef = React.useRef<Record<string, ControlStateItem<any>>>({});
+  const controlStateMapRef = React.useRef<Record<string, GridControlStateItem<any>>>({});
 
-  const updateControlState = React.useCallback((controlStateItem: ControlStateItem<any>) => {
+  const updateControlState = React.useCallback((controlStateItem: GridControlStateItem<any>) => {
     const { stateId, stateSelector, ...others } = controlStateItem;
 
     controlStateMapRef.current[stateId] = {

--- a/packages/grid/_modules_/grid/hooks/features/core/useGridControlState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/core/useGridControlState.ts
@@ -64,9 +64,7 @@ export function useGridControlState(apiRef: GridApiRef) {
               controlState.propOnChange(model);
             }
 
-            if (controlState.onChangeCallback) {
-              controlState.onChangeCallback!(model);
-            }
+            apiRef.current.publishEvent(controlState.changeEvent, model);
           });
         },
       };

--- a/packages/grid/_modules_/grid/hooks/features/core/useGridState.ts
+++ b/packages/grid/_modules_/grid/hooks/features/core/useGridState.ts
@@ -18,29 +18,25 @@ export const useGridState = (
   const setGridState = React.useCallback(
     (stateUpdaterFn: (oldState: GridState) => GridState) => {
       const newState = stateUpdaterFn(apiRef.current.state);
-      const hasChanged = apiRef.current.state !== newState;
-      if (!hasChanged) {
+      if (apiRef.current.state === newState) {
+        return false;
+      }
+
+      const { ignoreSetState, postUpdate } = apiRef.current.applyControlStateConstraint(newState);
+
+      if (!ignoreSetState) {
         // We always assign it as we mutate rows for perf reason.
         apiRef.current.state = newState;
-        return false;
+
+        if (apiRef.current.publishEvent) {
+          const params: GridStateChangeParams = { api: apiRef.current, state: newState };
+          apiRef.current.publishEvent(GRID_STATE_CHANGE, params);
+        }
       }
 
-      const { shouldUpdate, postUpdate } = apiRef.current.applyControlStateConstraint(newState);
+      postUpdate();
 
-      if (!shouldUpdate) {
-        return false;
-      }
-      // We always assign it as we mutate rows for perf reason.
-      apiRef.current.state = newState;
-
-      if (hasChanged && apiRef.current.publishEvent) {
-        const params: GridStateChangeParams = { api: apiRef.current, state: newState };
-        apiRef.current.publishEvent(GRID_STATE_CHANGE, params);
-
-        postUpdate();
-      }
-
-      return hasChanged;
+      return !ignoreSetState;
     },
     [apiRef],
   );

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -301,9 +301,7 @@ export const useGridFilter = (
       propModel: props.filterModel,
       propOnChange: props.onFilterModelChange,
       stateSelector: (state) => state.filter,
-      onChangeCallback: (model) => {
-        apiRef.current.publishEvent(GRID_FILTER_MODEL_CHANGE, model);
-      },
+      changeEvent: GRID_FILTER_MODEL_CHANGE,
     });
   }, [apiRef, props.filterModel, props.onFilterModelChange]);
 

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -308,9 +308,8 @@ export const useGridFilter = (
   }, [apiRef, props.filterModel, props.onFilterModelChange]);
 
   React.useEffect(() => {
-    const filterModel = props.filterModel;
-    if (filterModel && filterModel.items.length > 1) {
-      const hasItemsWithoutIds = filterModel.items.find((item) => item.id == null);
+    if (props.filterModel !== undefined && props.filterModel.items.length > 1) {
+      const hasItemsWithoutIds = props.filterModel.items.find((item) => item.id == null);
       if (hasItemsWithoutIds) {
         throw new Error(
           "The 'id' field is required on filterModel.items when you use multiple filters.",
@@ -318,7 +317,7 @@ export const useGridFilter = (
       }
     }
     const oldFilterModel = apiRef.current.state.filter;
-    if (filterModel && !isDeepEqual(filterModel, oldFilterModel)) {
+    if (props.filterModel !== undefined && props.filterModel !== oldFilterModel) {
       logger.debug('filterModel prop changed, applying filters');
       setGridState((state) => ({
         ...state,

--- a/packages/grid/_modules_/grid/hooks/features/pagination/useGridPage.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/useGridPage.ts
@@ -58,9 +58,7 @@ export const useGridPage = (
       propModel: props.page,
       propOnChange: props.onPageChange,
       stateSelector: (state) => state.pagination.page,
-      onChangeCallback: (page) => {
-        apiRef.current.publishEvent(GRID_PAGE_CHANGE, page);
-      },
+      changeEvent: GRID_PAGE_CHANGE,
     });
   }, [apiRef, props.page, props.onPageChange]);
 

--- a/packages/grid/_modules_/grid/hooks/features/pagination/useGridPageSize.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/useGridPageSize.ts
@@ -40,9 +40,7 @@ export const useGridPageSize = (
       propModel: props.pageSize,
       propOnChange: props.onPageSizeChange,
       stateSelector: (state) => state.pagination.pageSize,
-      onChangeCallback: (pageSize) => {
-        apiRef.current.publishEvent(GRID_PAGE_SIZE_CHANGE, pageSize);
-      },
+      changeEvent: GRID_PAGE_SIZE_CHANGE,
     });
   }, [apiRef, props.pageSize, props.onPageSizeChange]);
 

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridEditRows.ts
@@ -338,9 +338,7 @@ export function useGridEditRows(
       propModel: props.editRowsModel,
       propOnChange: props.onEditRowsModelChange,
       stateSelector: (state) => state.editRows,
-      onChangeCallback: (model: GridEditRowsModel) => {
-        apiRef.current.publishEvent(GRID_EDIT_ROWS_MODEL_CHANGE, model);
-      },
+      changeEvent: GRID_EDIT_ROWS_MODEL_CHANGE,
     });
   }, [apiRef, props.editRowsModel, props.onEditRowsModelChange]);
 }

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -142,9 +142,12 @@ export const useGridSelection = (apiRef: GridApiRef, props: GridComponentProps):
 
   const setSelectionModel = React.useCallback(
     (model: GridSelectionModel) => {
-      apiRef.current.selectRows(model, true, true);
+      const currentModel = apiRef.current.getState().selection;
+      if (currentModel !== model) {
+        setGridState((state) => ({ ...state, selection: model || [] }));
+      }
     },
-    [apiRef],
+    [setGridState, apiRef],
   );
 
   const handleRowClick = React.useCallback(
@@ -204,14 +207,11 @@ export const useGridSelection = (apiRef: GridApiRef, props: GridComponentProps):
   }, [rowsLookup, apiRef, setGridState, forceUpdate]);
 
   React.useEffect(() => {
-    // prop selectionModel changed
     if (props.selectionModel === undefined) {
       return;
     }
-    const currentModel = apiRef.current.getState().selection;
-    if (currentModel !== props.selectionModel) {
-      setGridState((state) => ({ ...state, selection: props.selectionModel || [] }));
-    }
+
+    apiRef.current.setSelectionModel(props.selectionModel);
   }, [apiRef, props.selectionModel, setGridState]);
 
   React.useEffect(() => {

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -180,9 +180,7 @@ export const useGridSelection = (apiRef: GridApiRef, props: GridComponentProps):
       propModel: props.selectionModel,
       propOnChange: props.onSelectionModelChange,
       stateSelector: gridSelectionStateSelector,
-      onChangeCallback: (model: GridSelectionModel) => {
-        apiRef.current.publishEvent(GRID_SELECTION_CHANGE, model);
-      },
+      changeEvent: GRID_SELECTION_CHANGE,
     });
   }, [apiRef, props.onSelectionModelChange, props.selectionModel]);
 

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -25,12 +25,11 @@ import {
 } from '../../../models/gridSortModel';
 import { isDesc, nextGridSortDirection } from '../../../utils/sortingUtils';
 import { isEnterKey } from '../../../utils/keyboardUtils';
-import { isDeepEqual } from '../../../utils/utils';
 import { useGridApiEventHandler } from '../../root/useGridApiEventHandler';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
 import { optionsSelector } from '../../utils/optionsSelector';
 import { useLogger } from '../../utils/useLogger';
-import { allGridColumnsSelector, visibleGridColumnsSelector } from '../columns/gridColumnsSelector';
+import { allGridColumnsSelector } from '../columns/gridColumnsSelector';
 import { useGridSelector } from '../core/useGridSelector';
 import { useGridState } from '../core/useGridState';
 import { gridRowCountSelector } from '../rows/gridRowsSelector';
@@ -44,7 +43,6 @@ export const useGridSorting = (
 
   const [gridState, setGridState, forceUpdate] = useGridState(apiRef);
   const options = useGridSelector(apiRef, optionsSelector);
-  const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
   const rowCount = useGridSelector(apiRef, gridRowCountSelector);
 
   const upsertSortModel = React.useCallback(
@@ -148,25 +146,25 @@ export const useGridSorting = (
   );
 
   const applySorting = React.useCallback(() => {
-    const rowIds = apiRef.current.getAllRowIds();
+    let sortedRows = apiRef.current.getAllRowIds();
 
     if (options.sortingMode === GridFeatureModeConstant.server) {
       logger.debug('Skipping sorting rows as sortingMode = server');
       setGridState((oldState) => {
         return {
           ...oldState,
-          sorting: { ...oldState.sorting, sortedRows: rowIds },
+          sorting: { ...oldState.sorting, sortedRows },
         };
       });
       return;
     }
 
     const sortModel = apiRef.current.getState().sorting.sortModel;
-    let sorted = rowIds;
+
     if (sortModel.length > 0) {
       const comparatorList = buildComparatorList(sortModel);
       logger.debug('Sorting rows with ', sortModel);
-      sorted = rowIds
+      sortedRows = sortedRows
         .map((id) => {
           return comparatorList.map((colComparator) => {
             return getSortCellParams(id, colComparator.field);
@@ -179,7 +177,7 @@ export const useGridSorting = (
     setGridState((oldState) => {
       return {
         ...oldState,
-        sorting: { ...oldState.sorting, sortedRows: sorted },
+        sorting: { ...oldState.sorting, sortedRows },
       };
     });
     forceUpdate();
@@ -197,17 +195,12 @@ export const useGridSorting = (
   const setSortModel = React.useCallback(
     (sortModel: GridSortModel) => {
       setGridState((oldState) => {
-        const sortingState = { ...oldState.sorting, sortModel };
-        return { ...oldState, sorting: { ...sortingState } };
+        return { ...oldState, sorting: { ...oldState.sorting, sortModel } };
       });
       forceUpdate();
-
-      if (visibleColumns.length === 0) {
-        return;
-      }
       apiRef.current.applySorting();
     },
-    [setGridState, forceUpdate, visibleColumns.length, apiRef],
+    [setGridState, forceUpdate, apiRef],
   );
 
   const sortColumn = React.useCallback(
@@ -328,12 +321,9 @@ export const useGridSorting = (
   }, [apiRef, props.sortModel, props.onSortModelChange]);
 
   React.useEffect(() => {
-    const sortModel = props.sortModel || [];
     const oldSortModel = apiRef.current.state.sorting.sortModel;
-    if (!isDeepEqual(sortModel, oldSortModel)) {
-      setGridState((state) => ({ ...state, sorting: { ...state.sorting, sortModel } }));
-      // we use apiRef to avoid watching setSortModel as it will trigger an update on every state change
-      apiRef.current.applySorting();
+    if (props.sortModel !== undefined && props.sortModel !== oldSortModel) {
+      setSortModel(props.sortModel);
     }
-  }, [props.sortModel, apiRef, setGridState]);
+  }, [props.sortModel, apiRef, setSortModel]);
 };

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -314,9 +314,7 @@ export const useGridSorting = (
       propModel: props.sortModel,
       propOnChange: props.onSortModelChange,
       stateSelector: (state) => state.sorting.sortModel,
-      onChangeCallback: (model) => {
-        apiRef.current.publishEvent(GRID_SORT_MODEL_CHANGE, model);
-      },
+      changeEvent: GRID_SORT_MODEL_CHANGE,
     });
   }, [apiRef, props.sortModel, props.onSortModelChange]);
 

--- a/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
@@ -1,5 +1,5 @@
 import { GridState } from '../../hooks/features/core/gridState';
-import { ControlStateItem } from '../controlStateItem';
+import { GridControlStateItem } from '../controlStateItem';
 
 /**
  * The control state API interface that is available in the grid `apiRef`.
@@ -7,10 +7,10 @@ import { ControlStateItem } from '../controlStateItem';
 export interface GridControlStateApi {
   /**
    * Updates a control state that binds the model, the onChange prop, and the grid state together.
-   * @param {ControlStateItem<TModel>} controlState The [[ControlStateItem]] to be registered.
+   * @param {GridControlStateItem<TModel>} controlState The [[GridControlStateItem]] to be registered.
    * @ignore - do not document.
    */
-  updateControlState: <TModel>(controlState: ControlStateItem<TModel>) => void;
+  updateControlState: <TModel>(controlState: GridControlStateItem<TModel>) => void;
   /**
    * Allows the internal grid state to apply the registered control state constraint.
    * @param {GridState} state The new modified state that would be the next if the state is not controlled.

--- a/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
@@ -14,11 +14,11 @@ export interface GridControlStateApi {
   /**
    * Allows the internal grid state to apply the registered control state constraint.
    * @param {GridState} state The new modified state that would be the next if the state is not controlled.
-   * @returns {shouldUpdate: boolean, postUpdate: () => void}, shouldUpdate let the state know if it should update, and postUpdate is a callback function triggered if the state has updated.
+   * @returns {ignoreSetState: boolean, postUpdate: () => void}, ignoreSetState let the state know if it should update, and postUpdate is a callback function triggered if the state has updated.
    * @ignore - do not document.
    */
   applyControlStateConstraint: (state: GridState) => {
-    shouldUpdate: boolean;
+    ignoreSetState: boolean;
     postUpdate: () => void;
   };
 }

--- a/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
@@ -14,7 +14,7 @@ export interface GridControlStateApi {
   /**
    * Allows the internal grid state to apply the registered control state constraint.
    * @param {GridState} state The new modified state that would be the next if the state is not controlled.
-   * @returns {ignoreSetState: boolean, postUpdate: () => void}, ignoreSetState let the state know if it should update, and postUpdate is a callback function triggered if the state has updated.
+   * @returns {{ ignoreSetState: boolean, postUpdate: () => void }} ignoreSetState let the state know if it should update, and postUpdate is a callback function triggered if the state has updated.
    * @ignore - do not document.
    */
   applyControlStateConstraint: (state: GridState) => {

--- a/packages/grid/_modules_/grid/models/controlStateItem.ts
+++ b/packages/grid/_modules_/grid/models/controlStateItem.ts
@@ -1,6 +1,6 @@
 import { GridState } from '../hooks/features/core/gridState';
 
-export interface ControlStateItem<TModel> {
+export interface GridControlStateItem<TModel> {
   stateId: string;
   propModel?: any;
   stateSelector: (state: GridState) => TModel;

--- a/packages/grid/_modules_/grid/models/controlStateItem.ts
+++ b/packages/grid/_modules_/grid/models/controlStateItem.ts
@@ -5,5 +5,5 @@ export interface GridControlStateItem<TModel> {
   propModel?: any;
   stateSelector: (state: GridState) => TModel;
   propOnChange?: (model: TModel) => void;
-  onChangeCallback?: (model: TModel) => void;
+  changeEvent: string;
 }

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -810,8 +810,9 @@ describe('<DataGrid /> - Filter', () => {
         },
       ],
       columns: [{ field: 'country' }],
+      field: 'country',
     });
-    expect(getColumnValues()).to.deep.equal(['France', 'UK', 'US']);
+    expect(getColumnValues()).to.deep.equal(['France']);
   });
 
   it('should translate operators dynamically in toolbar without crashing ', () => {

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { fireEvent, screen, createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { DataGrid } from '@material-ui/data-grid';
+import { DataGrid, GridSelectionModel } from '@material-ui/data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -266,11 +266,12 @@ describe('<DataGrid /> - Selection', () => {
           </div>
         );
       }
-      const { setProps } = render(<Demo selectionModel={0} />);
+      const selectionModel: GridSelectionModel = [0];
+      const { setProps } = render(<Demo selectionModel={selectionModel} />);
       expect(onSelectionModelChange.callCount).to.equal(0);
       const firstRow = getRow(0);
       expect(firstRow).to.have.class('Mui-selected');
-      setProps({ selectionModel: 0 });
+      setProps({ selectionModel });
       expect(onSelectionModelChange.callCount).to.equal(0);
       expect(getRow(0)).to.have.class('Mui-selected');
     });

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { fireEvent, screen, createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { DataGrid, GridSelectionModel } from '@material-ui/data-grid';
+import { DataGrid, DataGridProps } from '@material-ui/data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -266,7 +266,7 @@ describe('<DataGrid /> - Selection', () => {
           </div>
         );
       }
-      const selectionModel: GridSelectionModel = [0];
+      const selectionModel: DataGridProps['selectionModel'] = 0;
       const { setProps } = render(<Demo selectionModel={selectionModel} />);
       expect(onSelectionModelChange.callCount).to.equal(0);
       const firstRow = getRow(0);

--- a/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/filtering.XGrid.test.tsx
@@ -232,7 +232,6 @@ describe('<XGrid /> - Filter', () => {
     );
     expect(onFilterModelChange.callCount).to.equal(0);
     expect(getColumnValues()).to.deep.equal([]);
-    onFilterModelChange.callCount = 0;
 
     const select = screen.queryAllByRole('combobox', { name: /Operators/i })[1];
     fireEvent.change(select, { target: { value: 'or' } });

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -15,6 +15,7 @@ import {
   GridSelectionModel,
   useGridApiRef,
   XGrid,
+  GRID_SELECTION_CHANGE,
 } from '@material-ui/x-grid';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -322,6 +323,15 @@ describe('<XGrid /> - Selection', () => {
       expect(getRow(0)).not.to.have.class('Mui-selected');
       expect(getRow(1)).to.have.class('Mui-selected');
       expect(getRow(2)).to.have.class('Mui-selected');
+    });
+
+    it('should not publish GRID_SELECTION_CHANGE if the selection state did not change ', () => {
+      const handleSelectionChange = spy();
+      const selectionModel = [];
+      render(<Test selectionModel={selectionModel} />);
+      apiRef.current.subscribeEvent(GRID_SELECTION_CHANGE, handleSelectionChange);
+      apiRef.current.setSelectionModel(selectionModel);
+      expect(handleSelectionChange.callCount).to.equal(0);
     });
   });
 });

--- a/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.XGrid.test.tsx
@@ -70,11 +70,11 @@ describe('<XGrid /> - Selection', () => {
   };
 
   describe('getSelectedRows', () => {
-    it('should not change before onSelectionModelChange', () => {
+    it('should handle the event internally before triggering onSelectionModelChange', () => {
       render(
         <Test
           onSelectionModelChange={(model) => {
-            expect(apiRef!.current.getSelectedRows().size).to.equal(0);
+            expect(apiRef!.current.getSelectedRows().size).to.equal(1);
             expect(model).to.deep.equal([1]);
           }}
         />,


### PR DESCRIPTION
I have used #2200 as an entry to find myself interest in the controlled state. Along the way, I have noticed a couple of anti-patterns that I went on fixing:

- The presence of a onXXX prop shouldn't change the behavior of the state
- Using deepEqual to compare props is no longer relevant since we compare the reference in the useGridControlState
- The user's onXXX prop is supposed to be called after the component has handled the logic. It's how we aim to make it work in the core. It's not always possible, for instance, when we need to do `event.isMuiDefaultPrevented`.
- The event should be triggered, regardless of if the change was persisted in the state or not.
- Change the logic to have fewer branches