### PR TITLE
[docs] Fix pagination in Ant Design demo

### DIFF
--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.js
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.js
@@ -115,8 +115,7 @@ function CustomPagination() {
       shape="rounded"
       page={state.pagination.page}
       count={state.pagination.pageCount}
-      // @ts-expect-error
-      renderItem={(props2) => <PaginationItem {...props2} disableRipple />}
+      renderItem={(props2) => <PaginationItem {...props2} />}
       onChange={(event, value) => apiRef.current.setPage(value)}
     />
   );

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.js
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.js
@@ -113,10 +113,10 @@ function CustomPagination() {
       color="primary"
       variant="outlined"
       shape="rounded"
-      page={state.pagination.page}
+      page={state.pagination.page + 1}
       count={state.pagination.pageCount}
       renderItem={(props2) => <PaginationItem {...props2} />}
-      onChange={(event, value) => apiRef.current.setPage(value)}
+      onChange={(event, value) => apiRef.current.setPage(value - 1)}
     />
   );
 }

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
@@ -113,10 +113,12 @@ function CustomPagination() {
       color="primary"
       variant="outlined"
       shape="rounded"
-      page={state.pagination.page}
+      page={state.pagination.page + 1}
       count={state.pagination.pageCount}
       renderItem={(props2) => <PaginationItem {...props2} />}
-      onChange={(event, value) => apiRef.current.setPage(value)}
+      onChange={(event: React.ChangeEvent<unknown>, value: number) =>
+        apiRef.current.setPage(value - 1)
+      }
     />
   );
 }

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx
@@ -115,8 +115,7 @@ function CustomPagination() {
       shape="rounded"
       page={state.pagination.page}
       count={state.pagination.pageCount}
-      // @ts-expect-error
-      renderItem={(props2) => <PaginationItem {...props2} disableRipple />}
+      renderItem={(props2) => <PaginationItem {...props2} />}
       onChange={(event, value) => apiRef.current.setPage(value)}
     />
   );


### PR DESCRIPTION
Point 3 of #2685 

The `Pagination` component's `page` prop starts at 1 while the DataGrid's default `TablePagination` starts at 0.