### PR TITLE
[DataGrid] Pressing `Escape` should close `GridColumnHeaderMenu` without errors

### DIFF
--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles(
 export interface GridMenuProps extends Omit<PopperProps, 'onKeyDown'> {
   open: boolean;
   target: React.ReactNode;
-  onClickAway: (event: React.SyntheticEvent<Document, MouseEvent>) => void;
+  onClickAway: (event: React.MouseEvent<Document> | React.TouchEvent) => void;
   position?: MenuPosition;
 }
 

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -39,7 +39,7 @@ const useStyles = makeStyles(
 export interface GridMenuProps extends Omit<PopperProps, 'onKeyDown'> {
   open: boolean;
   target: React.ReactNode;
-  onClickAway: (event?: React.MouseEvent<Document, MouseEvent>) => void;
+  onClickAway: (event: React.SyntheticEvent<Document, MouseEvent>) => void;
   position?: MenuPosition;
 }
 

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -25,7 +25,7 @@ export function GridColumnHeaderMenu({
   const currentColumn = apiRef.current.getColumn(field);
 
   const hideMenu = React.useCallback(
-    (event: React.SyntheticEvent<any, any>) => {
+    (event: React.SyntheticEvent<any>) => {
       // Prevent triggering the sorting
       event.stopPropagation();
       apiRef.current.hideColumnMenu();

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnHeaderMenu.tsx
@@ -25,7 +25,7 @@ export function GridColumnHeaderMenu({
   const currentColumn = apiRef.current.getColumn(field);
 
   const hideMenu = React.useCallback(
-    (event) => {
+    (event: React.SyntheticEvent<any, any>) => {
       // Prevent triggering the sorting
       event.stopPropagation();
       apiRef.current.hideColumnMenu();

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuContainer.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuContainer.tsx
@@ -14,7 +14,7 @@ export const GridColumnMenuContainer = React.forwardRef<HTMLUListElement, GridCo
           event.preventDefault();
         }
         if (isHideMenuKey(event.key)) {
-          hideMenu();
+          hideMenu(event);
         }
       },
       [hideMenu],

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuProps.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuProps.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { GridColDef } from '../../../models/colDef/gridColDef';
 
 export interface GridColumnMenuProps extends React.HTMLAttributes<HTMLUListElement> {
-  hideMenu: () => void;
+  hideMenu: (event?: React.SyntheticEvent) => void;
   currentColumn: GridColDef;
   open: boolean;
   id?: string;

--- a/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuProps.tsx
+++ b/packages/grid/_modules_/grid/components/menu/columnMenu/GridColumnMenuProps.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { GridColDef } from '../../../models/colDef/gridColDef';
 
 export interface GridColumnMenuProps extends React.HTMLAttributes<HTMLUListElement> {
-  hideMenu: (event?: React.SyntheticEvent) => void;
+  hideMenu: (event: React.SyntheticEvent) => void;
   currentColumn: GridColDef;
   open: boolean;
   id?: string;

--- a/packages/grid/x-grid/src/tests/columnHeaders.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/columnHeaders.DataGridPro.test.tsx
@@ -43,22 +43,22 @@ describe('<DataGridPro /> - Column Headers', () => {
     ],
   };
 
-  it('should close the menu when the window is scrolled', async () => {
-    render(
-      <div style={{ width: 300, height: 500 }}>
-        <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} />
-      </div>,
-    );
-    const columnCell = getColumnHeaderCell(0);
-    const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
-    fireEvent.click(menuIconButton);
-    await waitFor(() => expect(screen.queryByRole('menu')).not.to.equal(null));
-    const gridWindow = document.querySelector('.MuiDataGrid-window')!;
-    gridWindow.dispatchEvent(new Event('scroll'));
-    await waitFor(() => expect(screen.queryByRole('menu')).to.equal(null));
-  });
-
   describe('GridColumnHeaderMenu', () => {
+    it('should close the menu when the window is scrolled', async () => {
+      render(
+        <div style={{ width: 300, height: 500 }}>
+          <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} />
+        </div>,
+      );
+      const columnCell = getColumnHeaderCell(0);
+      const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
+      fireEvent.click(menuIconButton);
+      await waitFor(() => expect(screen.queryByRole('menu')).not.to.equal(null));
+      const gridWindow = document.querySelector('.MuiDataGrid-window')!;
+      gridWindow.dispatchEvent(new Event('scroll'));
+      await waitFor(() => expect(screen.queryByRole('menu')).to.equal(null));
+    });
+
     it('should close the menu of a column when resizing this column', async () => {
       render(
         <div style={{ width: 300, height: 500 }}>
@@ -111,6 +111,23 @@ describe('<DataGridPro /> - Column Headers', () => {
         `.${GRID_COLUMN_HEADER_SEPARATOR_RESIZABLE_CSS_CLASS}`,
       );
       fireEvent.mouseDown(separator);
+      await waitFor(() => expect(screen.queryByRole('menu')).to.equal(null));
+    });
+
+    it('should close the menu of a column when pressing the Escape key', async () => {
+      render(
+        <div style={{ width: 300, height: 500 }}>
+          <DataGridPro {...baselineProps} columns={[{ field: 'brand' }]} />
+        </div>,
+      );
+
+      const columnCell = getColumnHeaderCell(0);
+      const menuIconButton = columnCell.querySelector('button[aria-label="Menu"]');
+
+      fireEvent.click(menuIconButton);
+      await waitFor(() => expect(screen.queryByRole('menu')).not.to.equal(null));
+      /* eslint-disable material-ui/disallow-active-element-as-key-event-target */
+      fireEvent.keyDown(document.activeElement!, { key: 'Escape' });
       await waitFor(() => expect(screen.queryByRole('menu')).to.equal(null));
     });
   });


### PR DESCRIPTION
Found a regression that is a quick win.

Currently pressing the `Escape` key when the `GridColumnHeaderMenu` is opened results in an error in the console and the menu doesn't close. This PR fixes the broken behavior.