### PR TITLE
[DataGrid] Fix transitive dependency

### DIFF
--- a/packages/grid/data-grid/package.json
+++ b/packages/grid/data-grid/package.json
@@ -37,6 +37,7 @@
     "directory": "packages/grid/data-grid"
   },
   "dependencies": {
+    "@mui/system": "^5.0.1",
     "@mui/utils": "^5.0.1",
     "clsx": "^1.1.1",
     "prop-types": "^15.7.2",

--- a/packages/grid/x-grid/package.json
+++ b/packages/grid/x-grid/package.json
@@ -37,6 +37,7 @@
     "directory": "packages/grid/x-grid"
   },
   "dependencies": {
+    "@mui/system": "^5.0.1",
     "@mui/utils": "^5.0.1",
     "@mui/x-license-pro": "5.0.0-beta.6",
     "clsx": "^1.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2474,6 +2474,15 @@
     "@emotion/cache" "^11.4.0"
     prop-types "^15.7.2"
 
+"@mui/styled-engine@^5.0.2":
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/@mui/styled-engine/-/styled-engine-5.0.2.tgz#a2d188e80d2c8c3501316649c1901a41ac07e376"
+  integrity sha512-vApnXLj/5V+SbBy+jGFtPgu3tgs0ybSdwWLwXcnUAdNdRyJBffi2KyOP8fhUONLOcZBMU2heNXWz/Zqn5kbDKQ==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@emotion/cache" "^11.5.0"
+    prop-types "^15.7.2"
+
 "@mui/styles@^5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@mui/styles/-/styles-5.0.1.tgz#1634d08d892b5c7e85c9f84e4fc8bc02a5fb0f7a"
@@ -2495,6 +2504,20 @@
     jss-plugin-props-sort "^10.8.0"
     jss-plugin-rule-value-function "^10.8.0"
     jss-plugin-vendor-prefixer "^10.8.0"
+    prop-types "^15.7.2"
+
+"@mui/system@^5.0.1":
+  version "5.0.6"
+  resolved "https://registry.yarnpkg.com/@mui/system/-/system-5.0.6.tgz#053ad18e3888f041137db9f0c0ac1486c86972a0"
+  integrity sha512-qZdgODiO82/r1bH9KV5bdqqx/q14i32OGUK/bO6phhXM/DX0TmWSUsnPqFX4F7/UKrvBHsGzIb8ohdRuihQD+Q==
+  dependencies:
+    "@babel/runtime" "^7.15.4"
+    "@mui/private-theming" "^5.0.1"
+    "@mui/styled-engine" "^5.0.2"
+    "@mui/types" "^7.0.0"
+    "@mui/utils" "^5.0.1"
+    clsx "^1.1.1"
+    csstype "^3.0.9"
     prop-types "^15.7.2"
 
 "@mui/system@^5.0.4":


### PR DESCRIPTION
We have this line https://github.com/mui-org/material-ui-x/blob/3ad0e791be440de82aeadc9acd5b861887c6838a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts#L1

and yet no direct dependency on the package. Yarn 2 would fail on a JS module (here it's a TS one, I don't really know what happens). In the future, with the objective to support multiple design systems, we will likely do:

```diff
-import { darken, lighten, alpha, styled } from '@mui/material/styles';
+import { darken, lighten, alpha, styled } from '@mui/system';
```