### PR TITLE
[core] Run at most one setGridState and one applyFilters when updating the filterModel due to column changes

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -341,14 +341,10 @@ export const useGridFilter = (
     logger.debug('onColUpdated - GridColumns changed, applying filters');
     const filterModel = gridFilterModelSelector(apiRef.current.state);
     const columnsIds = filterableGridColumnsIdsSelector(apiRef.current.state);
-    logger.debug('GridColumns changed, applying filters');
-
-    filterModel.items.forEach((filter) => {
-      if (!columnsIds.find((field) => field === filter.columnField)) {
-        apiRef.current.deleteFilterItem(filter);
-      }
-    });
-    apiRef.current.unsafe_applyFilters();
+    const newFilterItems = filterModel.items.filter(item => item.columnField && columnsIds.includes(item.columnField))
+    if (newFilterItems.length < filterModel.items.length) {
+      apiRef.current.setFilterModel({ ...filterModel, items: newFilterItems })
+    }
   }, [apiRef, logger]);
 
   React.useEffect(() => {

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -257,8 +257,9 @@ export const useGridFilter = (
       });
       if (gridFilterModelSelector(apiRef.current.state).items.length === 0) {
         apiRef.current.upsertFilterItem({});
+      } else {
+        apiRef.current.unsafe_applyFilters();
       }
-      apiRef.current.unsafe_applyFilters();
     },
     [apiRef, logger, setGridState],
   );

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -341,9 +341,11 @@ export const useGridFilter = (
     logger.debug('onColUpdated - GridColumns changed, applying filters');
     const filterModel = gridFilterModelSelector(apiRef.current.state);
     const columnsIds = filterableGridColumnsIdsSelector(apiRef.current.state);
-    const newFilterItems = filterModel.items.filter(item => item.columnField && columnsIds.includes(item.columnField))
+    const newFilterItems = filterModel.items.filter(
+      (item) => item.columnField && columnsIds.includes(item.columnField),
+    );
     if (newFilterItems.length < filterModel.items.length) {
-      apiRef.current.setFilterModel({ ...filterModel, items: newFilterItems })
+      apiRef.current.setFilterModel({ ...filterModel, items: newFilterItems });
     }
   }, [apiRef, logger]);
 

--- a/scripts/exportsSnapshot.json
+++ b/scripts/exportsSnapshot.json
@@ -135,6 +135,7 @@
   { "name": "GridToolbarFilterButtonProps", "kind": "Interface" },
   { "name": "GridTypeFilterInputValueProps", "kind": "Interface" },
   { "name": "GridValueFormatterParams", "kind": "Interface" },
+  { "name": "GridValueOptionsParams", "kind": "Interface" },
   { "name": "GridValueSetterParams", "kind": "Interface" },
   { "name": "Logger", "kind": "Interface" },
   { "name": "DataGridProps", "kind": "Type alias" },


### PR DESCRIPTION
Before, for N column with a filter removed, we ran (N+1) `applyFilters` and N `setGridState`.

For instance, if we changed the columns but did not impact any column with a filterItem, we re-applied the filter anyway.
And if we removed 2 columns that had a filter item, we ran the filters 3 times and did 2 `setGridState).

And the best scenario for the end, if you removed all the columns that had a filter item, it was N+2 `applyFilters`.
So if you had 2 filter item, you removed both columns, you ended up with 4 application of the filters.