### PR TITLE
[core] Automatically close issues that are incomplete and inactive

### DIFF
--- a/.github/workflows/close-incomplete-inactive.yml
+++ b/.github/workflows/close-incomplete-inactive.yml
@@ -1,0 +1,17 @@
+name: Close incomplete inactive
+on:
+  schedule:
+    - cron: "0 0 * * *"
+jobs:
+  close-issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Need more information
+        uses: actions-cool/issues-helper@v2
+        with:
+          actions: 'close-issues'
+          labels: 'status: incomplete'
+          inactive-day: 7
+          body: |
+            Since the issue is missing key information, and has been inactive for 7 days, it has been automatically closed.
+            If you wish to see the issue reopened, please provide the missing information.


### PR DESCRIPTION
This is identical to https://github.com/mui-org/material-ui/pull/27638. I do believe that it would be a net positive for the efficiency of the team. You can see it used at Ant Design for over 8 months with a [close delay of 3 days](https://github.com/ant-design/ant-design/blob/a0982081fa19b67eaf2064dc2e2845e00942aeba/.github/workflows/issue-close-require.yml).

If this experimentation is successful here, I think that we should move it to the other repositories. In the past, I didn't move forward in the main repository because Sebastian was against giving it a try. 

## Why work on it now?

I saw https://github.com/mui-org/material-ui-x/issues/2559#issuecomment-950734506, it seems to be a waste of time to have to go back to older issues to close them manually. 

## Drawback?

I think that the main one is: What happens if a developer leaves the [`status: incomplete`](https://github.com/mui-org/material-ui-x/issues?q=is%3Aissue+is%3Aopen+label%3A%22status%3A+incomplete%22+) label and miss the notification of a user with the reproduction in 7 days? Then the issue gets closed by mistake. I would argue that if we get so many notifications that we can't process an update from a user in 7 days, something else is wrong (understaffed, too ambitious on how many issues one can own, forgotten to transfer the issues owned to someone else in the team when going on holidays, etc.)