### PR TITLE
[docs] Explain how to use valueGetter to transform type

### DIFF
--- a/docs/src/pages/components/data-grid/columns/ValueGetterGrid.js
+++ b/docs/src/pages/components/data-grid/columns/ValueGetterGrid.js
@@ -15,7 +15,6 @@ const columns = [
     headerName: 'Full name',
     width: 160,
     valueGetter: getFullName,
-    sortComparator: (v1, v2) => v1.toString().localeCompare(v2.toString()),
   },
 ];
 

--- a/docs/src/pages/components/data-grid/columns/ValueGetterGrid.tsx
+++ b/docs/src/pages/components/data-grid/columns/ValueGetterGrid.tsx
@@ -15,7 +15,6 @@ const columns: GridColDef[] = [
     headerName: 'Full name',
     width: 160,
     valueGetter: getFullName,
-    sortComparator: (v1, v2) => v1!.toString().localeCompare(v2!.toString()),
   },
 ];
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -280,7 +280,7 @@ The following are the native column types:
 
 ### Converting types
 
-Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values.
+Default methods, such as filtering and sorting, assume that the type of the values will match the type of the column specified in `type` (e.g. the values of a `number` column will be numbers).
 For example, values of column with `type: 'dateTime'` are expecting to be stored as a `Date()` objects.
 If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -309,6 +309,17 @@ However, some types require additional properties to be set to make them work co
   }
   ```
 
+Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values. For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects. If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
+
+```tsx
+{
+  field: 'lastLogin',
+  type: 'dateTime',
+  valueGetter: ({ value }) => value && new Date(value),
+  sortComparator: (v1, v2) => (new Date(v1) < new Date(v2) ? -1 : 1)
+}
+```
+
 {{"demo": "pages/components/data-grid/columns/ColumnTypesGrid.js", "bg": "inline"}}
 
 ## Custom column types

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -282,6 +282,21 @@ The following are the native column types:
 - `'singleSelect'`
 - `'actions'`
 
+### Converting types
+
+Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values. For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects. If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
+
+```tsx
+{
+  field: 'lastLogin',
+  type: 'dateTime',
+  valueGetter: ({ value }) => value && new Date(value),
+  sortComparator: (v1, v2) => (new Date(v1) < new Date(v2) ? -1 : 1)
+}
+```
+
+### Special properties
+
 To use most of the column types, you only need to define the `type` property in your column definition.
 However, some types require additional properties to be set to make them work correctly:
 
@@ -308,17 +323,6 @@ However, some types require additional properties to be set to make them work co
     ]
   }
   ```
-
-Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values. For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects. If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
-
-```tsx
-{
-  field: 'lastLogin',
-  type: 'dateTime',
-  valueGetter: ({ value }) => value && new Date(value),
-  sortComparator: (v1, v2) => (new Date(v1) < new Date(v2) ? -1 : 1)
-}
-```
 
 {{"demo": "pages/components/data-grid/columns/ColumnTypesGrid.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -284,7 +284,9 @@ The following are the native column types:
 
 ### Converting types
 
-Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values. For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects. If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
+Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values.
+For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects.
+If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
 
 ```tsx
 {

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -281,7 +281,7 @@ The following are the native column types:
 ### Converting types
 
 Default methods such as filtering or sorting assume that `type` corresponds to the type of the stored values.
-For example, values of column with `type:'dateTime'` are expecting to be stored as a `Date()` objects.
+For example, values of column with `type: 'dateTime'` are expecting to be stored as a `Date()` objects.
 If for any reason, your data type is not the correct one, you can use `valueGetter` to parse the value to the correct type.
 
 ```tsx

--- a/docs/src/pages/components/data-grid/columns/columns.md
+++ b/docs/src/pages/components/data-grid/columns/columns.md
@@ -107,8 +107,6 @@ Sometimes a column might not have a corresponding value, or you might want to re
 
 To achieve that, set the `valueGetter` attribute of `GridColDef` as in the example below.
 
-**Note**: You need to set a `sortComparator` for the column sorting to work when setting the `valueGetter` attribute.
-
 ```tsx
 function getFullName(params) {
   return `${params.getValue(params.id, 'firstName') || ''} ${
@@ -124,8 +122,6 @@ const columns: GridColDef[] = [
     headerName: 'Full name',
     width: 160,
     valueGetter: getFullName,
-    sortComparator: (v1, v2, cellParams1, cellParams2) =>
-      getFullName(cellParams1).localeCompare(getFullName(cellParams2)),
   },
 ];
 ```
@@ -293,7 +289,6 @@ If for any reason, your data type is not the correct one, you can use `valueGett
   field: 'lastLogin',
   type: 'dateTime',
   valueGetter: ({ value }) => value && new Date(value),
-  sortComparator: (v1, v2) => (new Date(v1) < new Date(v2) ? -1 : 1)
 }
 ```
 


### PR DESCRIPTION
Solves #1313

add a paragraph in "column types" section to explain that column of type `"dateTime"` should not be stored with a string value.

I added subsections to separate clearly the two topics:
 - the additional properties
 - data type

preview: https://deploy-preview-3003--material-ui-x.netlify.app/components/data-grid/columns/#column-types