### PR TITLE
[docs] Remove legacy logic

### DIFF
--- a/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.js
+++ b/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.js
@@ -9,16 +9,11 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-// TODO v5: remove
-function getThemePaletteMode(palette) {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme) => {
     const backgroundColor =
-      getThemePaletteMode(theme.palette) === 'dark' ? '#376331' : 'rgb(217 243 190)';
+      theme.palette.mode === 'dark' ? '#376331' : 'rgb(217 243 190)';
     return {
       root: {
         '& .MuiDataGrid-cell--editable': {

--- a/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.tsx
@@ -9,16 +9,11 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-// TODO v5: remove
-function getThemePaletteMode(palette: any): string {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme: Theme) => {
     const backgroundColor =
-      getThemePaletteMode(theme.palette) === 'dark' ? '#376331' : 'rgb(217 243 190)';
+      theme.palette.mode === 'dark' ? '#376331' : 'rgb(217 243 190)';
     return {
       root: {
         '& .MuiDataGrid-cell--editable': {

--- a/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.js
+++ b/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.js
@@ -10,15 +10,10 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-// TODO v5: remove
-function getThemePaletteMode(palette) {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme) => {
-    const isDark = getThemePaletteMode(theme.palette) === 'dark';
+    const isDark = theme.palette.mode === 'dark';
 
     return {
       root: {

--- a/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx
@@ -15,15 +15,10 @@ import {
   randomUpdatedDate,
 } from '@material-ui/x-grid-data-generator';
 
-// TODO v5: remove
-function getThemePaletteMode(palette: any): string {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme: Theme) => {
-    const isDark = getThemePaletteMode(theme.palette) === 'dark';
+    const isDark = theme.palette.mode === 'dark';
 
     return {
       root: {

--- a/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.js
+++ b/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.js
@@ -4,15 +4,10 @@ import { createTheme } from '@material-ui/core/styles';
 import { makeStyles } from '@material-ui/styles';
 import { useGridApiRef, XGrid } from '@material-ui/x-grid';
 
-// TODO v5: remove
-function getThemePaletteMode(palette) {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme) => {
-    const isDark = getThemePaletteMode(theme.palette) === 'dark';
+    const isDark = theme.palette.mode === 'dark';
 
     return {
       root: {

--- a/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx
@@ -10,15 +10,10 @@ import {
   XGrid,
 } from '@material-ui/x-grid';
 
-// TODO v5: remove
-function getThemePaletteMode(palette: any): string {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme: Theme) => {
-    const isDark = getThemePaletteMode(theme.palette) === 'dark';
+    const isDark = theme.palette.mode === 'dark';
 
     return {
       root: {

--- a/docs/src/pages/components/data-grid/style/StylingRowsGrid.js
+++ b/docs/src/pages/components/data-grid/style/StylingRowsGrid.js
@@ -4,23 +4,14 @@ import { useDemoData } from '@material-ui/x-grid-data-generator';
 import { createTheme, darken, lighten } from '@material-ui/core/styles';
 import { makeStyles } from '@material-ui/styles';
 
-// TODO v5: remove
-function getThemePaletteMode(palette) {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme) => {
     const getBackgroundColor = (color) =>
-      getThemePaletteMode(theme.palette) === 'dark'
-        ? darken(color, 0.6)
-        : lighten(color, 0.6);
+      theme.palette.mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
     const getHoverBackgroundColor = (color) =>
-      getThemePaletteMode(theme.palette) === 'dark'
-        ? darken(color, 0.5)
-        : lighten(color, 0.5);
+      theme.palette.mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
 
     return {
       root: {

--- a/docs/src/pages/components/data-grid/style/StylingRowsGrid.tsx
+++ b/docs/src/pages/components/data-grid/style/StylingRowsGrid.tsx
@@ -4,23 +4,14 @@ import { useDemoData } from '@material-ui/x-grid-data-generator';
 import { createTheme, darken, lighten, Theme } from '@material-ui/core/styles';
 import { makeStyles } from '@material-ui/styles';
 
-// TODO v5: remove
-function getThemePaletteMode(palette: any): string {
-  return palette.type || palette.mode;
-}
-
 const defaultTheme = createTheme();
 const useStyles = makeStyles(
   (theme: Theme) => {
     const getBackgroundColor = (color) =>
-      getThemePaletteMode(theme.palette) === 'dark'
-        ? darken(color, 0.6)
-        : lighten(color, 0.6);
+      theme.palette.mode === 'dark' ? darken(color, 0.6) : lighten(color, 0.6);
 
     const getHoverBackgroundColor = (color) =>
-      getThemePaletteMode(theme.palette) === 'dark'
-        ? darken(color, 0.5)
-        : lighten(color, 0.5);
+      theme.palette.mode === 'dark' ? darken(color, 0.5) : lighten(color, 0.5);
 
     return {
       root: {


### PR DESCRIPTION
Since #2281, the demos break on `createTheme()` for developers that uses core < v4.12.0 so we might as well remove the rest.