### PR TITLE
[test] Retry each expect until success

### DIFF
--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -119,7 +119,7 @@ describe('e2e', () => {
       });
       await page.keyboard.press('Tab');
       await waitFor(async () => {
-        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('1000');
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('100');
         expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
           'button',
         );

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,9 +1,27 @@
 import { expect } from 'chai';
+import * as path from 'path';
 import * as playwright from 'playwright';
 
 function sleep(timeoutMS: number): Promise<void> {
   return new Promise((resolve) => {
     setTimeout(() => resolve(), timeoutMS);
+  });
+}
+
+// A simplified version of https://github.com/testing-library/dom-testing-library/blob/main/src/wait-for.js
+function waitFor(callback: () => Promise<void>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    async function checkCallback(attemptsRemaining = 5, lastError: any = null) {
+      if (attemptsRemaining <= 0) {
+        throw lastError;
+      }
+      try {
+        await callback();
+      } catch (error) {
+        await checkCallback(attemptsRemaining - 1, error);
+      }
+    }
+    checkCallback().then(resolve, reject);
   });
 }
 
@@ -45,8 +63,11 @@ describe('e2e', () => {
   before(async function beforeHook() {
     this.timeout(20000);
 
-    browser = await playwright.chromium.launch({
+    browser = await playwright.chromium.launchPersistentContext('', {
       headless: true,
+      recordVideo: {
+        dir: path.resolve(__dirname, '../../'),
+      },
     });
     page = await browser.newPage();
     const isServerRunning = await attemptGoto(page, `${baseUrl}#no-dev`);
@@ -80,30 +101,46 @@ describe('e2e', () => {
         await page.evaluate(() => document.activeElement?.getAttribute('data-testid')),
       ).to.equal('initial-focus');
       await page.keyboard.press('Tab');
+      await waitFor(async () => {
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('brand');
+        expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+          'columnheader',
+        );
+      });
       await page.keyboard.press('ArrowDown');
-      expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Nike');
-      expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
-        'cell',
-      );
+      await waitFor(async () => {
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Nike');
+        expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+          'cell',
+        );
+      });
       await page.keyboard.press('ArrowDown');
-      expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Adidas');
-      expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
-        'cell',
-      );
+      await waitFor(async () => {
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Adidas');
+        expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+          'cell',
+        );
+      });
       await page.keyboard.press('Tab');
-      expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('100');
-      expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
-        'button',
-      );
+      await waitFor(async () => {
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('100');
+        expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+          'button',
+        );
+      });
       await page.keyboard.press('Shift+Tab');
-      expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Adidas');
-      expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
-        'cell',
-      );
+      await waitFor(async () => {
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('Adidas');
+        expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+          'cell',
+        );
+      });
       await page.keyboard.press('Shift+Tab');
-      expect(
-        await page.evaluate(() => document.activeElement?.getAttribute('data-testid')),
-      ).to.equal('initial-focus');
+      await waitFor(async () => {
+        expect(
+          await page.evaluate(() => document.activeElement?.getAttribute('data-testid')),
+        ).to.equal('initial-focus');
+      });
     });
 
     it('should display the rows', async () => {

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import * as path from 'path';
 import * as playwright from 'playwright';
 
 function sleep(timeoutMS: number): Promise<void> {
@@ -63,11 +62,8 @@ describe('e2e', () => {
   before(async function beforeHook() {
     this.timeout(20000);
 
-    browser = await playwright.chromium.launchPersistentContext('', {
+    browser = await playwright.chromium.launch({
       headless: true,
-      recordVideo: {
-        dir: path.resolve(__dirname, '../../'),
-      },
     });
     page = await browser.newPage();
     const isServerRunning = await attemptGoto(page, `${baseUrl}#no-dev`);

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -119,7 +119,7 @@ describe('e2e', () => {
       });
       await page.keyboard.press('Tab');
       await waitFor(async () => {
-        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('100');
+        expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('1000');
         expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
           'button',
         );


### PR DESCRIPTION
I believe this test fails because it's not waiting for the keyboard commands to take effect. It dispatches the command and immediately runs the assertion. I'm trying to fix it here by adding a `waitFor` which tries to assert a couple of times before giving up and throwing the error. I ran `yarn test:e2e` a good 10 times via SSH on CircleCI and all passed. I might be a little biased because I had to run #3026 more than 10 times to have one failing.

From #3026. The tab roving test begins at frame 59.

https://user-images.githubusercontent.com/42154031/139518181-78c597e2-bc76-49e1-a303-ce8ac4fea72f.mp4

This PR. The tab roving test begins at frame 84.

https://user-images.githubusercontent.com/42154031/139518358-6428fa40-2b3d-43fa-a691-4c965df26cfa.mp4

Both recordings are supposed to be at 60 fps, however I noticed that some frames are lost.
