### PR TITLE
[DataGrid] Translate booleans when exporting to CSV

### DIFF
--- a/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
@@ -7,7 +7,9 @@ import { getGridBooleanOperators } from './gridBooleanOperators';
 import { GridValueFormatterParams } from '../params/gridCellParams';
 
 function gridBooleanFormatter({ value, api }: GridValueFormatterParams) {
-  return api.getLocaleText(value ? 'booleanCellTrueLabel' : 'booleanCellFalseLabel');
+  return value
+    ? api.getLocaleText('booleanCellTrueLabel')
+    : api.getLocaleText('booleanCellFalseLabel');
 }
 
 export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {

--- a/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
+++ b/packages/grid/_modules_/grid/models/colDef/gridBooleanColDef.tsx
@@ -4,6 +4,11 @@ import { renderBooleanCell } from '../../components/cell/GridBooleanCell';
 import { renderEditBooleanCell } from '../../components/cell/GridEditBooleanCell';
 import { gridNumberComparer } from '../../utils/sortingUtils';
 import { getGridBooleanOperators } from './gridBooleanOperators';
+import { GridValueFormatterParams } from '../params/gridCellParams';
+
+function gridBooleanFormatter({ value, api }: GridValueFormatterParams) {
+  return api.getLocaleText(value ? 'booleanCellTrueLabel' : 'booleanCellFalseLabel');
+}
 
 export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   ...GRID_STRING_COL_DEF,
@@ -13,5 +18,6 @@ export const GRID_BOOLEAN_COL_DEF: GridColTypeDef = {
   renderCell: renderBooleanCell,
   renderEditCell: renderEditBooleanCell,
   sortComparator: gridNumberComparer,
+  valueFormatter: gridBooleanFormatter,
   filterOperators: getGridBooleanOperators(),
 };

--- a/packages/grid/x-grid/src/tests/export.XGrid.test.tsx
+++ b/packages/grid/x-grid/src/tests/export.XGrid.test.tsx
@@ -380,5 +380,27 @@ describe('<XGrid /> - Export', () => {
         }),
       ).to.equal(['id,Brand', '0,Nike', '1,Adidas'].join('\r\n'));
     });
+
+    it('should work with booleans', () => {
+      const TestCaseCSVExport = () => {
+        apiRef = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <XGrid
+              {...baselineProps}
+              apiRef={apiRef}
+              localeText={{ booleanCellTrueLabel: 'Yes', booleanCellFalseLabel: 'No' }}
+              columns={[{ field: 'id' }, { field: 'isAdmin', type: 'boolean' }]}
+              rows={[
+                { id: 0, isAdmin: true },
+                { id: 1, isAdmin: false },
+              ]}
+            />
+          </div>
+        );
+      };
+      render(<TestCaseCSVExport />);
+      expect(apiRef.current.getDataAsCsv()).to.equal(['id,isAdmin', '0,Yes', '1,No'].join('\r\n'));
+    });
   });
 });


### PR DESCRIPTION
A quick follow-up from https://github.com/mui-org/material-ui-x/pull/2242#discussion_r679944486

Before: https://codesandbox.io/s/material-demo-forked-4bdf7?file=/demo.js
Export to CSV and check the "Is admin" column. It's "true" and "false" when it should be translated.

After: https://codesandbox.io/s/material-demo-forked-rmgvq?file=/demo.js
Export to CSV and check the "Is admin" column. It's correctly translated.