### PR TITLE
[docs] Fix docs links and pagination sentence

### DIFF
--- a/docs/src/pages/components/data-grid/components/components.md
+++ b/docs/src/pages/components/data-grid/components/components.md
@@ -9,7 +9,7 @@ title: Data Grid - Components
 ## Overriding components
 
 As part of the customization API, the grid allows you to override internal components with the `components` prop.
-The prop accepts an object of type [`GridSlotsComponent`](/api/data-grid/#slots).
+The prop accepts an object of type [`GridSlotsComponent`](/api/data-grid/data-grid/#slots).
 
 If you wish to pass additional props in a component slot, you can do it using the `componentsProps` prop. This prop is of type `GridSlotsComponentsProps`.
 
@@ -54,7 +54,7 @@ function CustomRowCounter() {
 
 ## Components
 
-The full list of overridable components can be found on the [`GridSlotsComponent`](/api/data-grid/#slots) API page.
+The full list of overridable components can be found on the [`GridSlotsComponent`](/api/data-grid/data-grid/#slots) API page.
 
 ### Column menu
 

--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -75,7 +75,7 @@ To validate the value in the cells, use `onEditRowsModelChange` to set the `erro
 If this attribute is true, the value will never be commited.
 This prop is invoked when a change is triggered by the edit cell component.
 
-Alternatively, you can use the `GridEditRowsModel` state mentioned in the [Control editing](#controlled-editing) section.
+Alternatively, you can use the `GridEditRowsModel` state mentioned in the [Controlled editing](#controlled-editing) section.
 
 {{"demo": "pages/components/data-grid/editing/ValidateRowModelControlGrid.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -75,13 +75,13 @@ To validate the value in the cells, use `onEditRowsModelChange` to set the `erro
 If this attribute is true, the value will never be commited.
 This prop is invoked when a change is triggered by the edit cell component.
 
-Alternatively, you can use the `GridEditRowsModel` state mentioned in the [Control editing](#control-editing) section.
+Alternatively, you can use the `GridEditRowsModel` state mentioned in the [Control editing](#controlled-editing) section.
 
 {{"demo": "pages/components/data-grid/editing/ValidateRowModelControlGrid.js", "bg": "inline"}}
 
 ### Server-side validation
 
-Server-side validation works like client-side [validation](#validation).
+Server-side validation works like client-side [validation](#client-side-validation).
 
 - Use `onEditCellPropsChange` to set the `error` attribute to true of the respective field which will be validated.
 - Validate the value in the server.

--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -38,7 +38,7 @@ By default, this feature is off.
 
 By default, pagination works on the client-side.
 To switch it to server-side, set `paginationMode="server"`.
-You also need to set the `rowCount` prop to so the grid know the total number of pages.
+You also need to set the `rowCount` prop so that the grid knows the total number of pages.
 Finally, you need to handle the `onPageChange` callback to load the rows for the corresponding page.
 
 {{"demo": "pages/components/data-grid/pagination/ServerPaginationGrid.js", "bg": "inline"}}


### PR DESCRIPTION
Just a few small fixes in docs.

Preview: 
https://deploy-preview-2381--material-ui-x.netlify.app/components/data-grid/components
https://deploy-preview-2381--material-ui-x.netlify.app/components/data-grid/editing
https://deploy-preview-2381--material-ui-x.netlify.app/components/data-grid/pagination/#server-side-pagination
