### PR TITLE
[DataGrid] Don't filter numeric column when value is empty

### DIFF
--- a/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterInputValue.tsx
+++ b/packages/grid/_modules_/grid/components/panel/filterPanel/GridFilterInputValue.tsx
@@ -61,6 +61,12 @@ function GridFilterInputValue(props: GridTypeFilterInputValueProps & TextFieldPr
 
       clearTimeout(filterTimeout.current);
       setFilterValueState(String(value));
+
+      if (type !== 'singleSelect' && value === '') {
+        setIsApplying(false);
+        return;
+      }
+
       setIsApplying(true);
       // TODO singleSelect doesn't a debounce
       filterTimeout.current = setTimeout(() => {

--- a/packages/grid/_modules_/grid/models/colDef/gridNumericOperators.ts
+++ b/packages/grid/_modules_/grid/models/colDef/gridNumericOperators.ts
@@ -7,7 +7,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '=',
     value: '=',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 
@@ -22,7 +22,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '!=',
     value: '!=',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 
@@ -37,7 +37,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '>',
     value: '>',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 
@@ -52,7 +52,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '>=',
     value: '>=',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 
@@ -67,7 +67,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '<',
     value: '<',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 
@@ -82,7 +82,7 @@ export const getGridNumericColumnOperators = (): GridFilterOperator[] => [
     label: '<=',
     value: '<=',
     getApplyFilterFn: (filterItem: GridFilterItem) => {
-      if (filterItem.value == null) {
+      if (filterItem.value == null || Number.isNaN(filterItem.value)) {
         return null;
       }
 

--- a/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/filtering.DataGrid.test.tsx
@@ -350,11 +350,17 @@ describe('<DataGrid /> - Filter', () => {
       { operatorValue: '>=', value: 0, expected: [0, 1984, 1954, 1974] },
       { operatorValue: '<', value: 0, expected: [] },
       { operatorValue: '<=', value: 0, expected: [0] },
+      { operatorValue: '=', value: undefined, expected: [0, 1984, 1954, 1974] },
+      { operatorValue: '!=', value: undefined, expected: [0, 1984, 1954, 1974] },
+      { operatorValue: '>', value: undefined, expected: [0, 1984, 1954, 1974] },
+      { operatorValue: '>=', value: undefined, expected: [0, 1984, 1954, 1974] },
+      { operatorValue: '<', value: undefined, expected: [0, 1984, 1954, 1974] },
+      { operatorValue: '<=', value: undefined, expected: [0, 1984, 1954, 1974] },
     ].forEach(({ operatorValue, value, expected }) => {
-      it(`should allow object as value and work with valueGetter, operatorValue: ${operatorValue}, value: ${value}`, () => {
+      it(`should allow object as value and work with valueGetter, operatorValue: ${operatorValue}, value: '${value}'`, () => {
         render(
           <TestCase
-            value={value.toString()}
+            value={value?.toString()}
             operatorValue={operatorValue}
             rows={[
               { id: 2, brand: { year: 0 } },


### PR DESCRIPTION
Fixes #2779 

This fix works by not filtering if the value field is empty. To filter empty values there're dedicated operators. The reason to ignore `singleSelect` is because the first option might be `<option value="">Any</option>`, which in this case it should filter when "empty".