### PR TITLE
[DataGrid] Fix prop-type warning with v5

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
@@ -29,7 +29,7 @@ export function GridPanelWrapper(
     ? {
         getDoc: () => document,
       }
-    : {} as any;
+    : ({} as any);
 
   return (
     <TrapFocus open disableEnforceFocus isEnabled={isEnabled} {...extraProps}>

--- a/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
+++ b/packages/grid/_modules_/grid/components/panel/GridPanelWrapper.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import TrapFocus from '@material-ui/core/Unstable_TrapFocus';
 import { makeStyles } from '@material-ui/styles';
+import { getMuiVersion } from '../../utils';
 
 const useStyles = makeStyles(
   () => ({
@@ -24,8 +25,14 @@ export function GridPanelWrapper(
 ) {
   const classes = useStyles();
   const { className, ...other } = props;
+  const extraProps = getMuiVersion().startsWith('v4')
+    ? {
+        getDoc: () => document,
+      }
+    : {} as any;
+
   return (
-    <TrapFocus open disableEnforceFocus isEnabled={isEnabled} getDoc={() => document}>
+    <TrapFocus open disableEnforceFocus isEnabled={isEnabled} {...extraProps}>
       <div tabIndex={-1} className={clsx(classes.root, className)} {...other} />
     </TrapFocus>
   );

--- a/packages/grid/data-grid/README.md
+++ b/packages/grid/data-grid/README.md
@@ -19,7 +19,7 @@ This component has two peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+  "@material-ui/core": "^4.9.12 || ^5.0.0-beta.0",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -45,7 +45,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+    "@material-ui/core": "^4.9.12 || ^5.0.0-beta.0",
     "react": "^17.0.0"
   },
   "setupFiles": [

--- a/packages/grid/x-grid/README.md
+++ b/packages/grid/x-grid/README.md
@@ -19,7 +19,7 @@ This component has two peer dependencies that you will need to install as well.
 
 ```json
 "peerDependencies": {
-  "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+  "@material-ui/core": "^4.9.12 || ^5.0.0-beta.0",
   "react": "^17.0.0"
 },
 ```

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -46,7 +46,7 @@
     "reselect": "^4.0.0"
   },
   "peerDependencies": {
-    "@material-ui/core": "^4.9.12 || ^5.0.0-alpha.34",
+    "@material-ui/core": "^4.9.12 || ^5.0.0-beta.0",
     "react": "^17.0.0"
   },
   "setupFiles": [


### PR DESCRIPTION
Fix the warning visible in this reproduction: https://github.com/mui-org/material-ui-x/issues/2222#issuecomment-887474509.

<img width="490" alt="Capture d’écran 2021-07-27 à 16 28 47" src="https://user-images.githubusercontent.com/3165635/127172077-0b893ebd-0fff-44b8-9634-55ee6525bb2e.png">

https://codesandbox.io/s/blissful-herschel-xpm45?file=/src/Demo.tsx

It also improves cross-document support. Sebastian has figured out a smart way to remove the need for this `getDoc` prop in v5.