### PR TITLE
[core] Ignore *.tsbuildinfo files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 __diff_output__
 .DS_STORE
 *.log
+*.tsbuildinfo
 /.eslintcache
 /.nyc_output
 /coverage


### PR DESCRIPTION
Follow-up to #3054 

Nextjs 12 added `incremental` support which generates a xxx.tsbuildinfo file during build.

It matches with https://github.com/mui-org/material-ui/blob/master/.gitignore#L7