### PR TITLE
[DataGrid] Don't apply `box-sizing: border-box` on everything

### DIFF
--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -23,9 +23,6 @@ export const useStyles = makeStyles(
         height: '100%',
         display: 'flex',
         flexDirection: 'column',
-        '& *, & *::before, & *::after': {
-          boxSizing: 'inherit',
-        },
         '&.MuiDataGrid-autoHeight': {
           height: 'auto',
         },
@@ -88,6 +85,7 @@ export const useStyles = makeStyles(
           WebkitTapHighlightColor: 'transparent',
           lineHeight: null,
           padding: '0 10px',
+          boxSizing: 'border-box',
         },
         '& .MuiDataGrid-columnHeader:focus-within, & .MuiDataGrid-cell:focus-within': {
           outline: `solid ${muiStyleAlpha(theme.palette.primary.main, 0.5)} 1px`,


### PR DESCRIPTION
Fixes #2183

The differences pointed by argos is because the Select (rows per page) and the InputBase (quick filter) set different values for `box-sizing`, but previously these values were being forced to be `border-box`. 