### PR TITLE
[core] Publish GridEvents.rowsSet when the rows state is modified after props.rows is updated

### DIFF
--- a/packages/grid/_modules_/grid/constants/eventsConstants.ts
+++ b/packages/grid/_modules_/grid/constants/eventsConstants.ts
@@ -282,12 +282,12 @@ export enum GridEvents {
    */
   columnOrderChange = 'columnOrderChange',
   /**
-   * Fired when the rows are updated.
+   * Fired when some of the rows are updated.
    * @ignore - do not document.
    */
   rowsUpdate = 'rowsUpdate',
   /**
-   * Fired when the rows are updated.
+   * Fired when all the rows are updated.
    * @ignore - do not document.
    */
   rowsSet = 'rowsSet',

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -30,10 +30,7 @@ export const useGridFilter = (
   apiRef: GridApiRef,
   props: Pick<
     GridComponentProps,
-    | 'filterModel'
-    | 'onFilterModelChange'
-    | 'filterMode'
-    | 'disableMultipleColumnsFiltering'
+    'filterModel' | 'onFilterModelChange' | 'filterMode' | 'disableMultipleColumnsFiltering'
   >,
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridFilter');

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -30,7 +30,6 @@ export const useGridFilter = (
   apiRef: GridApiRef,
   props: Pick<
     GridComponentProps,
-    | 'rows'
     | 'filterModel'
     | 'onFilterModelChange'
     | 'filterMode'
@@ -279,12 +278,6 @@ export const useGridFilter = (
     },
     'FilterApi',
   );
-
-  React.useEffect(() => {
-    logger.debug('Rows prop changed, applying filters');
-    clearFilteredRows();
-    apiRef.current.applyFilters();
-  }, [apiRef, clearFilteredRows, logger, props.rows]);
 
   const onColUpdated = React.useCallback(() => {
     logger.debug('onColUpdated - GridColumns changed, applying filters');

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -93,7 +93,9 @@ export const useGridRows = (
 
       return { ...state, rows: internalRowsState.current };
     });
-  }, [props.getRowId, props.rows, props.rowCount, setGridState]);
+
+    apiRef.current.publishEvent(GridEvents.rowsSet)
+  }, [apiRef, props.getRowId, props.rows, props.rowCount, setGridState]);
 
   const getRowIndexFromId = React.useCallback(
     (id: GridRowId): number => {

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -57,11 +57,11 @@ export const useGridRows = (
   props: Pick<GridComponentProps, 'rows' | 'getRowId' | 'rowCount'>,
 ): void => {
   const logger = useGridLogger(apiRef, 'useGridRows');
-  const [, setGridState, updateComponent] = useGridState(apiRef);
+  const [, setGridState, forceUpdate] = useGridState(apiRef);
   const stateRows = useGridSelector(apiRef, gridRowsStateSelector);
   const updateTimeout = React.useRef<any>();
 
-  const forceUpdate = React.useCallback(
+  const delayedForceUpdate = React.useCallback(
     (preUpdateCallback?: Function) => {
       if (updateTimeout.current == null) {
         updateTimeout.current = setTimeout(() => {
@@ -70,32 +70,14 @@ export const useGridRows = (
           if (preUpdateCallback) {
             preUpdateCallback();
           }
-          updateComponent();
+          forceUpdate();
         }, 100);
       }
     },
-    [logger, updateComponent],
+    [logger, forceUpdate],
   );
 
   const internalRowsState = React.useRef<InternalGridRowsState>(stateRows);
-
-  React.useEffect(() => {
-    return () => clearTimeout(updateTimeout!.current);
-  }, []);
-
-  React.useEffect(() => {
-    setGridState((state) => {
-      internalRowsState.current = convertGridRowsPropToState(
-        props.rows,
-        props.rowCount,
-        props.getRowId,
-      );
-
-      return { ...state, rows: internalRowsState.current };
-    });
-
-    apiRef.current.publishEvent(GridEvents.rowsSet)
-  }, [apiRef, props.getRowId, props.rows, props.rowCount, setGridState]);
 
   const getRowIndexFromId = React.useCallback(
     (id: GridRowId): number => {
@@ -120,32 +102,36 @@ export const useGridRows = (
     [apiRef],
   );
 
-  const setRows = React.useCallback(
-    (allNewRows: GridRowModel[]) => {
-      logger.debug(`updating all rows, new length ${allNewRows.length}`);
+  const setRowsState = React.useCallback(
+    (
+      rows: GridRowModel[] | readonly GridRowModel[],
+      rowCount: GridComponentProps['rowCount'],
+      getRowId: GridComponentProps['getRowId'],
+      waitBeforeUpdate: boolean,
+    ) => {
+      logger.debug(`updating all rows, new length ${rows.length}`);
 
       if (internalRowsState.current.allRows.length > 0) {
         apiRef.current.publishEvent(GridEvents.rowsClear);
       }
 
-      const allRows: GridRowId[] = [];
-      const idRowsLookup = allNewRows.reduce((acc, row) => {
-        const id = getGridRowId(row, props.getRowId);
-        acc[id] = row;
-        allRows.push(id);
-        return acc;
-      }, {});
-
-      const totalRowCount =
-        props.rowCount && props.rowCount > allRows.length ? props.rowCount : allRows.length;
-
-      internalRowsState.current = { idRowsLookup, allRows, totalRowCount };
+      internalRowsState.current = convertGridRowsPropToState(rows, rowCount, getRowId);
 
       setGridState((state) => ({ ...state, rows: internalRowsState.current }));
 
-      forceUpdate(() => apiRef.current.publishEvent(GridEvents.rowsSet));
+      if (waitBeforeUpdate) {
+        delayedForceUpdate(() => apiRef.current.publishEvent(GridEvents.rowsSet));
+      } else {
+        forceUpdate();
+        apiRef.current.publishEvent(GridEvents.rowsSet);
+      }
     },
-    [logger, setGridState, forceUpdate, apiRef, props.getRowId, props.rowCount],
+    [apiRef, logger, setGridState, forceUpdate, delayedForceUpdate],
+  );
+
+  const setRows = React.useCallback<GridRowApi['setRows']>(
+    (rows) => setRowsState(rows, props.rowCount, props.getRowId, true),
+    [setRowsState, props.rowCount, props.getRowId],
   );
 
   const updateRows = React.useCallback(
@@ -202,9 +188,9 @@ export const useGridRows = (
         ];
         setRows(newRows);
       }
-      forceUpdate(() => apiRef.current.publishEvent(GridEvents.rowsUpdate));
+      delayedForceUpdate(() => apiRef.current.publishEvent(GridEvents.rowsUpdate));
     },
-    [apiRef, forceUpdate, getRow, props.getRowId, setGridState, setRows],
+    [apiRef, delayedForceUpdate, getRow, props.getRowId, setGridState, setRows],
   );
 
   const getRowModels = React.useCallback(
@@ -219,6 +205,14 @@ export const useGridRows = (
   );
   const getRowsCount = React.useCallback(() => apiRef.current.state.rows.totalRowCount, [apiRef]);
   const getAllRowIds = React.useCallback(() => apiRef.current.state.rows.allRows, [apiRef]);
+
+  React.useEffect(() => {
+    return () => clearTimeout(updateTimeout!.current);
+  }, []);
+
+  React.useEffect(() => {
+    setRowsState(props.rows, props.rowCount, props.getRowId, false);
+  }, [setRowsState, props.rows, props.rowCount, props.getRowId]);
 
   const rowApi: GridRowApi = {
     getRowIndex: getRowIndexFromId,

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -21,9 +21,7 @@ import { useGridApiEventHandler } from '../../root/useGridApiEventHandler';
 import { useGridApiMethod } from '../../root/useGridApiMethod';
 import { useGridLogger } from '../../utils/useGridLogger';
 import { allGridColumnsSelector } from '../columns/gridColumnsSelector';
-import { useGridSelector } from '../core/useGridSelector';
 import { useGridState } from '../core/useGridState';
-import { gridRowCountSelector } from '../rows/gridRowsSelector';
 import { sortedGridRowIdsSelector, sortedGridRowsSelector } from './gridSortingSelector';
 
 /**
@@ -45,7 +43,6 @@ export const useGridSorting = (
   const logger = useGridLogger(apiRef, 'useGridSorting');
 
   const [gridState, setGridState, forceUpdate] = useGridState(apiRef);
-  const rowCount = useGridSelector(apiRef, gridRowCountSelector);
 
   const upsertSortModel = React.useCallback(
     (field: string, sortItem?: GridSortItem): GridSortModel => {
@@ -297,13 +294,6 @@ export const useGridSorting = (
     applySorting,
   };
   useGridApiMethod(apiRef, sortApi, 'GridSortApi');
-
-  React.useEffect(() => {
-    if (rowCount > 0) {
-      logger.debug('row changed, applying sortModel');
-      apiRef.current.applySorting();
-    }
-  }, [rowCount, apiRef, logger]);
 
   React.useEffect(() => {
     apiRef.current.updateControlState<GridSortModel>({

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -219,30 +219,6 @@ export const useGridSorting = (
     [upsertSortModel, setSortModel, createSortItem, props.disableMultipleColumnsSorting],
   );
 
-  const handleColumnHeaderClick = React.useCallback(
-    ({ colDef }: GridColumnHeaderParams, event: React.MouseEvent) => {
-      const allowMultipleSorting = event.shiftKey || event.metaKey || event.ctrlKey;
-      sortColumn(colDef, undefined, allowMultipleSorting);
-    },
-    [sortColumn],
-  );
-
-  const handleColumnHeaderKeyDown = React.useCallback(
-    ({ colDef }: GridColumnHeaderParams, event: React.KeyboardEvent) => {
-      // CTRL + Enter opens the column menu
-      if (isEnterKey(event.key) && !event.ctrlKey && !event.metaKey) {
-        sortColumn(colDef, undefined, event.shiftKey);
-      }
-    },
-    [sortColumn],
-  );
-
-  const onRowsCleared = React.useCallback(() => {
-    setGridState((state) => {
-      return { ...state, sorting: { ...state.sorting, sortedRows: [] } };
-    });
-  }, [setGridState]);
-
   const getSortModel = React.useCallback(
     () => gridState.sorting.sortModel,
     [gridState.sorting.sortModel],
@@ -257,33 +233,6 @@ export const useGridSorting = (
     (): GridRowId[] => sortedGridRowIdsSelector(apiRef.current.state),
     [apiRef],
   );
-
-  const onColUpdated = React.useCallback(() => {
-    // When the columns change we check that the sorted columns are still part of the dataset
-    setGridState((state) => {
-      const sortModel = state.sorting.sortModel;
-      const latestColumns = allGridColumnsSelector(state);
-      let newModel = sortModel;
-      if (sortModel.length > 0) {
-        newModel = sortModel.reduce((model, sortedCol) => {
-          const exist = latestColumns.find((col) => col.field === sortedCol.field);
-          if (exist) {
-            model.push(sortedCol);
-          }
-          return model;
-        }, [] as GridSortModel);
-      }
-
-      return { ...state, sorting: { ...state.sorting, sortModel: newModel } };
-    });
-  }, [setGridState]);
-
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderClick, handleColumnHeaderClick);
-  useGridApiEventHandler(apiRef, GridEvents.columnHeaderKeyDown, handleColumnHeaderKeyDown);
-  useGridApiEventHandler(apiRef, GridEvents.rowsSet, apiRef.current.applySorting);
-  useGridApiEventHandler(apiRef, GridEvents.rowsClear, onRowsCleared);
-  useGridApiEventHandler(apiRef, GridEvents.rowsUpdate, apiRef.current.applySorting);
-  useGridApiEventHandler(apiRef, GridEvents.columnsChange, onColUpdated);
 
   const sortApi: GridSortApi = {
     getSortModel,
@@ -311,4 +260,55 @@ export const useGridSorting = (
       setSortModel(props.sortModel);
     }
   }, [props.sortModel, apiRef, setSortModel]);
+
+  const handleColumnHeaderClick = React.useCallback(
+    ({ colDef }: GridColumnHeaderParams, event: React.MouseEvent) => {
+      const allowMultipleSorting = event.shiftKey || event.metaKey || event.ctrlKey;
+      sortColumn(colDef, undefined, allowMultipleSorting);
+    },
+    [sortColumn],
+  );
+
+  const handleColumnHeaderKeyDown = React.useCallback(
+    ({ colDef }: GridColumnHeaderParams, event: React.KeyboardEvent) => {
+      // CTRL + Enter opens the column menu
+      if (isEnterKey(event.key) && !event.ctrlKey && !event.metaKey) {
+        sortColumn(colDef, undefined, event.shiftKey);
+      }
+    },
+    [sortColumn],
+  );
+
+  const onRowsCleared = React.useCallback(() => {
+    setGridState((state) => {
+      return { ...state, sorting: { ...state.sorting, sortedRows: [] } };
+    });
+  }, [setGridState]);
+
+  const onColUpdated = React.useCallback(() => {
+    // When the columns change we check that the sorted columns are still part of the dataset
+    setGridState((state) => {
+      const sortModel = state.sorting.sortModel;
+      const latestColumns = allGridColumnsSelector(state);
+      let newModel = sortModel;
+      if (sortModel.length > 0) {
+        newModel = sortModel.reduce((model, sortedCol) => {
+          const exist = latestColumns.find((col) => col.field === sortedCol.field);
+          if (exist) {
+            model.push(sortedCol);
+          }
+          return model;
+        }, [] as GridSortModel);
+      }
+
+      return { ...state, sorting: { ...state.sorting, sortModel: newModel } };
+    });
+  }, [setGridState]);
+
+  useGridApiEventHandler(apiRef, GridEvents.columnHeaderClick, handleColumnHeaderClick);
+  useGridApiEventHandler(apiRef, GridEvents.columnHeaderKeyDown, handleColumnHeaderKeyDown);
+  useGridApiEventHandler(apiRef, GridEvents.rowsSet, apiRef.current.applySorting);
+  useGridApiEventHandler(apiRef, GridEvents.rowsClear, onRowsCleared);
+  useGridApiEventHandler(apiRef, GridEvents.rowsUpdate, apiRef.current.applySorting);
+  useGridApiEventHandler(apiRef, GridEvents.columnsChange, onColUpdated);
 };

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -35,7 +35,6 @@ export const useGridSorting = (
   apiRef: GridApiRef,
   props: Pick<
     GridComponentProps,
-    | 'rows'
     | 'sortModel'
     | 'onSortModelChange'
     | 'sortingOrder'
@@ -298,11 +297,6 @@ export const useGridSorting = (
     applySorting,
   };
   useGridApiMethod(apiRef, sortApi, 'GridSortApi');
-
-  React.useEffect(() => {
-    // When the rows prop change, we re apply the sorting.
-    apiRef.current.applySorting();
-  }, [apiRef, props.rows]);
 
   React.useEffect(() => {
     if (rowCount > 0) {

--- a/packages/grid/x-grid/src/tests/state.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/state.DataGridPro.test.tsx
@@ -62,6 +62,7 @@ describe('<DataGridPro /> - State', () => {
           ...prev,
           sorting: { ...prev.sorting, sortModel: [{ field: 'brand', sort: 'asc' }] },
         }));
+        apiRef.current.applySorting();
       }, [apiRef]);
       return (
         <div style={{ width: 300, height: 300 }}>


### PR DESCRIPTION
I'm starting to work on the tree data and I found it weird to listen to `props.rows` in a `useEffect` to trigger behavior that is based on `state.rows`.
We rely on the fact that when the `useEffect` of `useGridFilter` or `useGridSorting`, the update of the state of `useGridRows` has already been done.

Additionally, the description of the events was suggesting that it was trigger of rows update, not matter why it was updated

```
  /**
   * Fired when the rows are updated.
   * @ignore - do not document.
   */
  rowsSet = 'rowsSet',
```