### PR TITLE
[test] Fix flaky e2e tests

### DIFF
--- a/test/e2e/.mocharc.js
+++ b/test/e2e/.mocharc.js
@@ -2,7 +2,7 @@ module.exports = {
   extension: ['js', 'ts', 'tsx'],
   recursive: true,
   slow: 500,
-  timeout: (process.env.CIRCLECI === 'true' ? 4 : 2) * 1000, // Circle CI has low-performance CPUs.
+  timeout: (process.env.CIRCLECI === 'true' ? 6 : 2) * 1000, // Circle CI has low-performance CPUs.
   reporter: 'dot',
   require: [require.resolve('../utils/setupBabel')],
 };


### PR DESCRIPTION
Some e2e tests fail with
```
Error: Timeout of 4000ms exceeded. For async tests and hooks, ensure "done()" is called; if returning a Promise, ensure it resolves.
```

I do not see any other way than increasing the timeout parameter.