### PR TITLE
[DataGrid] Fix renderCell returning false-ish values

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -178,7 +178,7 @@ export const GridCell = React.memo(function GridCell(props: GridCellProps) {
       tabIndex={tabIndex}
       {...eventsHandlers}
     >
-      {children || valueToRender?.toString()}
+      {children != null ? children : valueToRender?.toString()}
     </div>
   );
 });

--- a/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
@@ -4,6 +4,14 @@ import { renderBooleanCell } from '../../components/cell/GridBooleanCell';
 import { renderEditBooleanCell } from '../../components/cell/GridEditBooleanCell';
 import { gridNumberComparer } from '../../utils/sortingUtils';
 import { getGridBooleanOperators } from './gridBooleanOperators';
+import { GridValueFormatterParams } from '../params/gridCellParams';
+
+function gridBooleanFormatter({ value }: GridValueFormatterParams) {
+  if (typeof value === 'boolean') {
+    return value.toString();
+  }
+  return value;
+}
 
 export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   ...GRID_STRING_COL_DEF,
@@ -14,4 +22,5 @@ export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   renderEditCell: renderEditBooleanCell,
   sortComparator: gridNumberComparer,
   filterOperators: getGridBooleanOperators(),
+  valueFormatter: gridBooleanFormatter,
 };

--- a/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
@@ -4,14 +4,6 @@ import { renderBooleanCell } from '../../components/cell/GridBooleanCell';
 import { renderEditBooleanCell } from '../../components/cell/GridEditBooleanCell';
 import { gridNumberComparer } from '../../utils/sortingUtils';
 import { getGridBooleanOperators } from './gridBooleanOperators';
-import { GridValueFormatterParams } from '../params/gridCellParams';
-
-function gridBooleanFormatter({ value }: GridValueFormatterParams) {
-  if (typeof value === 'boolean') {
-    return value.toString();
-  }
-  return value;
-}
 
 export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   ...GRID_STRING_COL_DEF,
@@ -22,5 +14,4 @@ export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   renderEditCell: renderEditBooleanCell,
   sortComparator: gridNumberComparer,
   filterOperators: getGridBooleanOperators(),
-  valueFormatter: gridBooleanFormatter,
 };

--- a/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
@@ -63,4 +63,66 @@ describe('<DataGrid /> - Cells', () => {
     );
     expect(getCell(0, 0)).to.have.class('foobar');
   });
+
+  describe('type `boolean`', () => {
+    it('able to render number from provided `renderCell`', () => {
+      render(
+        <div style={{ width: 300, height: 500 }}>
+          <DataGrid
+            autoHeight={isJSDOM}
+            columns={[
+              {
+                field: 'number',
+                headerName: 'Number',
+                type: 'boolean',
+                renderCell: (params) => (params.value ? 1 : 0),
+              },
+            ]}
+            rows={[
+              {
+                id: 1,
+                number: false,
+              },
+              {
+                id: 2,
+                number: true,
+              },
+            ]}
+          />
+        </div>,
+      );
+      expect(getCell(0, 0)).to.have.text('0');
+      expect(getCell(1, 0)).to.have.text('1');
+    });
+
+    it('formattedValue to string by default', () => {
+      render(
+        <div style={{ width: 300, height: 500 }}>
+          <DataGrid
+            autoHeight={isJSDOM}
+            columns={[
+              {
+                field: 'text',
+                headerName: 'Text',
+                type: 'boolean',
+                renderCell: (params) => params.formattedValue,
+              },
+            ]}
+            rows={[
+              {
+                id: 1,
+                text: false,
+              },
+              {
+                id: 2,
+                text: true,
+              },
+            ]}
+          />
+        </div>,
+      );
+      expect(getCell(0, 0)).to.have.text('false');
+      expect(getCell(1, 0)).to.have.text('true');
+    });
+  });
 });

--- a/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
@@ -94,35 +94,5 @@ describe('<DataGrid /> - Cells', () => {
       expect(getCell(0, 0)).to.have.text('0');
       expect(getCell(1, 0)).to.have.text('1');
     });
-
-    it('formattedValue to string by default', () => {
-      render(
-        <div style={{ width: 300, height: 500 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            columns={[
-              {
-                field: 'text',
-                headerName: 'Text',
-                type: 'boolean',
-                renderCell: (params) => params.formattedValue,
-              },
-            ]}
-            rows={[
-              {
-                id: 1,
-                text: false,
-              },
-              {
-                id: 2,
-                text: true,
-              },
-            ]}
-          />
-        </div>,
-      );
-      expect(getCell(0, 0)).to.have.text('false');
-      expect(getCell(1, 0)).to.have.text('true');
-    });
   });
 });

--- a/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/cells.DataGrid.test.tsx
@@ -64,35 +64,16 @@ describe('<DataGrid /> - Cells', () => {
     expect(getCell(0, 0)).to.have.class('foobar');
   });
 
-  describe('type `boolean`', () => {
-    it('able to render number from provided `renderCell`', () => {
-      render(
-        <div style={{ width: 300, height: 500 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            columns={[
-              {
-                field: 'number',
-                headerName: 'Number',
-                type: 'boolean',
-                renderCell: (params) => (params.value ? 1 : 0),
-              },
-            ]}
-            rows={[
-              {
-                id: 1,
-                number: false,
-              },
-              {
-                id: 2,
-                number: true,
-              },
-            ]}
-          />
-        </div>,
-      );
-      expect(getCell(0, 0)).to.have.text('0');
-      expect(getCell(1, 0)).to.have.text('1');
-    });
+  it('should allow renderCell to return a false-ish value', () => {
+    render(
+      <div style={{ width: 300, height: 500 }}>
+        <DataGrid
+          autoHeight={isJSDOM}
+          columns={[{ field: 'brand', renderCell: () => 0 }]}
+          rows={[{ id: 1, brand: 'Nike' }]}
+        />
+      </div>,
+    );
+    expect(getCell(0, 0)).to.have.text('0');
   });
 });


### PR DESCRIPTION
closes #1849

- fix render `0` from renderCell. (`renderCell: () => 0` now show 0 on the screen)
- add default formatter to string for column type boolean. (`renderCell: params => params.formattedValue` now show `'true'` | `'false'` on the screen.
- add tests