### PR TITLE
[DataGrid] Vertically align column header icons

### DIFF
--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -126,6 +126,9 @@ export const useStyles = makeStyles(
           overflow: 'hidden',
           padding: '0 6px',
         },
+        [`& .${gridClasses.iconButtonContainer}`]: {
+          display: 'flex',
+        },
         [`& .${gridClasses.sortIcon}, & .${gridClasses.filterIcon}`]: {
           fontSize: 'inherit',
         },


### PR DESCRIPTION
I have noticed this on @siriwatknp's PR https://github.com/mui-org/material-ui/pull/28106, see how the icons are not vertically aligned:

<img width="251" alt="Screenshot 2021-09-05 at 15 03 14" src="https://user-images.githubusercontent.com/3165635/132127881-3e66c6d9-9374-473e-aeb3-25e7f806c569.png">

https://deploy-preview-28106--material-ui.netlify.app/branding/x-advanced/

**Before**

<img width="176" alt="Screenshot 2021-09-05 at 15 01 26" src="https://user-images.githubusercontent.com/3165635/132127902-425bb331-441c-426c-888b-816d2fb6c14e.png">

**After**

<img width="175" alt="Screenshot 2021-09-05 at 15 01 04" src="https://user-images.githubusercontent.com/3165635/132127900-04c4b47c-dcdf-4c9f-a7f4-d589bdc761d9.png">
