### PR TITLE
[core] Clean GridSimpleOptions interface

### DIFF
--- a/packages/grid/_modules_/grid/models/gridOptions.tsx
+++ b/packages/grid/_modules_/grid/models/gridOptions.tsx
@@ -1,11 +1,10 @@
 import { GridLocaleText } from './api/gridLocaleTextApi';
 import { GridDensity, GridDensityTypes } from './gridDensity';
-import { GridEditMode, GridEditModes, GridEditRowsModel } from './gridEditRowModel';
+import { GridEditMode, GridEditModes } from './gridEditRowModel';
 import { GridFeatureMode, GridFeatureModeConstant } from './gridFeatureMode';
 import { Logger } from './logger';
 import { GridSortDirection } from './gridSortModel';
 import { GridSlotsComponent } from './gridSlotsComponent';
-import { GridFilterModel } from './gridFilterModel';
 
 export type GridMergedOptions = {
   [key in keyof GridProcessedMergedOptions]: Partial<GridProcessedMergedOptions[key]>;
@@ -26,9 +25,11 @@ export interface GridProcessedMergedOptions {
   localeText: GridLocaleText;
 }
 
-// TODO add multiSortKey
 /**
  * The grid options with a default in value overridable through props
+ * None of the entry of this interface should be optional, they all have default values and `GridInputComponentProps` already applies a `Partial<GridSimpleOptions>` for the public interface
+ * The controlled model do not have a default value at the prop processing level so they must be defined in `GridComponentOtherProps`
+ * TODO: add multiSortKey
  */
 export interface GridSimpleOptions {
   /**
@@ -121,26 +122,18 @@ export interface GridSimpleOptions {
    * If `true`, the virtualization is disabled.
    * @default false
    */
-  disableVirtualization?: boolean;
+  disableVirtualization: boolean;
   /**
    * Controls whether to use the cell or row editing.
    * @default "cell"
    */
-  editMode?: GridEditMode;
-  /**
-   * Set the edit rows model of the grid.
-   */
-  editRowsModel?: GridEditRowsModel;
+  editMode: GridEditMode;
   /**
    * Filtering can be processed on the server or client-side.
    * Set it to 'server' if you would like to handle filtering on the server-side.
    * @default "client"
    */
-  filterMode?: GridFeatureMode;
-  /**
-   * Set the filter model of the grid.
-   */
-  filterModel?: GridFilterModel;
+  filterMode: GridFeatureMode;
   /**
    * Set the height in pixel of the column headers in the grid.
    * @default 56
@@ -176,7 +169,7 @@ export interface GridSimpleOptions {
    * Allows to pass the logging level or false to turn off logging.
    * @default "debug"
    */
-  logLevel?: keyof Logger | false;
+  logLevel: keyof Logger | false;
   /**
    * If `true`, pagination is enabled.
    * @default false
@@ -248,6 +241,7 @@ export const GRID_DEFAULT_SIMPLE_OPTIONS: GridSimpleOptions = {
   disableMultipleSelection: false,
   disableMultipleColumnsSorting: false,
   disableSelectionOnClick: false,
+  disableVirtualization: false,
   editMode: GridEditModes.Cell,
   filterMode: GridFeatureModeConstant.client,
   headerHeight: 56,


### PR DESCRIPTION
I'll merge this only quickly

- [x] Remove models that are also defined in `GridComponentOtherProps`
- [x] Make all values in `GridSimpleOptions` mandatory (and add default value if missing)
- [x] Improve the description of `GridSimpleOptions` to explain why the values should not be optional