### PR TITLE
[DataGrid] Fix filter with extended columns

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -88,7 +88,7 @@ function updateColumnsWidth(columns: GridColumns, viewportWidth: number): GridCo
 
 function hydrateColumns(
   columns: GridColumns,
-  columnTypes: GridColumnTypesRecord = {},
+  columnTypes: GridColumnTypesRecord,
   withCheckboxSelection: boolean,
   logger: Logger,
   getLocaleText: <T extends GridTranslationKeys>(key: T) => GridLocaleText[T],

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -22,7 +22,6 @@ import { Logger } from '../../../models/logger';
 import { GridColumnOrderChangeParams } from '../../../models/params/gridColumnOrderChangeParams';
 import { mergeGridColTypes } from '../../../utils/mergeUtils';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
-import { optionsSelector } from '../../utils/optionsSelector';
 import { useLogger } from '../../utils/useLogger';
 import { useGridSelector } from '../core/useGridSelector';
 import { GridLocaleText, GridTranslationKeys } from '../../../models/api/gridLocaleTextApi';
@@ -89,7 +88,7 @@ function updateColumnsWidth(columns: GridColumns, viewportWidth: number): GridCo
 
 function hydrateColumns(
   columns: GridColumns,
-  columnTypes: GridColumnTypesRecord,
+  columnTypes: GridColumnTypesRecord = {},
   withCheckboxSelection: boolean,
   logger: Logger,
   getLocaleText: <T extends GridTranslationKeys>(key: T) => GridLocaleText[T],
@@ -139,14 +138,16 @@ const upsertColumnsState = (
 
 export function useGridColumns(
   apiRef: GridApiRef,
-  props: Pick<GridComponentProps, 'columns' | 'onColumnVisibilityChange'>,
+  props: Pick<
+    GridComponentProps,
+    'columns' | 'onColumnVisibilityChange' | 'columnTypes' | 'checkboxSelection'
+  >,
 ): void {
   const logger = useLogger('useGridColumns');
   const [gridState, setGridState, forceUpdate] = useGridState(apiRef);
   const columnsMeta = useGridSelector(apiRef, gridColumnsMetaSelector);
   const allColumns = useGridSelector(apiRef, allGridColumnsSelector);
   const visibleColumns = useGridSelector(apiRef, visibleGridColumnsSelector);
-  const options = useGridSelector(apiRef, optionsSelector);
 
   const updateState = React.useCallback(
     (newState: GridInternalColumns, emit = true) => {
@@ -303,8 +304,8 @@ export function useGridColumns(
     if (props.columns.length > 0) {
       const hydratedColumns = hydrateColumns(
         props.columns,
-        options.columnTypes,
-        !!options.checkboxSelection,
+        props.columnTypes,
+        !!props.checkboxSelection,
         logger,
         apiRef.current.getLocaleText,
       );
@@ -318,8 +319,8 @@ export function useGridColumns(
     logger,
     apiRef,
     props.columns,
-    options.columnTypes,
-    options.checkboxSelection,
+    props.columnTypes,
+    props.checkboxSelection,
     updateState,
     setColumnsState,
   ]);

--- a/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
+++ b/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts
@@ -304,7 +304,7 @@ export function useGridColumns(
     if (props.columns.length > 0) {
       const hydratedColumns = hydrateColumns(
         props.columns,
-        props.columnTypes,
+        props.columnTypes!,
         !!props.checkboxSelection,
         logger,
         apiRef.current.getLocaleText,

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -65,6 +65,7 @@ describe('<DataGrid /> - Filter', () => {
     value?: any;
     field?: string;
     state?: any;
+    columnTypes?: any;
   }) => {
     const { operatorValue, value, rows, columns, field = 'brand', ...other } = props;
     return (
@@ -104,6 +105,23 @@ describe('<DataGrid /> - Filter', () => {
   it('should apply the filterModel prop correctly', () => {
     render(<TestCase value="a" operatorValue="contains" />);
     expect(getColumnValues()).to.deep.equal(['Adidas', 'Puma']);
+  });
+
+  it('should apply the filterModel prop correctly when filtering extended columns', () => {
+    render(
+      <TestCase
+        rows={[
+          { id: 0, price: 0 },
+          { id: 1, price: 1 },
+        ]}
+        columnTypes={{ price: { extendType: 'number' } }}
+        columns={[{ field: 'price', type: 'price' }]}
+        field="price"
+        value={1}
+        operatorValue="="
+      />,
+    );
+    expect(getColumnValues()).to.deep.equal(['1']);
   });
 
   it('should apply the filterModel prop correctly when row prop changes', () => {


### PR DESCRIPTION
Fixes #2225 
Preview: https://deploy-preview-2246--material-ui-x.netlify.app/components/data-grid/filtering/#extend-filter-operators

The fix is the same idea of #2213: use the props instead of the options.

The bug started to happen because in #1720 the filter hook was changed to get the `filterModel` from the props, instead of the options:

https://github.com/mui-org/material-ui-x/blob/4f52c84e104dd598e454e5d8d0c395c5aa3b7d54/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts#L323-L326

However, the hydration of the extended columns was still using the options:

https://github.com/mui-org/material-ui-x/blob/4f52c84e104dd598e454e5d8d0c395c5aa3b7d54/packages/grid/_modules_/grid/hooks/features/columns/useGridColumns.ts#L304-L306