### PR TITLE
[core] Do not run test_browsers on Renovate PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -218,6 +218,10 @@ workflows:
       - test_browser:
           requires:
             - checkout
+          filters:
+            branches:
+              ignore:
+                -  /.*renovate.*/
       - test_types:
           requires:
             - checkout


### PR DESCRIPTION
The Renovate PRs are coming in large groups every week.
So the `test_browser` step is failing 100% of the time and rerun it PR by PR sequentially to avoid timeout would take hours.
I think we can drop it, as we are merging them anyway.

