### PR TITLE
[DataGrid] Add German (deDE) translation for export and isEmpty operator

### DIFF
--- a/packages/grid/_modules_/grid/locales/deDE.ts
+++ b/packages/grid/_modules_/grid/locales/deDE.ts
@@ -28,9 +28,9 @@ const deDEGrid: Partial<GridLocaleText> = {
     count !== 1 ? `${count} aktive Filter` : `${count} aktiver Filter`,
 
   // Export selector toolbar button text
-  // toolbarExport: 'Export',
-  // toolbarExportLabel: 'Export',
-  // toolbarExportCSV: 'Download as CSV',
+  toolbarExport: 'Exportieren',
+  toolbarExportLabel: 'Exportieren',
+  toolbarExportCSV: 'Download als CSV',
 
   // Columns panel text
   columnsPanelTextFieldLabel: 'Finde Spalte',
@@ -60,8 +60,8 @@ const deDEGrid: Partial<GridLocaleText> = {
   filterOperatorBefore: 'ist vor',
   filterOperatorOnOrBefore: 'ist an oder vor',
   filterOperatorAfter: 'ist nach',
-  // filterOperatorIsEmpty: 'is empty',
-  // filterOperatorIsNotEmpty: 'is not empty',
+  filterOperatorIsEmpty: 'ist leer',
+  filterOperatorIsNotEmpty: 'ist nicht leer',
 
   // Column menu text
   columnMenuLabel: 'Menü',


### PR DESCRIPTION
Add the missing deDE locale values for exporting and using the "is empty" and "is not empty" operators.