### PR TITLE
[DataGrid] Export single select operators (#2666)

### DIFF
--- a/packages/grid/_modules_/grid/models/colDef/index.ts
+++ b/packages/grid/_modules_/grid/models/colDef/index.ts
@@ -11,3 +11,5 @@ export * from './gridColTypeDef';
 export * from './gridDefaultColumnTypes';
 export * from './gridStringOperators';
 export * from './gridActionsColDef';
+export * from './gridSingleSelectColDef';
+export * from './gridSingleSelectOperators';


### PR DESCRIPTION
Fixes #2666 

Adds "single select" operators to the list of exports.

For more details - please see:
https://github.com/mui-org/material-ui-x/issues/2666