### PR TITLE
[DataGrid] Show page size controls on narrower screens

### DIFF
--- a/packages/grid/_modules_/grid/components/GridPagination.tsx
+++ b/packages/grid/_modules_/grid/components/GridPagination.tsx
@@ -14,7 +14,7 @@ const useStyles = makeStyles(
   (theme: Theme) => ({
     selectLabel: {
       display: 'none',
-      [theme.breakpoints.up('md')]: {
+      [theme.breakpoints.up('sm')]: {
         display: 'block',
       },
     },
@@ -22,14 +22,14 @@ const useStyles = makeStyles(
       // input label
       '&[id]': {
         display: 'none',
-        [theme.breakpoints.up('md')]: {
+        [theme.breakpoints.up('sm')]: {
           display: 'block',
         },
       },
     },
     input: {
       display: 'none',
-      [theme.breakpoints.up('md')]: {
+      [theme.breakpoints.up('sm')]: {
         display: 'inline-flex',
       },
     },


### PR DESCRIPTION
As discussed in https://github.com/mui-org/material-ui-x/issues/1907#issuecomment-861888562
This PR makes the page size controls visible on 'sm' screens.

Fixes #1907 
