### PR TITLE
[docs] Fix Algolia index

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -24,7 +24,7 @@
     "@material-ui/docs": "^4.0.0-beta.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.56",
-    "@material-ui/monorepo": "https://github.com/mui-org/material-ui.git#master",
+    "@material-ui/monorepo": "https://github.com/mui-org/material-ui.git#v4.x",
     "@trendmicro/react-interpolate": "^0.5.5",
     "@types/react-dom": "^17.0.9",
     "@types/react-router-dom": "^5.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,13 +2371,13 @@
     prop-types "^15.7.2"
     react-is "^16.8.0 || ^17.0.0"
 
-"@material-ui/monorepo@https://github.com/mui-org/material-ui.git#master":
-  version "4.12.3"
-  resolved "https://github.com/mui-org/material-ui.git#5cc1d0fc8756534f181d55af02a5a0d65b486603"
-
 "@material-ui/monorepo@https://github.com/mui-org/material-ui.git#next":
   version "5.0.0-beta.4"
   resolved "https://github.com/mui-org/material-ui.git#5314e4247502b786b7993ff8bd813ee2db6e8682"
+
+"@material-ui/monorepo@https://github.com/mui-org/material-ui.git#v4.x":
+  version "4.12.3"
+  resolved "https://github.com/mui-org/material-ui.git#b7d2943f9a00021f526b1f55b98ba9e2d721cddd"
 
 "@material-ui/styles@^4.11.4":
   version "4.11.4"


### PR DESCRIPTION
Open https://mui.com/api/css-baseline/ and see how the results are duplicated

<img width="536" alt="Screenshot 2021-09-20 at 01 10 56" src="https://user-images.githubusercontent.com/3165635/133945936-104c58e0-7956-47cc-a853-96fdc5a1e0af.png">

Note that I have created a new `docs-v4` branch. I propose that we update the core repo to use it, and kill the `release` branch, used for v4.