### PR TITLE
[docs] Fix docs for `onEditRowsModelChange` prop

### DIFF
--- a/docs/pages/api-docs/data-grid/data-grid-pro.md
+++ b/docs/pages/api-docs/data-grid/data-grid-pro.md
@@ -92,7 +92,7 @@ The name <code>MuiDataGridPro</code> can be used when providing [default props](
 | <span class="prop-name">onRowEditCommit</span> | <span class="prop-type">(id: GridRowId, event: MouseEvent<React.SyntheticEvent>) => void</span> |   | Callback fired when the row changes are committed. |
 | <span class="prop-name">onRowEditStart</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to edit mode. |
 | <span class="prop-name">onRowEditStop</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to view mode. |
-| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |   Callback fired when the `editRowsModel` changes. |
+| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |  Callback fired when the `editRowsModel` changes. |
 | <span class="prop-name">onFilterModelChange</span> | <span class="prop-type">(model: GridFilterModel) => void</span> |   | Callback fired when the Filter model changes before the filters are applied. |
 | <span class="prop-name">onPageChange</span> | <span class="prop-type">(page: number) => void</span> |   | Callback fired when the current page has changed. |
 | <span class="prop-name">onPageSizeChange</span> | <span class="prop-type">(pageSize: number) => void</span> |   | Callback fired when the page size has changed. |

--- a/docs/pages/api-docs/data-grid/data-grid-pro.md
+++ b/docs/pages/api-docs/data-grid/data-grid-pro.md
@@ -92,7 +92,7 @@ The name <code>MuiDataGridPro</code> can be used when providing [default props](
 | <span class="prop-name">onRowEditCommit</span> | <span class="prop-type">(id: GridRowId, event: MouseEvent<React.SyntheticEvent>) => void</span> |   | Callback fired when the row changes are committed. |
 | <span class="prop-name">onRowEditStart</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to edit mode. |
 | <span class="prop-name">onRowEditStop</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to view mode. |
-| <span class="prop-name">onEditRowModelChange</span> | <span class="prop-type">(params: GridEditRowModelParams) => void</span> |   |  Callback fired when the EditRowModel changed. |
+| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |   Callback fired when the `editRowsModel` changes. |
 | <span class="prop-name">onFilterModelChange</span> | <span class="prop-type">(model: GridFilterModel) => void</span> |   | Callback fired when the Filter model changes before the filters are applied. |
 | <span class="prop-name">onPageChange</span> | <span class="prop-type">(page: number) => void</span> |   | Callback fired when the current page has changed. |
 | <span class="prop-name">onPageSizeChange</span> | <span class="prop-type">(pageSize: number) => void</span> |   | Callback fired when the page size has changed. |

--- a/docs/pages/api-docs/data-grid/data-grid.md
+++ b/docs/pages/api-docs/data-grid/data-grid.md
@@ -85,7 +85,7 @@ The name <code>MuiDataGrid</code> can be used when providing [default props](/cu
 | <span class="prop-name">onRowEditCommit</span> | <span class="prop-type">(id: GridRowId, event: MouseEvent<React.SyntheticEvent>) => void</span> |   | Callback fired when the row changes are committed. |
 | <span class="prop-name">onRowEditStart</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to edit mode. |
 | <span class="prop-name">onRowEditStop</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to view mode. |
-| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |   Callback fired when the `editRowsModel` changes. |
+| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |  Callback fired when the `editRowsModel` changes. |
 | <span class="prop-name">onFilterModelChange</span> | <span class="prop-type">(model: GridFilterModel) => void</span> |   | Callback fired when the Filter model changes before the filters are applied. |
 | <span class="prop-name">onPageChange</span> | <span class="prop-type">(page: number) => void</span> |   | Callback fired when the current page has changed. |
 | <span class="prop-name">onPageSizeChange</span> | <span class="prop-type">(pageSize: number) => void</span> |   | Callback fired when the page size has changed. |

--- a/docs/pages/api-docs/data-grid/data-grid.md
+++ b/docs/pages/api-docs/data-grid/data-grid.md
@@ -85,7 +85,7 @@ The name <code>MuiDataGrid</code> can be used when providing [default props](/cu
 | <span class="prop-name">onRowEditCommit</span> | <span class="prop-type">(id: GridRowId, event: MouseEvent<React.SyntheticEvent>) => void</span> |   | Callback fired when the row changes are committed. |
 | <span class="prop-name">onRowEditStart</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to edit mode. |
 | <span class="prop-name">onRowEditStop</span> | <span class="prop-type">(params: GridRowParams, event: React.SyntheticEvent) => void</span> |   | Callback fired when the row turns to view mode. |
-| <span class="prop-name">onEditRowModelChange</span> | <span class="prop-type">(params: GridEditRowModelParams) => void</span> |   |  Callback fired when the EditRowModel changed. |
+| <span class="prop-name">onEditRowsModelChange</span> | <span class="prop-type">(editRowsModel: GridEditRowsModel, details?: any) => void</span> |   |   Callback fired when the `editRowsModel` changes. |
 | <span class="prop-name">onFilterModelChange</span> | <span class="prop-type">(model: GridFilterModel) => void</span> |   | Callback fired when the Filter model changes before the filters are applied. |
 | <span class="prop-name">onPageChange</span> | <span class="prop-type">(page: number) => void</span> |   | Callback fired when the current page has changed. |
 | <span class="prop-name">onPageSizeChange</span> | <span class="prop-type">(pageSize: number) => void</span> |   | Callback fired when the page size has changed. |

--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -137,7 +137,7 @@ export interface GridOptions {
    */
   editRowsModel?: GridEditRowsModel;
   /**
-   * Callback fired when the EditRowModel changes.
+   * Callback fired when the `editRowsModel` changes.
    * @param {GridEditRowsModel} editRowsModel With all properties from [[GridEditRowsModel]].
    * @param {GridCallbackDetails} details Additional details for this callback.
    */


### PR DESCRIPTION
Noticed while looking at the row editing feature which looks awesome! And yes we need the auto docs generator like the core repo soon. 

Prop was changed in #2143 