### PR TITLE
[core] Fix rollup external warnings

### DIFF
--- a/packages/grid/rollup.data-grid.config.js
+++ b/packages/grid/rollup.data-grid.config.js
@@ -25,7 +25,10 @@ export default [
         sourcemap: !production,
       },
     ],
-    external: [...Object.keys(pkg.peerDependencies || {})],
+    external: Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies }).map((packageName) => {
+      // Make sure that e.g. `react` as well as `react/jsx-runtime` is considered an external
+      return new RegExp(`(${packageName}|${packageName}\\/.*)`);
+    }),
     plugins: [
       production &&
         cleaner({

--- a/packages/grid/rollup.x-grid-data-generator.config.js
+++ b/packages/grid/rollup.x-grid-data-generator.config.js
@@ -28,7 +28,10 @@ export default [
         sourcemap: !production,
       },
     ],
-    external: [...Object.keys(pkg.peerDependencies || {})],
+    external: Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies }).map((packageName) => {
+      // Make sure that e.g. `react` as well as `react/jsx-runtime` is considered an external
+      return new RegExp(`(${packageName}|${packageName}\\/.*)`);
+    }),
     plugins: [
       production &&
         cleaner({

--- a/packages/grid/rollup.x-grid.config.js
+++ b/packages/grid/rollup.x-grid.config.js
@@ -27,7 +27,10 @@ export default [
         sourcemap: !production,
       },
     ],
-    external: [...Object.keys(pkg.peerDependencies || {})],
+    external: Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies }).map((packageName) => {
+      // Make sure that e.g. `react` as well as `react/jsx-runtime` is considered an external
+      return new RegExp(`(${packageName}|${packageName}\\/.*)`);
+    }),
     plugins: [
       replace({
         __RELEASE_INFO__: generateReleaseInfo(),

--- a/packages/x-license/rollup.config.js
+++ b/packages/x-license/rollup.config.js
@@ -27,7 +27,10 @@ export default [
         sourcemap: !production,
       },
     ],
-    external: [...Object.keys(pkg.peerDependencies || {})],
+    external: Object.keys({ ...pkg.peerDependencies, ...pkg.dependencies }).map((packageName) => {
+      // Make sure that e.g. `react` as well as `react/jsx-runtime` is considered an external
+      return new RegExp(`(${packageName}|${packageName}\\/.*)`);
+    }),
     plugins: [
       production &&
         cleaner({


### PR DESCRIPTION
List just `'react'` in `external` would not include `'react/jsx-runtime'`. We do want to consider both as external which is what rollup is already doing. The warning is annoying though so let's explicitly encode the desired behavior.