### PR TITLE
[docs] Fix page size warnings

### DIFF
--- a/docs/src/pages/components/data-grid/components/CustomPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/components/CustomPaginationGrid.js
@@ -37,6 +37,7 @@ export default function CustomPaginationGrid() {
       <DataGrid
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         components={{
           Pagination: CustomPagination,
         }}

--- a/docs/src/pages/components/data-grid/components/CustomPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/components/CustomPaginationGrid.tsx
@@ -37,6 +37,7 @@ export default function CustomPaginationGrid() {
       <DataGrid
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         components={{
           Pagination: CustomPagination,
         }}

--- a/docs/src/pages/components/data-grid/overview/DataGridDemo.js
+++ b/docs/src/pages/components/data-grid/overview/DataGridDemo.js
@@ -54,6 +54,7 @@ export default function DataGridDemo() {
         rows={rows}
         columns={columns}
         pageSize={5}
+        rowsPerPageOptions={[5]}
         checkboxSelection
         disableSelectionOnClick
       />

--- a/docs/src/pages/components/data-grid/overview/DataGridDemo.tsx
+++ b/docs/src/pages/components/data-grid/overview/DataGridDemo.tsx
@@ -54,6 +54,7 @@ export default function DataGridDemo() {
         rows={rows}
         columns={columns}
         pageSize={5}
+        rowsPerPageOptions={[5]}
         checkboxSelection
         disableSelectionOnClick
       />

--- a/docs/src/pages/components/data-grid/pagination/200PaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/200PaginationGrid.js
@@ -11,7 +11,7 @@ export default function BasisPaginationGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <XGrid pagination pageSize={200} {...data} />
+      <XGrid pagination pageSize={200} rowsPerPageOptions={[200]} {...data} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/pagination/200PaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/200PaginationGrid.tsx
@@ -11,7 +11,7 @@ export default function BasisPaginationGrid() {
 
   return (
     <div style={{ height: 400, width: '100%' }}>
-      <XGrid pagination pageSize={200} {...data} />
+      <XGrid pagination pageSize={200} rowsPerPageOptions={[200]} {...data} />
     </div>
   );
 }

--- a/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.js
@@ -25,7 +25,13 @@ export default function ApiRefPaginationGrid() {
         Set page 2
       </Button>
       <div style={{ height: 400, width: '100%', marginTop: 16 }}>
-        <XGrid pagination pageSize={5} apiRef={apiRef} {...data} />
+        <XGrid
+          pagination
+          pageSize={5}
+          rowsPerPageOptions={[5]}
+          apiRef={apiRef}
+          {...data}
+        />
       </div>
     </div>
   );

--- a/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx
@@ -25,7 +25,13 @@ export default function ApiRefPaginationGrid() {
         Set page 2
       </Button>
       <div style={{ height: 400, width: '100%', marginTop: 16 }}>
-        <XGrid pagination pageSize={5} apiRef={apiRef} {...data} />
+        <XGrid
+          pagination
+          pageSize={5}
+          rowsPerPageOptions={[5]}
+          apiRef={apiRef}
+          {...data}
+        />
       </div>
     </div>
   );

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.js
@@ -17,6 +17,7 @@ export default function ControlledPaginationGrid() {
         page={page}
         onPageChange={(newPage) => setPage(newPage)}
         pageSize={5}
+        rowsPerPageOptions={[5]}
         pagination
         {...data}
       />

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx
@@ -16,6 +16,7 @@ export default function ControlledPaginationGrid() {
         page={page}
         onPageChange={(newPage) => setPage(newPage)}
         pageSize={5}
+        rowsPerPageOptions={[5]}
         pagination
         {...data}
       />

--- a/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.js
@@ -73,6 +73,7 @@ export default function CursorPaginationGrid() {
         columns={data.columns}
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         rowCount={100}
         paginationMode="server"
         onPageChange={handlePageChange}

--- a/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.tsx
@@ -85,6 +85,7 @@ export default function CursorPaginationGrid() {
         columns={data.columns}
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         rowCount={100}
         paginationMode="server"
         onPageChange={handlePageChange}

--- a/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.js
+++ b/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.js
@@ -48,6 +48,7 @@ export default function ServerPaginationGrid() {
         columns={data.columns}
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         rowCount={100}
         paginationMode="server"
         onPageChange={(newPage) => setPage(newPage)}

--- a/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx
+++ b/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx
@@ -47,6 +47,7 @@ export default function ServerPaginationGrid() {
         columns={data.columns}
         pagination
         pageSize={5}
+        rowsPerPageOptions={[5]}
         rowCount={100}
         paginationMode="server"
         onPageChange={(newPage) => setPage(newPage)}

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.js
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.js
@@ -136,6 +136,7 @@ export default function AntDesignGrid() {
         className={classes.root}
         checkboxSelection
         pageSize={5}
+        rowsPerPageOptions={[5]}
         components={{
           Pagination: CustomPagination,
         }}

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
@@ -136,6 +136,7 @@ export default function AntDesignGrid() {
         className={classes.root}
         checkboxSelection
         pageSize={5}
+        rowsPerPageOptions={[5]}
         components={{
           Pagination: CustomPagination,
         }}


### PR DESCRIPTION
We forgot about this in #2014

Open http://0.0.0.0:3001/components/data-grid/ in dev mode:

<img width="580" alt="Capture d’écran 2021-08-07 à 18 29 58" src="https://user-images.githubusercontent.com/3165635/128607349-22abbccd-d8ed-4f03-9b14-989ad264cde6.png">

Our regression tests run all the demos an fail the CI when a warning is raised, unfortunately, we run the regression test in production mode, so no warning is thrown.

---

Next

- [ ] Fix the demo in the core @flaviendelangle Do you want to own it?