### PR TITLE
[DataGrid] Fix navigation between column headers with rows filtered

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -193,7 +193,7 @@ export const useGridKeyboardNavigation = (
 
       if (!nextColumnHeaderIndexes) {
         const field = apiRef.current.getVisibleColumns()[colIndex].field;
-        const id = apiRef.current.getRowIdFromRowIndex(0);
+        const [id] = visibleSortedRowsAsArray[0];
         apiRef.current.setCellFocus(id, field);
         return;
       }
@@ -209,7 +209,7 @@ export const useGridKeyboardNavigation = (
       const field = apiRef.current.getVisibleColumns()[nextColumnHeaderIndexes.colIndex].field;
       apiRef.current.setColumnHeaderFocus(field, event);
     },
-    [apiRef, colCount, containerSizes, logger],
+    [apiRef, colCount, containerSizes, logger, visibleSortedRowsAsArray],
   );
 
   useGridApiEventHandler(apiRef, GridEvents.cellNavigationKeyDown, navigateCells);

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -215,6 +215,25 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(getActiveCell()).to.equal('0-0');
   });
 
+  it('should navigate between column headers with arrows when rows are filtered', () => {
+    render(
+      <KeyboardTest
+        nbRows={10}
+        filterModel={{ items: [{ columnField: 'id', value: 1, operatorValue: '>' }] }}
+      />,
+    );
+    getCell(0, 0).focus();
+    expect(getActiveCell()).to.equal('0-0');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(getActiveColumnHeader()).to.equal('1');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowRight' });
+    expect(getActiveColumnHeader()).to.equal('2');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowLeft' });
+    expect(getActiveColumnHeader()).to.equal('1');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    expect(getActiveCell()).to.equal('0-0');
+  });
+
   it('should scroll horizontally when navigating between column headers with arrows', function test() {
     if (isJSDOM) {
       // Need layouting for column virtualization


### PR DESCRIPTION
A follow-up from #2336.

The same problem from #2335 was happening with the column headers too. To reproduce it apply a filter, then navigate with the keyboard between the column headers and the rows.