### PR TITLE
[docs] Fix the outdated demo of the docs

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/Codesandbox.js
+++ b/docs/src/pages/components/data-grid/getting-started/Codesandbox.js
@@ -4,7 +4,7 @@ export default function Codesandbox() {
   return (
     <iframe
       title="codesandbox"
-      src="https://codesandbox.io/embed/d3ex9?hidenavigation=1&fontsize=14&view=preview"
+      src="https://codesandbox.io/embed/datagrid-quick-start-0whfr?hidenavigation=1&fontsize=14&view=preview"
       style={{
         width: '100%',
         height: 400,


### PR DESCRIPTION
What really matters here is that I have moved the owner of the codesandbox from my personal profile to the MUI's org one. This is important so that we can keep the demo up to date without having to do yet another PR like this one.

- Before: https://codesandbox.io/s/d3ex9
- After: https://codesandbox.io/s/datagrid-quick-start-0whfr

Preview: https://deploy-preview-3058--material-ui-x.netlify.app/components/data-grid/getting-started/#demo