### PR TITLE
[DataGrid] Improve error message if using multiple versions of data grid

### DIFF
--- a/packages/grid/_modules_/grid/hooks/root/useGridApiContext.ts
+++ b/packages/grid/_modules_/grid/hooks/root/useGridApiContext.ts
@@ -9,6 +9,7 @@ export function useGridApiContext() {
       [
         'Material-UI X: Could not find the data grid context.',
         'It looks like you rendered your component outside of a DataGrid or XGrid parent component.',
+        'This can also happen if you are bundling multiple versions of the data grid.',
       ].join('\n'),
     );
   }


### PR DESCRIPTION
Fix on the surface on #2245 

I tried to add the following test case but it is not working. Not sure what am I missing.

```jsx
import { GridApiRef, useGridApiRef, XGrid, ptBR } from '@material-ui/x-grid';
import { GridToolbarFilterButton, GridToolbarDensitySelector } from '@material-ui/data-grid'
--
--
it('should throw error if multiple versions of data grid is being used', () => {
    expect(() => {
      function CustomToolbar() {
        return (
          <div>
            {/* imported from '@material-ui/data-grid' but using in XGrid */}
            <GridToolbarFilterButton />
            <GridToolbarDensitySelector />
          </div>
        );
      }
      render(
        <div style={{ width: 300, height: 300 }}>
          <XGrid {...baselineProps} components={{ Toolbar: CustomToolbar }} />
        </div>,
      );
    }).to.throw();
  });
```