### PR TITLE
[docs] Replace 'paging' with 'pagination'

### DIFF
--- a/docs/src/pages/components/data-grid/pagination/pagination.md
+++ b/docs/src/pages/components/data-grid/pagination/pagination.md
@@ -1,10 +1,10 @@
 ---
-title: Data Grid - Paging
+title: Data Grid - Pagination
 ---
 
 # Data Grid - Pagination
 
-<p class="description">Through paging, a segment of data can be viewed from the assigned data source.</p>
+<p class="description">Through pagination, a segment of data can be viewed from the assigned data source.</p>
 
 By default, the MIT `DataGrid` displays the rows with pagination, and up to 100 rows per page.
 


### PR DESCRIPTION
This small PR improves consistency in the docs. There were two occurrences of the term 'paging' vs 31 ones of 'pagination' on the docs page. 