### PR TITLE
[docs] Include packages from next tag

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -44,7 +44,7 @@ import createEmotionCache from 'docs/src/createEmotionCache';
 
 function getMuiPackageVersion(packageName, commitRef) {
   if (commitRef === undefined) {
-    return 'latest';
+    return 'next';
   }
   const shortSha = commitRef.slice(0, 8);
   return `https://pkg.csb.dev/mui-org/material-ui-x/commit/${shortSha}/@mui/${packageName}`;


### PR DESCRIPTION
The demos in https://mui.com/components/data-grid/demo/ are not working in codesandbox because the dependency used is from the `latest` tag. The dependencies that support @mui/material are in the `next` tag.