### PR TITLE
[DataGrid] GridMenu should not remove the anchor before the end of the closing transition

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
@@ -15,7 +15,8 @@ const hasActions = (colDef: any): colDef is GridActionsColDef =>
 type GridActionsCellProps = GridRenderCellParams & Pick<GridMenuProps, 'position'>;
 
 const GridActionsCell = (props: GridActionsCellProps) => {
-  const [anchorEl, setAnchorEl] = React.useState(null);
+  const [open, setOpen] = React.useState(false);
+  const buttonRef = React.useRef<HTMLButtonElement>(null);
   const menuId = useId();
   const buttonId = useId();
   const rootProps = useGridRootProps();
@@ -25,13 +26,9 @@ const GridActionsCell = (props: GridActionsCellProps) => {
     throw new Error('Material-UI: Missing the `getActions` property in the `GridColDef`.');
   }
 
-  const showMenu = (event) => {
-    setAnchorEl(event.currentTarget);
-  };
+  const showMenu = () => setOpen(true);
 
-  const hideMenu = () => {
-    setAnchorEl(null);
-  };
+  const hideMenu = () => setOpen(false);
 
   const options = colDef.getActions(api.getRowParams(id));
   const iconButtons = options.filter((option) => !option.props.showInMenu);
@@ -42,10 +39,11 @@ const GridActionsCell = (props: GridActionsCellProps) => {
       {iconButtons.map((button, index) => React.cloneElement(button, { key: index }))}
       {menuButtons.length > 0 && (
         <IconButton
+          ref={buttonRef}
           id={buttonId}
           aria-label={api.getLocaleText('actionsCellMore')}
           aria-controls={menuId}
-          aria-expanded={anchorEl ? 'true' : undefined}
+          aria-expanded={open ? 'true' : undefined}
           aria-haspopup="true"
           size="small"
           onClick={showMenu}
@@ -59,8 +57,8 @@ const GridActionsCell = (props: GridActionsCellProps) => {
           id={menuId}
           onClickAway={hideMenu}
           onClick={hideMenu}
-          open={Boolean(anchorEl)}
-          target={anchorEl}
+          open={open}
+          target={buttonRef.current}
           position={position}
           aria-labelledby={buttonId}
         >

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -52,7 +52,6 @@ const transformOrigin = {
 
 const GridMenu = (props: GridMenuProps) => {
   const { open, target, onClickAway, children, position, ...other } = props;
-
   const prevTarget = React.useRef(target);
   const prevOpen = React.useRef(open);
   const classes = useStyles();

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -51,7 +51,7 @@ const transformOrigin = {
 };
 
 const GridMenu = (props: GridMenuProps) => {
-  const { open, target, onClickAway, children, position, ...other } = props;
+  const { open, target, onClickAway, children, position, onTransitionEnd, ...other } = props;
 
   const [stateTarget, setStateTarget] = React.useState(target);
   const prevTarget = React.useRef(target);
@@ -74,11 +74,16 @@ const GridMenu = (props: GridMenuProps) => {
     }
   }, [open, stateTarget]);
 
-  const handleTransitionEnd = React.useCallback(() => {
-    if (!target) {
-      setStateTarget(null);
-    }
-  }, [target]);
+  const handleTransitionEnd = React.useCallback<React.TransitionEventHandler<HTMLDivElement>>(
+    (event) => {
+      if (!target) {
+        setStateTarget(null);
+      }
+
+      onTransitionEnd?.(event);
+    },
+    [target, onTransitionEnd],
+  );
 
   return (
     <Popper

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -53,13 +53,13 @@ const transformOrigin = {
 const GridMenu = (props: GridMenuProps) => {
   const { open, target, onClickAway, children, position, ...other } = props;
 
-  const [stateTarget, setStateTarget] = React.useState(target)
+  const [stateTarget, setStateTarget] = React.useState(target);
   const prevTarget = React.useRef(target);
   const prevOpen = React.useRef(open);
   const classes = useStyles();
 
   if (target && target !== stateTarget) {
-    setStateTarget(target)
+    setStateTarget(target);
   }
 
   React.useEffect(() => {
@@ -76,9 +76,9 @@ const GridMenu = (props: GridMenuProps) => {
 
   const handleTransitionEnd = React.useCallback(() => {
     if (!target) {
-      setStateTarget(null)
+      setStateTarget(null);
     }
-  }, [target])
+  }, [target]);
 
   return (
     <Popper

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -51,16 +51,11 @@ const transformOrigin = {
 };
 
 const GridMenu = (props: GridMenuProps) => {
-  const { open, target, onClickAway, children, position, onTransitionEnd, ...other } = props;
+  const { open, target, onClickAway, children, position, ...other } = props;
 
-  const [stateTarget, setStateTarget] = React.useState(target);
   const prevTarget = React.useRef(target);
   const prevOpen = React.useRef(open);
   const classes = useStyles();
-
-  if (target && target !== stateTarget) {
-    setStateTarget(target);
-  }
 
   React.useEffect(() => {
     if (prevOpen.current && prevTarget.current) {
@@ -68,30 +63,15 @@ const GridMenu = (props: GridMenuProps) => {
     }
 
     prevOpen.current = open;
-
-    if (stateTarget) {
-      prevTarget.current = stateTarget;
-    }
-  }, [open, stateTarget]);
-
-  const handleTransitionEnd = React.useCallback<React.TransitionEventHandler<HTMLDivElement>>(
-    (event) => {
-      if (!target) {
-        setStateTarget(null);
-      }
-
-      onTransitionEnd?.(event);
-    },
-    [target, onTransitionEnd],
-  );
+    prevTarget.current = target;
+  }, [open, target]);
 
   return (
     <Popper
       className={classes.root}
       open={open}
-      anchorEl={stateTarget as any}
+      anchorEl={target as any}
       transition
-      onTransitionEnd={handleTransitionEnd}
       placement={position}
       {...other}
     >

--- a/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
+++ b/packages/grid/_modules_/grid/components/menu/GridMenu.tsx
@@ -52,9 +52,15 @@ const transformOrigin = {
 
 const GridMenu = (props: GridMenuProps) => {
   const { open, target, onClickAway, children, position, ...other } = props;
+
+  const [stateTarget, setStateTarget] = React.useState(target)
   const prevTarget = React.useRef(target);
   const prevOpen = React.useRef(open);
   const classes = useStyles();
+
+  if (target && target !== stateTarget) {
+    setStateTarget(target)
+  }
 
   React.useEffect(() => {
     if (prevOpen.current && prevTarget.current) {
@@ -62,15 +68,25 @@ const GridMenu = (props: GridMenuProps) => {
     }
 
     prevOpen.current = open;
-    prevTarget.current = target;
-  }, [open, target]);
+
+    if (stateTarget) {
+      prevTarget.current = stateTarget;
+    }
+  }, [open, stateTarget]);
+
+  const handleTransitionEnd = React.useCallback(() => {
+    if (!target) {
+      setStateTarget(null)
+    }
+  }, [target])
 
   return (
     <Popper
       className={classes.root}
       open={open}
-      anchorEl={target as any}
+      anchorEl={stateTarget as any}
       transition
+      onTransitionEnd={handleTransitionEnd}
       placement={position}
       {...other}
     >

--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarDensitySelector.tsx
@@ -24,7 +24,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
 
     const [open, setOpen] = React.useState(false);
     const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const forkedButtonRef = useForkRef(ref, buttonRef);
+    const handleRef = useForkRef(ref, buttonRef);
 
     const densityOptions: GridDensityOption[] = [
       {
@@ -93,7 +93,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
     return (
       <React.Fragment>
         <Button
-          ref={forkedButtonRef}
+          ref={handleRef}
           color="primary"
           size="small"
           startIcon={startIcon}

--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarDensitySelector.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarDensitySelector.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { unstable_useId as useId } from '@mui/material/utils';
+import { unstable_useId as useId, useForkRef } from '@mui/material/utils';
 import MenuList from '@mui/material/MenuList';
 import Button, { ButtonProps } from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
@@ -21,7 +21,10 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
     const densityValue = useGridSelector(apiRef, gridDensityValueSelector);
     const densityButtonId = useId();
     const densityMenuId = useId();
-    const [anchorEl, setAnchorEl] = React.useState(null);
+
+    const [open, setOpen] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+    const forkedButtonRef = useForkRef(ref, buttonRef);
 
     const densityOptions: GridDensityOption[] = [
       {
@@ -53,13 +56,13 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
     }, [densityValue, rootProps]);
 
     const handleDensitySelectorOpen = (event) => {
-      setAnchorEl(event.currentTarget);
+      setOpen(true);
       onClick?.(event);
     };
-    const handleDensitySelectorClose = () => setAnchorEl(null);
+    const handleDensitySelectorClose = () => setOpen(false);
     const handleDensityUpdate = (newDensity: GridDensity) => {
       apiRef.current.setDensity(newDensity);
-      setAnchorEl(null);
+      setOpen(false);
     };
 
     const handleListKeyDown = (event: React.KeyboardEvent) => {
@@ -90,12 +93,12 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
     return (
       <React.Fragment>
         <Button
-          ref={ref}
+          ref={forkedButtonRef}
           color="primary"
           size="small"
           startIcon={startIcon}
           aria-label={apiRef.current.getLocaleText('toolbarDensityLabel')}
-          aria-expanded={anchorEl ? 'true' : undefined}
+          aria-expanded={open ? 'true' : undefined}
           aria-haspopup="menu"
           aria-labelledby={densityMenuId}
           id={densityButtonId}
@@ -105,8 +108,8 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
           {apiRef.current.getLocaleText('toolbarDensity')}
         </Button>
         <GridMenu
-          open={Boolean(anchorEl)}
-          target={anchorEl}
+          open={open}
+          target={buttonRef.current}
           onClickAway={handleDensitySelectorClose}
           position="bottom-start"
         >
@@ -115,7 +118,7 @@ export const GridToolbarDensitySelector = React.forwardRef<HTMLButtonElement, Bu
             className="MuiDataGrid-gridMenuList"
             aria-labelledby={densityButtonId}
             onKeyDown={handleListKeyDown}
-            autoFocusItem={Boolean(anchorEl)}
+            autoFocusItem={open}
           >
             {densityElements}
           </MenuList>

--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { unstable_useId as useId } from '@mui/material/utils';
+import { unstable_useId as useId, useForkRef } from '@mui/material/utils';
 import MenuList from '@mui/material/MenuList';
 import Button, { ButtonProps } from '@mui/material/Button';
 import MenuItem from '@mui/material/MenuItem';
@@ -32,7 +32,10 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
     const rootProps = useGridRootProps();
     const buttonId = useId();
     const menuId = useId();
-    const [anchorEl, setAnchorEl] = React.useState(null);
+
+    const [open, setOpen] = React.useState(false);
+    const buttonRef = React.useRef<HTMLButtonElement>(null);
+    const forkedButtonRef = useForkRef(ref, buttonRef);
 
     const exportOptions: Array<GridExportOption> = [];
     exportOptions.push({
@@ -42,16 +45,16 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
     });
 
     const handleMenuOpen = (event) => {
-      setAnchorEl(event.currentTarget);
+      setOpen(true);
       onClick?.(event);
     };
-    const handleMenuClose = () => setAnchorEl(null);
+    const handleMenuClose = () => setOpen(false);
     const handleExport = (option: GridExportOption) => () => {
       if (option.format === 'csv') {
         apiRef.current.exportDataAsCsv(option.formatOptions);
       }
 
-      setAnchorEl(null);
+      setOpen(false);
     };
 
     const handleListKeyDown = (event: React.KeyboardEvent) => {
@@ -66,11 +69,11 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
     return (
       <React.Fragment>
         <Button
-          ref={ref}
+          ref={forkedButtonRef}
           color="primary"
           size="small"
           startIcon={<rootProps.components.ExportIcon />}
-          aria-expanded={anchorEl ? 'true' : undefined}
+          aria-expanded={open ? 'true' : undefined}
           aria-label={apiRef.current.getLocaleText('toolbarExportLabel')}
           aria-haspopup="menu"
           aria-labelledby={menuId}
@@ -81,8 +84,8 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
           {apiRef.current.getLocaleText('toolbarExport')}
         </Button>
         <GridMenu
-          open={Boolean(anchorEl)}
-          target={anchorEl}
+          open={open}
+          target={buttonRef.current}
           onClickAway={handleMenuClose}
           position="bottom-start"
         >
@@ -91,7 +94,7 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
             className="MuiDataGrid-gridMenuList"
             aria-labelledby={buttonId}
             onKeyDown={handleListKeyDown}
-            autoFocusItem={Boolean(anchorEl)}
+            autoFocusItem={open}
           >
             {exportOptions.map((option, index) => (
               <MenuItem key={index} onClick={handleExport(option)}>

--- a/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
+++ b/packages/grid/_modules_/grid/components/toolbar/GridToolbarExport.tsx
@@ -35,7 +35,7 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
 
     const [open, setOpen] = React.useState(false);
     const buttonRef = React.useRef<HTMLButtonElement>(null);
-    const forkedButtonRef = useForkRef(ref, buttonRef);
+    const handleRef = useForkRef(ref, buttonRef);
 
     const exportOptions: Array<GridExportOption> = [];
     exportOptions.push({
@@ -69,7 +69,7 @@ const GridToolbarExport = React.forwardRef<HTMLButtonElement, GridToolbarExportP
     return (
       <React.Fragment>
         <Button
-          ref={forkedButtonRef}
+          ref={handleRef}
           color="primary"
           size="small"
           startIcon={<rootProps.components.ExportIcon />}


### PR DESCRIPTION
Closes #2720 

https://user-images.githubusercontent.com/3309670/135226242-4e47113b-9436-4a3d-9039-817bc3808f32.mp4


