### PR TITLE
[test] Clean selection tests 

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -236,6 +236,7 @@ export const useGridSelection = (apiRef: GridApiRef, props: GridComponentProps):
           hasChanged = true;
         }
       });
+
       if (hasChanged) {
         return { ...state, selection: Object.values(selectionLookup) };
       }

--- a/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/pagination.DataGrid.test.tsx
@@ -34,7 +34,7 @@ describe('<DataGrid /> - Pagination', () => {
     );
   };
 
-  describe('prop: page and onPageChange', () => {
+  describe('props: page and onPageChange', () => {
     it('should display the rows of page given in props', () => {
       render(<BaselineTestCase page={1} pageSize={1} rowsPerPageOptions={[1]} />);
       expect(getColumnValues()).to.deep.equal(['1']);
@@ -200,7 +200,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
   });
 
-  describe('prop: pageSize and onPageSizeChange', () => {
+  describe('props: pageSize and onPageSizeChange', () => {
     it('should display the amount of rows given in props', () => {
       render(<BaselineTestCase page={0} pageSize={2} rowsPerPageOptions={[2]} />);
       expect(getColumnValues()).to.deep.equal(['0', '1']);
@@ -359,7 +359,7 @@ describe('<DataGrid /> - Pagination', () => {
     });
   });
 
-  describe('prop: autoPageSize', () => {
+  describe('props: autoPageSize', () => {
     before(function beforeHook() {
       if (isJSDOM) {
         // Need layouting

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -30,7 +30,7 @@ describe('<DataGrid /> - Selection', () => {
   };
 
   describe('no checkboxSelection prop - selection/deselection', () => {
-    it('should select one row at a time on click WITHOUT ctrl or meta keypress', () => {
+    it('should select one row at a time on click WITHOUT ctrl or meta pressed', () => {
       render(<TestDataGridSelection />);
       const firstRow = getRow(0);
       const secondRow = getRow(1);

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -6,6 +6,8 @@ import { DataGrid, DataGridProps } from '@mui/x-data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
 import { useData } from 'storybook/src/hooks/useData';
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
@@ -16,9 +18,13 @@ describe('<DataGrid /> - Selection', () => {
   ) => {
     const data = useData(2, 2);
 
+    if (!data.rows.length) {
+      return null;
+    }
+
     return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid {...data} {...props} />
+        <DataGrid {...data} {...props} autoHeight={isJSDOM} />
       </div>
     );
   };

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -2,36 +2,29 @@ import * as React from 'react';
 // @ts-expect-error need to migrate helpers to TypeScript
 import { fireEvent, screen, createClientRenderStrictMode } from 'test/utils';
 import { expect } from 'chai';
-import { spy } from 'sinon';
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, DataGridProps } from '@mui/x-data-grid';
 import { getCell, getRow } from 'test/utils/helperFn';
-
-const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+import { useData } from 'storybook/src/hooks/useData';
 
 describe('<DataGrid /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
 
-  describe('no checkboxSelection prop - selection/deselection', () => {
-    const TestDataGridSelection = () => (
+  const TestDataGridSelection = (
+    props: Omit<DataGridProps, 'rows' | 'columns'> &
+      Partial<Pick<DataGridProps, 'rows' | 'columns'>>,
+  ) => {
+    const data = useData(2, 2);
+
+    return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGrid
-          rows={[
-            {
-              id: 0,
-              brand: 'Nike',
-            },
-            {
-              id: 1,
-              brand: 'Adidas',
-            },
-          ]}
-          columns={[{ field: 'brand', width: 100 }]}
-        />
+        <DataGrid {...data} {...props} />
       </div>
     );
+  };
 
-    it('should select one row at a time on click WITHOUT keypress', () => {
+  describe('no checkboxSelection prop - selection/deselection', () => {
+    it('should select one row at a time on click WITHOUT ctrl or meta keypress', () => {
       render(<TestDataGridSelection />);
       const firstRow = getRow(0);
       const secondRow = getRow(1);
@@ -64,7 +57,7 @@ describe('<DataGrid /> - Selection', () => {
       });
     });
 
-    it('should not deselect the selected row on click WITHOUT keypress', () => {
+    it('should not deselect the selected row on click WITHOUT meta or ctrl keypress', () => {
       render(<TestDataGridSelection />);
       const firstRow = getRow(0);
       fireEvent.click(getCell(0, 0));
@@ -76,59 +69,23 @@ describe('<DataGrid /> - Selection', () => {
 
   describe('prop: checkboxSelection', () => {
     it('should check and uncheck when double clicking the row', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            checkboxSelection
-            hideFooter
-          />
-        </div>,
-      );
+      render(<TestDataGridSelection checkboxSelection />);
       const row = getRow(0);
       const checkbox = row!.querySelector('input');
       expect(row).not.to.have.class('Mui-selected');
       expect(checkbox).to.have.property('checked', false);
 
-      fireEvent.click(screen.getByRole('cell', { name: 'Nike' }));
+      fireEvent.click(getCell(0, 0));
       expect(row!.classList.contains('Mui-selected')).to.equal(true, 'class mui-selected 1');
       expect(checkbox).to.have.property('checked', true);
 
-      fireEvent.click(screen.getByRole('cell', { name: 'Nike' }));
+      fireEvent.click(getCell(0, 0));
       expect(row!.classList.contains('Mui-selected')).to.equal(false, 'class mui-selected 2');
       expect(checkbox).to.have.property('checked', false);
     });
 
     it('should select all visible rows regardless of pagination', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-              {
-                id: 1,
-                brand: 'Puma',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            checkboxSelection
-            // @ts-ignore
-            pagination
-            pageSize={1}
-            rowsPerPageOptions={[1]}
-          />
-        </div>,
-      );
+      render(<TestDataGridSelection checkboxSelection pageSize={1} rowsPerPageOptions={[1]} />);
       const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
       fireEvent.click(selectAllCheckbox);
       expect(getRow(0)).to.have.class('Mui-selected');
@@ -137,16 +94,7 @@ describe('<DataGrid /> - Selection', () => {
     });
 
     it('with no rows, the checkbox should not be checked', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            rows={[]}
-            checkboxSelection
-            columns={[{ field: 'brand', width: 100 }]}
-          />
-        </div>,
-      );
+      render(<TestDataGridSelection rows={[]} checkboxSelection />);
       const selectAll = screen.getByRole('checkbox', {
         name: /select all rows checkbox/i,
       });
@@ -155,25 +103,7 @@ describe('<DataGrid /> - Selection', () => {
 
     it('should disable the checkbox if isRowSelectable returns false', () => {
       render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-              {
-                id: 1,
-                brand: 'Adidas',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            isRowSelectable={(params) => params.id === 0}
-            checkboxSelection
-            hideFooter
-          />
-        </div>,
+        <TestDataGridSelection isRowSelectable={(params) => params.id === 0} checkboxSelection />,
       );
       expect(getRow(0).querySelector('input')).to.have.property('disabled', false);
       expect(getRow(1).querySelector('input')).to.have.property('disabled', true);
@@ -182,77 +112,19 @@ describe('<DataGrid /> - Selection', () => {
 
   describe('props: selectionModel', () => {
     it('should select rows when initialised (array-version)', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-              {
-                id: 1,
-                brand: 'Hugo Boss',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            selectionModel={[1]}
-          />
-        </div>,
-      );
+      render(<TestDataGridSelection selectionModel={[1]} />);
       const row = getRow(1);
       expect(row).to.have.class('Mui-selected');
     });
 
     it('should select rows when initialised (non-array version)', () => {
-      render(
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid
-            autoHeight={isJSDOM}
-            rows={[
-              {
-                id: 0,
-                brand: 'Nike',
-              },
-              {
-                id: 1,
-                brand: 'Hugo Boss',
-              },
-            ]}
-            columns={[{ field: 'brand', width: 100 }]}
-            selectionModel={1}
-          />
-        </div>,
-      );
+      render(<TestDataGridSelection selectionModel={1} />);
       const row = getRow(1);
       expect(row).to.have.class('Mui-selected');
     });
 
     it('should allow to switch selectionModel from array version to non array version', () => {
-      const data = {
-        rows: [
-          {
-            id: 0,
-            brand: 'Nike',
-          },
-          {
-            id: 1,
-            brand: 'Hugo Boss',
-          },
-        ],
-        columns: [{ field: 'brand', width: 100 }],
-      };
-
-      function Demo(props) {
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid autoHeight={isJSDOM} {...data} selectionModel={props.selectionModel} />
-          </div>
-        );
-      }
-
-      const { setProps } = render(<Demo selectionModel={[1]} />);
+      const { setProps } = render(<TestDataGridSelection />);
 
       setProps({ selectionModel: 1 });
       const row = getRow(1);
@@ -260,28 +132,7 @@ describe('<DataGrid /> - Selection', () => {
     });
 
     it('should deselect other selected rows', () => {
-      const data = {
-        rows: [
-          {
-            id: 0,
-            brand: 'Nike',
-          },
-          {
-            id: 1,
-            brand: 'Hugo Boss',
-          },
-        ],
-        columns: [{ field: 'brand', width: 100 }],
-      };
-      function Demo(props) {
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid autoHeight={isJSDOM} {...data} selectionModel={props.selectionModel} />
-          </div>
-        );
-      }
-
-      const { setProps } = render(<Demo />);
+      const { setProps } = render(<TestDataGridSelection />);
 
       const row1 = getRow(1);
       expect(row1).not.to.have.class('Mui-selected');
@@ -297,67 +148,10 @@ describe('<DataGrid /> - Selection', () => {
       expect(row1).to.have.class('Mui-selected');
     });
 
-    it('should not call onSelectionModelChange if the new value is the same', () => {
-      const onSelectionModelChange = spy();
-      const data = {
-        rows: [
-          {
-            id: 0,
-            brand: 'Nike',
-          },
-          {
-            id: 1,
-            brand: 'Hugo Boss',
-          },
-        ],
-        columns: [{ field: 'brand', width: 100 }],
-        checkboxSelection: true,
-        onSelectionModelChange,
-      };
-      function Demo(props) {
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...data} selectionModel={props.selectionModel} />
-          </div>
-        );
-      }
-      const selectionModel = [0];
-      const { setProps } = render(<Demo selectionModel={selectionModel} />);
-      expect(onSelectionModelChange.callCount).to.equal(0);
-      const firstRow = getRow(0);
-      expect(firstRow).to.have.class('Mui-selected');
-      setProps({ selectionModel });
-      expect(onSelectionModelChange.callCount).to.equal(0);
-      expect(getRow(0)).to.have.class('Mui-selected');
-    });
-
     it('should filter out unselectable rows when the selectionModel prop changes', () => {
-      const data = {
-        autoHeight: isJSDOM,
-        rows: [
-          {
-            id: 0,
-            brand: 'Nike',
-          },
-          {
-            id: 1,
-            brand: 'Adidas',
-          },
-        ],
-        columns: [{ field: 'brand', width: 100 }],
-        selectionModel: [1],
-        isRowSelectable: (params) => params.id > 0,
-      };
-
-      function Demo(props) {
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...props} />
-          </div>
-        );
-      }
-
-      const { setProps } = render(<Demo {...data} />);
+      const { setProps } = render(
+        <TestDataGridSelection selectionModel={[1]} isRowSelectable={(params) => params.id > 0} />,
+      );
       expect(getRow(0)).not.to.have.class('Mui-selected');
       expect(getRow(1)).to.have.class('Mui-selected');
 
@@ -369,31 +163,7 @@ describe('<DataGrid /> - Selection', () => {
 
   describe('props: isRowSelectable', () => {
     it('should update the selected rows when the isRowSelectable prop changes', () => {
-      const data = {
-        autoHeight: isJSDOM,
-        rows: [
-          {
-            id: 0,
-            brand: 'Nike',
-          },
-          {
-            id: 1,
-            brand: 'Adidas',
-          },
-        ],
-        columns: [{ field: 'brand', width: 100 }],
-        isRowSelectable: () => true,
-      };
-
-      function Demo(props) {
-        return (
-          <div style={{ width: 300, height: 300 }}>
-            <DataGrid {...props} />
-          </div>
-        );
-      }
-
-      const { setProps } = render(<Demo {...data} />);
+      const { setProps } = render(<TestDataGridSelection isRowSelectable={() => true} />);
       fireEvent.click(getRow(0));
       expect(getRow(0)).to.have.class('Mui-selected');
       expect(getRow(1)).not.to.have.class('Mui-selected');
@@ -405,31 +175,9 @@ describe('<DataGrid /> - Selection', () => {
   });
 
   describe('console error', () => {
-    const data = {
-      rows: [
-        {
-          id: 0,
-          brand: 'Nike',
-        },
-        {
-          id: 1,
-          brand: 'Hugo Boss',
-        },
-      ],
-      columns: [{ field: 'brand', width: 100 }],
-      selectionModel: [0, 1],
-    };
-    function TestDataGrid(props) {
-      return (
-        <div style={{ width: 300, height: 300 }}>
-          <DataGrid {...data} {...props} />
-        </div>
-      );
-    }
-
     it('should throw console error when selectionModel contains more than 1 item in DataGrid without checkbox selection', () => {
       expect(() => {
-        render(<TestDataGrid />);
+        render(<TestDataGridSelection selectionModel={[0, 1]} />);
       })
         // @ts-expect-error need to migrate helpers to TypeScript
         .toErrorDev('selectionModel can only be of 1 item in DataGrid');
@@ -437,7 +185,7 @@ describe('<DataGrid /> - Selection', () => {
 
     it('should not throw console error when selectionModel contains more than 1 item in DataGrid with checkbox selection', () => {
       expect(() => {
-        render(<TestDataGrid checkboxSelection />);
+        render(<TestDataGridSelection selectionModel={[0, 1]} checkboxSelection />);
       })
         .not // @ts-expect-error need to migrate helpers to TypeScript
         .toErrorDev();

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -99,7 +99,7 @@ describe('<DataGrid /> - Selection', () => {
       expect(getRow(1)).to.have.class('Mui-selected');
     });
 
-    it('with no rows, the checkbox should not be checked', () => {
+    it('should check the checkbox when there is no rows', () => {
       render(<TestDataGridSelection rows={[]} checkboxSelection />);
       const selectAll = screen.getByRole('checkbox', {
         name: /select all rows checkbox/i,

--- a/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/selection.DataGrid.test.tsx
@@ -129,7 +129,7 @@ describe('<DataGrid /> - Selection', () => {
       expect(row).to.have.class('Mui-selected');
     });
 
-    it('should allow to switch selectionModel from array version to non array version', () => {
+    it('should allow to switch selectionModel from array version to non-array version', () => {
       const { setProps } = render(<TestDataGridSelection />);
 
       setProps({ selectionModel: 1 });

--- a/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import { getCell, getColumnValues, getRow } from 'test/utils/helperFn';
+import { getColumnValues, getRow, getSelectedRowIndexes } from 'test/utils/helperFn';
 import {
   // @ts-expect-error need to migrate helpers to TypeScript
   screen,
@@ -11,19 +11,12 @@ import {
 } from 'test/utils';
 import {
   GridApiRef,
-  GridComponentProps,
-  GridInputSelectionModel,
   useGridApiRef,
   DataGridPro,
   GridEvents,
   DataGridProProps,
 } from '@mui/x-data-grid-pro';
-import { useData } from 'storybook/src/hooks/useData';
 import { getData } from 'storybook/src/data/data-service';
-
-function getSelectedRows(apiRef) {
-  return Array.from(apiRef.current.getSelectedRows().keys());
-}
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
 
@@ -33,25 +26,57 @@ describe('<DataGridPro /> - Selection', () => {
 
   let apiRef: GridApiRef;
 
+  const defaultData = getData(4, 2);
+
   const TestDataGridSelection = (
     props: Omit<DataGridProProps, 'rows' | 'columns' | 'apiRef'> &
       Partial<Pick<DataGridProProps, 'rows' | 'columns'>>,
   ) => {
     apiRef = useGridApiRef();
-    const data = useData(4, 2);
-
-    if (!data.rows.length) {
-      return null;
-    }
 
     return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGridPro {...data} {...props} apiRef={apiRef} autoHeight={isJSDOM} />
+        <DataGridPro {...defaultData} {...props} apiRef={apiRef} autoHeight={isJSDOM} />
       </div>
     );
   };
 
-  describe('getSelectedRows', () => {
+  describe('prop: checkboxSelectionVisibleOnly', () => {
+    it('should select all visible rows regardless of pagination if checkboxSelectionVisibleOnly = false', () => {
+      render(
+        <TestDataGridSelection
+          checkboxSelection
+          pageSize={1}
+          pagination
+          rowsPerPageOptions={[1]}
+        />,
+      );
+      const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
+      fireEvent.click(selectAllCheckbox);
+      expect(getRow(0)).to.have.class('Mui-selected');
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(getRow(1)).to.have.class('Mui-selected');
+    });
+
+    it('should select all visible rows of the current page if checkboxSelectionVisibleOnly = true', () => {
+      render(
+        <TestDataGridSelection
+          checkboxSelection
+          checkboxSelectionVisibleOnly
+          pageSize={1}
+          pagination
+          rowsPerPageOptions={[1]}
+        />,
+      );
+      const selectAllCheckbox = document.querySelector('input[type="checkbox"]');
+      fireEvent.click(selectAllCheckbox);
+      expect(getRow(0)).to.have.class('Mui-selected');
+      fireEvent.click(screen.getByRole('button', { name: /next page/i }));
+      expect(getRow(1)).not.to.have.class('Mui-selected');
+    });
+  });
+
+  describe('apiRef: getSelectedRows', () => {
     it('should handle the event internally before triggering onSelectionModelChange', () => {
       render(
         <TestDataGridSelection
@@ -70,7 +95,7 @@ describe('<DataGridPro /> - Selection', () => {
     });
   });
 
-  describe('selectRow', () => {
+  describe('apiRef: selectRow', () => {
     it('should call onSelectionModelChange with the ids selected', () => {
       const handleSelectionModelChange = spy();
       render(<TestDataGridSelection onSelectionModelChange={handleSelectionModelChange} />);
@@ -100,7 +125,7 @@ describe('<DataGridPro /> - Selection', () => {
     });
   });
 
-  describe('selectRows', () => {
+  describe('apiRef: selectRows', () => {
     it('should call onSelectionModelChange with the ids selected', () => {
       const handleSelectionModelChange = spy();
       render(<TestDataGridSelection onSelectionModelChange={handleSelectionModelChange} />);
@@ -128,48 +153,6 @@ describe('<DataGridPro /> - Selection', () => {
     });
   });
 
-  it('should clean the selected ids when the rows prop changes', () => {
-    const { rows, columns } = getData(4, 2);
-
-    const DemoTest = (props: Partial<GridComponentProps>) => {
-      const [selectionModelState, setSelectionModelState] = React.useState(props.selectionModel);
-      const handleSelectionChange = (model) => setSelectionModelState(model);
-      return (
-        <TestDataGridSelection
-          {...props}
-          selectionModel={selectionModelState}
-          onSelectionModelChange={handleSelectionChange}
-          columns={columns}
-        />
-      );
-    };
-
-    const { setProps } = render(
-      <DemoTest selectionModel={[0, 1, 2]} checkboxSelection rows={rows} />,
-    );
-    expect(getSelectedRows(apiRef)).to.deep.equal([0, 1, 2]);
-    setProps({
-      rows: [rows[0]],
-    });
-    expect(getSelectedRows(apiRef)).to.deep.equal([0]);
-  });
-
-  it('should call onSelectionModelChange when selection state changes', () => {
-    const handleSelectionModelChange = spy();
-
-    render(
-      <TestDataGridSelection
-        onSelectionModelChange={handleSelectionModelChange}
-        checkboxSelection
-      />,
-    );
-
-    expect(getSelectedRows(apiRef)).to.deep.equal([]);
-    fireEvent.click(getCell(0, 0));
-    expect(handleSelectionModelChange.callCount).to.equal(1);
-    expect(handleSelectionModelChange.getCall(0).args[0]).to.deep.equal([0]);
-  });
-
   it('should select only filtered rows after filter is applied', () => {
     render(<TestDataGridSelection checkboxSelection />);
     const selectAll = screen.getByRole('checkbox', {
@@ -186,88 +169,16 @@ describe('<DataGridPro /> - Selection', () => {
     });
     expect(getColumnValues(1)).to.deep.equal(['0', '1']);
     fireEvent.click(selectAll);
-    expect(getSelectedRows(apiRef)).to.deep.equal([0, 1]);
+    expect(getSelectedRowIndexes()).to.deep.equal([0, 1]);
     fireEvent.click(selectAll);
-    expect(getSelectedRows(apiRef)).to.deep.equal([]);
+    expect(getSelectedRowIndexes()).to.deep.equal([]);
     fireEvent.click(selectAll);
-    expect(getSelectedRows(apiRef)).to.deep.equal([0, 1]);
+    expect(getSelectedRowIndexes()).to.deep.equal([0, 1]);
     fireEvent.click(selectAll);
-    expect(getSelectedRows(apiRef)).to.deep.equal([]);
+    expect(getSelectedRowIndexes()).to.deep.equal([]);
   });
 
-  it('should only select visible rows on the current page', () => {
-    render(
-      <TestDataGridSelection
-        checkboxSelection
-        checkboxSelectionVisibleOnly
-        pagination
-        pageSize={1}
-        rowsPerPageOptions={[1]}
-      />,
-    );
-    const selectAll = screen.getByRole('checkbox', {
-      name: /select all rows checkbox/i,
-    });
-    fireEvent.click(selectAll);
-    expect(getRow(0)).to.have.class('Mui-selected');
-    fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-    expect(getRow(1)).not.to.have.class('Mui-selected');
-  });
-
-  describe('control Selection', () => {
-    it('should update the selection state when neither the model nor the onChange are set', () => {
-      render(<TestDataGridSelection />);
-      fireEvent.click(getCell(0, 0));
-      expect(getRow(0)).to.have.class('Mui-selected');
-    });
-
-    it('should not update the selection model when the selectionModelProp is set', () => {
-      const selectionModel: GridInputSelectionModel = [1];
-      render(<TestDataGridSelection selectionModel={selectionModel} />);
-      expect(getRow(0)).not.to.have.class('Mui-selected');
-      expect(getRow(1)).to.have.class('Mui-selected');
-      fireEvent.click(getCell(0, 0));
-      expect(getRow(0)).not.to.have.class('Mui-selected');
-    });
-
-    it('should update the selection state when the model is not set, but the onChange is set', () => {
-      const onModelChange = spy();
-      render(<TestDataGridSelection onSelectionModelChange={onModelChange} />);
-
-      fireEvent.click(getCell(0, 0));
-      expect(getRow(0)).to.have.class('Mui-selected');
-      expect(onModelChange.callCount).to.equal(1);
-      expect(onModelChange.firstCall.firstArg).to.deep.equal([0]);
-    });
-
-    it('should control selection state when the model and the onChange are set', () => {
-      const ControlCase = () => {
-        const [selectionModel, setSelectionModel] = React.useState<any>([]);
-
-        const handleSelectionChange = (newModel) => {
-          if (newModel.length) {
-            setSelectionModel([...newModel, 2]);
-            return;
-          }
-          setSelectionModel(newModel);
-        };
-
-        return (
-          <TestDataGridSelection
-            selectionModel={selectionModel}
-            onSelectionModelChange={handleSelectionChange}
-          />
-        );
-      };
-
-      render(<ControlCase />);
-      expect(getRow(0)).not.to.have.class('Mui-selected');
-      fireEvent.click(getCell(1, 0));
-      expect(getRow(0)).not.to.have.class('Mui-selected');
-      expect(getRow(1)).to.have.class('Mui-selected');
-      expect(getRow(2)).to.have.class('Mui-selected');
-    });
-
+  describe('controlled selection', () => {
     it('should not publish GRID_SELECTION_CHANGE if the selection state did not change ', () => {
       const handleSelectionChange = spy();
       const selectionModel = [];

--- a/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
@@ -25,6 +25,8 @@ function getSelectedRows(apiRef) {
   return Array.from(apiRef.current.getSelectedRows().keys());
 }
 
+const isJSDOM = /jsdom/.test(window.navigator.userAgent);
+
 describe('<DataGridPro /> - Selection', () => {
   // TODO v5: replace with createClientRender
   const render = createClientRenderStrictMode();
@@ -40,7 +42,7 @@ describe('<DataGridPro /> - Selection', () => {
 
     return (
       <div style={{ width: 300, height: 300 }}>
-        <DataGridPro {...data} {...props} apiRef={apiRef} />
+        <DataGridPro {...data} {...props} apiRef={apiRef} autoHeight={isJSDOM} />
       </div>
     );
   };

--- a/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { expect } from 'chai';
 import { spy } from 'sinon';
-import {getCell, getColumnValues, getRow} from 'test/utils/helperFn';
+import { getCell, getColumnValues, getRow } from 'test/utils/helperFn';
 import {
   // @ts-expect-error need to migrate helpers to TypeScript
   screen,
@@ -191,13 +191,13 @@ describe('<DataGridPro /> - Selection', () => {
 
   it('should only select visible rows on the current page', () => {
     render(
-        <TestDataGridSelection
-          checkboxSelection
-          checkboxSelectionVisibleOnly
-          pagination
-          pageSize={1}
-          rowsPerPageOptions={[1]}
-        />
+      <TestDataGridSelection
+        checkboxSelection
+        checkboxSelectionVisibleOnly
+        pagination
+        pageSize={1}
+        rowsPerPageOptions={[1]}
+      />,
     );
     const selectAll = screen.getByRole('checkbox', {
       name: /select all rows checkbox/i,
@@ -248,10 +248,10 @@ describe('<DataGridPro /> - Selection', () => {
         };
 
         return (
-            <TestDataGridSelection
-                selectionModel={selectionModel}
-                onSelectionModelChange={handleSelectionChange}
-            />
+          <TestDataGridSelection
+            selectionModel={selectionModel}
+            onSelectionModelChange={handleSelectionChange}
+          />
         );
       };
 

--- a/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/selection.DataGridPro.test.tsx
@@ -40,6 +40,10 @@ describe('<DataGridPro /> - Selection', () => {
     apiRef = useGridApiRef();
     const data = useData(4, 2);
 
+    if (!data.rows.length) {
+      return null;
+    }
+
     return (
       <div style={{ width: 300, height: 300 }}>
         <DataGridPro {...data} {...props} apiRef={apiRef} autoHeight={isJSDOM} />
@@ -220,7 +224,6 @@ describe('<DataGridPro /> - Selection', () => {
     it('should not update the selection model when the selectionModelProp is set', () => {
       const selectionModel: GridInputSelectionModel = [1];
       render(<TestDataGridSelection selectionModel={selectionModel} />);
-
       expect(getRow(0)).not.to.have.class('Mui-selected');
       expect(getRow(1)).to.have.class('Mui-selected');
       fireEvent.click(getCell(0, 0));

--- a/test/utils/helperFn.ts
+++ b/test/utils/helperFn.ts
@@ -97,3 +97,9 @@ export function getRow(rowIndex: number): HTMLElement {
   }
   return row as HTMLElement;
 }
+
+export function getSelectedRowIndexes() {
+  return [...getRows()]
+    .filter((row) => row.classList.contains('Mui-selected'))
+    .map((row) => Number((row as HTMLElement).dataset.rowindex));
+}


### PR DESCRIPTION
- [x] use `useData` / `getData` whenever possible
- [x] Remove test `should not call onSelectionModelChange if the new value is the same` which was not testing anything
- [x] Move tests not limited to premium feature to the `selection.DataGrid.test.tsx`
- [x] Use `getSelectedRowIndexes` in both `selection.DataGrid.test.tsx` and `selection.DataGridPro.test.tsx`
- [x] Remove test duplicate (some tests prior to control mode where duplicate in the control mode tests) 

It aims at reducing the complexity of the tests to prepare for new tests in #2456 