### PR TITLE
[docs] Update installation instructions

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/getting-started.md
+++ b/docs/src/pages/components/data-grid/getting-started/getting-started.md
@@ -12,10 +12,10 @@ Using your favorite package manager, install `@mui/x-data-grid-pro` for the full
 
 ```sh
 // with npm
-npm install @mui/x-data-grid
+npm install @mui/x-data-grid@next
 
 // with yarn
-yarn add @mui/x-data-grid
+yarn add @mui/x-data-grid@next
 ```
 
 The grid has two peer dependencies on Material-UI components.
@@ -109,7 +109,7 @@ import type {} from '@mui/x-data-grid-pro/themeAugmentation';
 
 const theme = createTheme({
   components: {
-    // Use `DataGrid` on both DataGrid and DataGridPro
+    // Use `MuiDataGrid` on both DataGrid and DataGridPro
     MuiDataGrid: {
       styleOverrides: {
         root: {


### PR DESCRIPTION
The `latest` tag on npm is pointing to the v4 version, while the documentation at https://mui.com/getting-started/usage/ is for the v5 version. What happens is that users think that by following the installation instructions it will install a v5-compatible version, when it won't. We had a couple of issues related to this: #2660 and #2654.