### PR TITLE
[docs] Add `Row & Cell editing` in features list

### DIFF
--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -71,6 +71,7 @@ We provide three options:
 - High performance 🚀
 - [Filtering](/components/data-grid/filtering/) and [multi-filtering](/components/data-grid/filtering/#multi-column-filtering) <span class="pro"></span>
 - [Pagination](/components/data-grid/pagination/)
+- [Editing](/components/data-grid/editing/)
 - [Sorting](/components/data-grid/sorting) and [multi-sort](/components/data-grid/sorting/#multi-column-sorting) <span class="pro"></span>
 - [Selection](/components/data-grid/selection/)
 - [Column virtualization](/components/data-grid/virtualization/#column-virtualization) and [rows virtualization](/components/data-grid/virtualization/#row-virtualization) <span class="pro"></span>

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -71,7 +71,7 @@ We provide three options:
 - High performance 🚀
 - [Filtering](/components/data-grid/filtering/) and [multi-filtering](/components/data-grid/filtering/#multi-column-filtering) <span class="pro"></span>
 - [Pagination](/components/data-grid/pagination/)
-- [Editing](/components/data-grid/editing/)
+- [Row & Cell editing](/components/data-grid/editing/)
 - [Sorting](/components/data-grid/sorting) and [multi-sort](/components/data-grid/sorting/#multi-column-sorting) <span class="pro"></span>
 - [Selection](/components/data-grid/selection/)
 - [Column virtualization](/components/data-grid/virtualization/#column-virtualization) and [rows virtualization](/components/data-grid/virtualization/#row-virtualization) <span class="pro"></span>


### PR DESCRIPTION
Maybe not that important, but since we are completed with row and cell editing, thought we can promote `Editing` as a feature.

In docs rearranging (part of  #2313), we need to change these as well or maybe there will be a re-direct rule.

Preview: https://deploy-preview-2396--material-ui-x.netlify.app/components/data-grid/#features