### PR TITLE
[DataGrid] Free up column header space when icons are not visible

### DIFF
--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -102,7 +102,8 @@ export const useStyles = makeStyles(
           alignItems: 'center',
         },
         [`& .${gridClasses['columnHeader--sorted']} .${gridClasses.iconButtonContainer}`]: {
-          display: 'flex',
+          visibility: 'visible',
+          width: 'auto',
         },
         [`& .${gridClasses.columnHeader}:not(.${gridClasses['columnHeader--sorted']}) .${gridClasses.sortIcon}`]:
           {
@@ -125,7 +126,9 @@ export const useStyles = makeStyles(
           padding: '0 6px',
         },
         [`& .${gridClasses.iconButtonContainer}`]: {
-          display: 'none',
+          display: 'flex',
+          visibility: 'hidden',
+          width: 0,
         },
         [`& .${gridClasses.sortIcon}, & .${gridClasses.filterIcon}`]: {
           fontSize: 'inherit',
@@ -191,7 +194,8 @@ export const useStyles = makeStyles(
         },
         [`& .${gridClasses.columnHeader}:hover`]: {
           [`& .${gridClasses.iconButtonContainer}`]: {
-            display: 'flex',
+            visibility: 'visible',
+            width: 'auto',
           },
           [`& .${gridClasses.menuIcon}`]: {
             width: 'auto',

--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -101,6 +101,9 @@ export const useStyles = makeStyles(
           display: 'flex',
           alignItems: 'center',
         },
+        [`& .${gridClasses['columnHeader--sorted']} .${gridClasses.iconButtonContainer}`]: {
+          display: 'flex',
+        },
         [`& .${gridClasses.columnHeader}:not(.${gridClasses['columnHeader--sorted']}) .${gridClasses.sortIcon}`]:
           {
             opacity: 0,
@@ -122,7 +125,7 @@ export const useStyles = makeStyles(
           padding: '0 6px',
         },
         [`& .${gridClasses.iconButtonContainer}`]: {
-          display: 'flex',
+          display: 'none',
         },
         [`& .${gridClasses.sortIcon}, & .${gridClasses.filterIcon}`]: {
           fontSize: 'inherit',
@@ -179,16 +182,25 @@ export const useStyles = makeStyles(
           color: 'inherit',
         },
         [`& .${gridClasses.menuIcon}`]: {
+          width: 0,
           visibility: 'hidden',
           fontSize: 20,
           marginRight: -6,
           display: 'flex',
           alignItems: 'center',
         },
-        [`& .${gridClasses.columnHeader}:hover .${gridClasses.menuIcon}, .${gridClasses.menuOpen}`]:
-          {
+        [`& .${gridClasses.columnHeader}:hover`]: {
+          [`& .${gridClasses.iconButtonContainer}`]: {
+            display: 'flex',
+          },
+          [`& .${gridClasses.menuIcon}`]: {
+            width: 'auto',
             visibility: 'visible',
           },
+        },
+        [`.${gridClasses.menuOpen}`]: {
+          visibility: 'visible',
+        },
         [`& .${gridClasses.columnHeaderWrapper}.scroll .${gridClasses.columnHeader}:last-child`]: {
           borderRight: 'none',
         },

--- a/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/layout.DataGrid.test.tsx
@@ -713,14 +713,14 @@ describe('<DataGrid /> - Layout & Warnings', () => {
     });
 
     it('should support translations in the theme', () => {
-      const { getByRole } = render(
+      render(
         <ThemeProvider theme={createTheme({}, ptBR)}>
           <div style={{ width: 300, height: 300 }}>
             <DataGrid {...baselineProps} />
           </div>
         </ThemeProvider>,
       );
-      expect(getByRole('button', { name: 'Ordenar' })).not.to.equal(null);
+      expect(document.querySelector('[title="Ordenar"]')).not.to.equal(null);
     });
   });
 

--- a/packages/grid/x-grid/src/tests/layout.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/layout.DataGridPro.test.tsx
@@ -139,13 +139,13 @@ describe('<DataGridPro /> - Layout', () => {
   });
 
   it('should support translations in the theme', () => {
-    const { getByRole } = render(
+    render(
       <ThemeProvider theme={createTheme({}, ptBR)}>
         <div style={{ width: 300, height: 300 }}>
           <DataGridPro {...baselineProps} />
         </div>
       </ThemeProvider>,
     );
-    expect(getByRole('button', { name: 'Ordenar' })).not.to.equal(null);
+    expect(document.querySelector('[title="Ordenar"]')).not.to.equal(null);
   });
 });


### PR DESCRIPTION
Based on this https://github.com/mui-org/material-ui-x/issues/2460

A small improvement that frees up column header space when column icons are not visible.

You can check Argos for more visual representation 😉

Before:
![before](https://user-images.githubusercontent.com/5858539/133233375-058adefd-d3bb-4dc0-8cf7-b24e73a0ef37.png)

After:
![after](https://user-images.githubusercontent.com/5858539/133233390-096b95e3-0957-488b-8731-896bd4ad6048.png)
