### PR TITLE
[XGrid] Fix width issue in FilterPopup

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterForm.tsx
@@ -34,7 +34,7 @@ const useStyles = makeStyles(
       padding: 8,
     },
     linkOperatorSelect: {
-      width: 60,
+      minWidth: 60,
     },
     columnSelect: {
       width: 150,
@@ -153,6 +153,7 @@ export function GridFilterForm(props: GridFilterFormProps) {
         </IconButton>
       </FormControl>
       <FormControl
+        variant="standard"
         className={classes.linkOperatorSelect}
         style={{
           display: hasMultipleFilters ? 'block' : 'none',


### PR DESCRIPTION
closes #2195 

From the [codesandbox reproduction](https://codesandbox.io/s/material-demo-forked-gbxtt?file=/demo.tsx:171-187), the select is hard to see because of default variant changed in core v5 and the style is fixed with `width`

**PR summary**
- force select variant to `standard` ([the default variant changed to `outlined` in core v5](https://next.material-ui.com/guides/migration-v4/#select))
- change `width` to `min-width` for future proof

I think there we should not force the width, instead make it flexible from the input (CSS Grid should do the job). Anyway, it is another step of improvement, wait to see the team's feedback first.

**Storybook screenshots**
<img width="595" alt="Screen Shot 2564-07-30 at 11 37 30" src="https://user-images.githubusercontent.com/18292247/127601216-fc2bea1c-4429-4c5e-b831-afd6a518888f.png">
<img width="602" alt="Screen Shot 2564-07-30 at 11 38 05" src="https://user-images.githubusercontent.com/18292247/127601183-5106222f-15f7-412b-acfb-aee3c644c3d0.png">
