### PR TITLE
[DataGrid] Remove unused row CSS classes

### DIFF
--- a/packages/grid/_modules_/grid/components/GridRow.tsx
+++ b/packages/grid/_modules_/grid/components/GridRow.tsx
@@ -11,13 +11,12 @@ import { optionsSelector } from '../hooks/utils/optionsSelector';
 export interface GridRowProps {
   id: GridRowId;
   selected: boolean;
-  className: string;
   rowIndex: number;
   children: React.ReactNode;
 }
 
 export function GridRow(props: GridRowProps) {
-  const { selected, id, className, rowIndex, children } = props;
+  const { selected, id, rowIndex, children } = props;
   const ariaRowIndex = rowIndex + 2; // 1 for the header row and 1 as it's 1 based
   const apiRef = useGridApiContext();
   const rowHeight = useGridSelector(apiRef, gridDensityRowHeightSelector);
@@ -59,7 +58,7 @@ export function GridRow(props: GridRowProps) {
 
   const rowClassName =
     isFunction(getRowClassName) && getRowClassName(apiRef!.current.getRowParams(id));
-  const cssClasses = clsx(className, rowClassName, classes?.row, {
+  const cssClasses = clsx(rowClassName, classes?.row, {
     'Mui-selected': selected,
   });
 

--- a/packages/grid/_modules_/grid/components/GridViewport.tsx
+++ b/packages/grid/_modules_/grid/components/GridViewport.tsx
@@ -56,9 +56,6 @@ export const GridViewport: ViewportType = React.forwardRef<HTMLDivElement, {}>(
 
       return renderedRows.map(([id, row], idx) => (
         <GridRow
-          className={
-            (renderState.renderContext!.firstRowIdx! + idx) % 2 === 0 ? 'Mui-even' : 'Mui-odd'
-          }
           key={id}
           id={id}
           selected={selectionLookup[id] !== undefined}


### PR DESCRIPTION
### Breaking changes

- [DataGrid] The CSS classes `.Mui-odd` and `.Mui-even` were removed from the row. Use the `:nth-child(odd|even)` selector to replace them.

---

While looking at bug #2315 which is unexpectedly on a large scope due to virutalization case to be considered for last row, I noticed this line is not being used. 

So removed `Mui-even` and `Mui-odd` classes.

Perhaps it is added so that it can be targeted via CSS like `& .Mui-even`, `& .Mui-odd`. If yes, I think we can rename it to `MuiDataGrid-odd` and `MuiDataGrid-even` and also document it. 

If its relevant, we can close this PR.