### PR TITLE
[DataGrid] Keyboard navigation broken on page > 0

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -142,16 +142,10 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      if (currentPage.range.lastRowIndex > 0) {
-        nextCellIndexes.rowIndex = Math.min(
-          currentPage.range.lastRowIndex,
-          nextCellIndexes.rowIndex,
-        );
-      }
-
-      nextCellIndexes.colIndex = nextCellIndexes.colIndex <= 0 ? 0 : nextCellIndexes.colIndex;
-      nextCellIndexes.colIndex =
-        nextCellIndexes.colIndex >= colCount ? colCount - 1 : nextCellIndexes.colIndex;
+      nextCellIndexes.rowIndex = Math.min(0, nextCellIndexes.rowIndex);
+      nextCellIndexes.rowIndex = Math.min(currentPage.range.lastRowIndex, nextCellIndexes.rowIndex);
+      nextCellIndexes.colIndex = Math.max(0, nextCellIndexes.colIndex);
+      nextCellIndexes.colIndex = Math.min(colCount - 1, nextCellIndexes.colIndex);
       logger.debug(
         `Navigating to next cell row ${nextCellIndexes.rowIndex}, col ${nextCellIndexes.colIndex}`,
       );

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -142,7 +142,7 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex = Math.min(0, nextCellIndexes.rowIndex);
+      nextCellIndexes.rowIndex = Math.max(0, nextCellIndexes.rowIndex);
       nextCellIndexes.rowIndex = Math.min(currentPage.range.lastRowIndex, nextCellIndexes.rowIndex);
       nextCellIndexes.colIndex = Math.max(0, nextCellIndexes.colIndex);
       nextCellIndexes.colIndex = Math.min(colCount - 1, nextCellIndexes.colIndex);

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -102,7 +102,6 @@ export const useGridKeyboardNavigation = (
 
       const key = mapKey(event);
       const isCtrlPressed = event.ctrlKey || event.metaKey || event.shiftKey;
-      const rowCount = currentPage.range.lastRowIndex - currentPage.range.firstRowIndex + 1;
 
       let nextCellIndexes: GridCellIndexCoordinates;
       if (isArrowKeys(key)) {
@@ -122,7 +121,7 @@ export const useGridKeyboardNavigation = (
           if (colIdx === 0) {
             newRowIndex = currentPage.range.firstRowIndex;
           } else {
-            newRowIndex = rowCount - 1;
+            newRowIndex = currentPage.range.lastRowIndex;
           }
           nextCellIndexes = { colIndex: colIdx, rowIndex: newRowIndex };
         }
@@ -144,8 +143,9 @@ export const useGridKeyboardNavigation = (
       }
 
       nextCellIndexes.rowIndex =
-        nextCellIndexes.rowIndex >= rowCount && rowCount > 0
-          ? rowCount - 1
+        nextCellIndexes.rowIndex >= currentPage.range.lastRowIndex &&
+        currentPage.range.lastRowIndex > 0
+          ? currentPage.range.lastRowIndex
           : nextCellIndexes.rowIndex;
       nextCellIndexes.colIndex = nextCellIndexes.colIndex <= 0 ? 0 : nextCellIndexes.colIndex;
       nextCellIndexes.colIndex =

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -142,11 +142,13 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex =
-        nextCellIndexes.rowIndex >= currentPage.range.lastRowIndex &&
-        currentPage.range.lastRowIndex > 0
-          ? currentPage.range.lastRowIndex
-          : nextCellIndexes.rowIndex;
+      if (currentPage.range.lastRowIndex > 0) {
+        nextCellIndexes.rowIndex = Math.min(
+          currentPage.range.lastRowIndex,
+          nextCellIndexes.rowIndex,
+        );
+      }
+
       nextCellIndexes.colIndex = nextCellIndexes.colIndex <= 0 ? 0 : nextCellIndexes.colIndex;
       nextCellIndexes.colIndex =
         nextCellIndexes.colIndex >= colCount ? colCount - 1 : nextCellIndexes.colIndex;

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -23,7 +23,7 @@ import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridComponentProps } from '../../../GridComponentProps';
 import { gridVisibleSortedRowEntriesSelector } from '../filter/gridFilterSelector';
 import { useCurrentPageRows } from '../../utils/useCurrentPageRows';
-import { clipNumber } from '../../../utils/utils';
+import { clamp } from '../../../utils/utils';
 
 const getNextCellIndexes = (key: string, indexes: GridCellIndexCoordinates) => {
   if (!isArrowKeys(key)) {
@@ -143,12 +143,8 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex = clipNumber(
-        nextCellIndexes.rowIndex,
-        0,
-        currentPage.range.lastRowIndex,
-      );
-      nextCellIndexes.colIndex = clipNumber(nextCellIndexes.colIndex, 0, colCount - 1);
+      nextCellIndexes.rowIndex = clamp(nextCellIndexes.rowIndex, 0, currentPage.range.lastRowIndex);
+      nextCellIndexes.colIndex = clamp(nextCellIndexes.colIndex, 0, colCount - 1);
       logger.debug(
         `Navigating to next cell row ${nextCellIndexes.rowIndex}, col ${nextCellIndexes.colIndex}`,
       );

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -23,7 +23,7 @@ import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridComponentProps } from '../../../GridComponentProps';
 import { gridVisibleSortedRowEntriesSelector } from '../filter/gridFilterSelector';
 import { useCurrentPageRows } from '../../utils/useCurrentPageRows';
-import { setInInterval } from '../../../utils/utils';
+import { clipNumber } from '../../../utils/utils';
 
 const getNextCellIndexes = (key: string, indexes: GridCellIndexCoordinates) => {
   if (!isArrowKeys(key)) {
@@ -143,12 +143,12 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex = setInInterval(
+      nextCellIndexes.rowIndex = clipNumber(
         nextCellIndexes.rowIndex,
         0,
         currentPage.range.lastRowIndex,
       );
-      nextCellIndexes.colIndex = setInInterval(nextCellIndexes.colIndex, 0, colCount - 1);
+      nextCellIndexes.colIndex = clipNumber(nextCellIndexes.colIndex, 0, colCount - 1);
       logger.debug(
         `Navigating to next cell row ${nextCellIndexes.rowIndex}, col ${nextCellIndexes.colIndex}`,
       );

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -23,6 +23,7 @@ import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridComponentProps } from '../../../GridComponentProps';
 import { gridVisibleSortedRowEntriesSelector } from '../filter/gridFilterSelector';
 import { useCurrentPageRows } from '../../utils/useCurrentPageRows';
+import { setInInterval } from '../../../utils/utils';
 
 const getNextCellIndexes = (key: string, indexes: GridCellIndexCoordinates) => {
   if (!isArrowKeys(key)) {
@@ -142,11 +143,12 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex = Math.max(
+      nextCellIndexes.rowIndex = setInInterval(
+        nextCellIndexes.rowIndex,
         0,
-        Math.min(currentPage.range.lastRowIndex, nextCellIndexes.rowIndex),
+        currentPage.range.lastRowIndex,
       );
-      nextCellIndexes.colIndex = Math.max(0, Math.min(colCount - 1, nextCellIndexes.colIndex));
+      nextCellIndexes.colIndex = setInInterval(nextCellIndexes.colIndex, 0, colCount - 1);
       logger.debug(
         `Navigating to next cell row ${nextCellIndexes.rowIndex}, col ${nextCellIndexes.colIndex}`,
       );

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -142,10 +142,11 @@ export const useGridKeyboardNavigation = (
         return;
       }
 
-      nextCellIndexes.rowIndex = Math.max(0, nextCellIndexes.rowIndex);
-      nextCellIndexes.rowIndex = Math.min(currentPage.range.lastRowIndex, nextCellIndexes.rowIndex);
-      nextCellIndexes.colIndex = Math.max(0, nextCellIndexes.colIndex);
-      nextCellIndexes.colIndex = Math.min(colCount - 1, nextCellIndexes.colIndex);
+      nextCellIndexes.rowIndex = Math.max(
+        0,
+        Math.min(currentPage.range.lastRowIndex, nextCellIndexes.rowIndex),
+      );
+      nextCellIndexes.colIndex = Math.max(0, Math.min(colCount - 1, nextCellIndexes.colIndex));
       logger.debug(
         `Navigating to next cell row ${nextCellIndexes.rowIndex}, col ${nextCellIndexes.colIndex}`,
       );

--- a/packages/grid/_modules_/grid/utils/utils.ts
+++ b/packages/grid/_modules_/grid/utils/utils.ts
@@ -32,5 +32,5 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
-export const clipNumber = (value: number, min: number, max: number) =>
+export const clamp = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));

--- a/packages/grid/_modules_/grid/utils/utils.ts
+++ b/packages/grid/_modules_/grid/utils/utils.ts
@@ -31,3 +31,6 @@ export function localStorageAvailable() {
 export function escapeRegExp(value: string): string {
   return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
+
+export const setInInterval = (value: number, min: number, max: number) =>
+  Math.min(max, Math.max(min, value));

--- a/packages/grid/_modules_/grid/utils/utils.ts
+++ b/packages/grid/_modules_/grid/utils/utils.ts
@@ -32,5 +32,5 @@ export function escapeRegExp(value: string): string {
   return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
 }
 
-export const setInInterval = (value: number, min: number, max: number) =>
+export const clipNumber = (value: number, min: number, max: number) =>
   Math.min(max, Math.max(min, value));

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -20,7 +20,7 @@ import {
   getColumnValues,
   getRow,
 } from 'test/utils/helperFn';
-import { DataGrid } from '@mui/x-data-grid';
+import { DataGrid, DataGridProps } from '@mui/x-data-grid';
 import { useData } from 'packages/storybook/src/hooks/useData';
 import { GridColumns } from 'packages/grid/_modules_/grid/models/colDef/gridColDef';
 
@@ -128,26 +128,25 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(handleKeyDown.returnValues).to.deep.equal([true]);
   });
 
-  const KeyboardTest = (props: {
-    nbRows?: number;
-    checkboxSelection?: boolean;
-    disableVirtualization?: boolean;
-    filterModel?: any;
-    width?: number;
-  }) => {
-    const data = useData(props.nbRows || 100, 20);
+  // TODO: Clean to allow passing any ad
+  const KeyboardTest = (
+    props: Omit<DataGridProps, 'autoHeight' | 'rows' | 'columns'> & {
+      width?: number;
+      nbRows?: number;
+    },
+  ) => {
+    const { nbRows = 100, width = 300, ...other } = props;
+    const data = useData(nbRows, 20);
     const transformColSizes = (columns: GridColumns) =>
       columns.map((column) => ({ ...column, width: 60 }));
 
     return (
-      <div style={{ width: props.width || 300, height: 360 }}>
+      <div style={{ width, height: 360 }}>
         <DataGrid
           autoHeight={isJSDOM}
           rows={data.rows}
           columns={transformColSizes(data.columns)}
-          checkboxSelection={props.checkboxSelection}
-          disableVirtualization={props.disableVirtualization}
-          filterModel={props.filterModel}
+          {...other}
         />
       </div>
     );
@@ -201,6 +200,16 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(getActiveCell()).to.equal('1-0');
     fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
     expect(getActiveCell()).to.equal('0-0');
+  });
+
+  it('should support cell navigation with arrows when page > 0', () => {
+    render(<KeyboardTest nbRows={10} page={1} pageSize={2} rowsPerPageOptions={[2]} />);
+    getCell(2, 0).focus();
+    expect(getActiveCell()).to.equal('2-0');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowDown' });
+    expect(getActiveCell()).to.equal('3-0');
+    fireEvent.keyDown(document.activeElement!, { key: 'ArrowUp' });
+    expect(getActiveCell()).to.equal('2-0');
   });
 
   it('should support cell navigation with arrows when rows are filtered', () => {

--- a/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
+++ b/packages/grid/data-grid/src/tests/keyboard.DataGrid.test.tsx
@@ -128,7 +128,6 @@ describe('<DataGrid /> - Keyboard', () => {
     expect(handleKeyDown.returnValues).to.deep.equal([true]);
   });
 
-  // TODO: Clean to allow passing any ad
   const KeyboardTest = (
     props: Omit<DataGridProps, 'autoHeight' | 'rows' | 'columns'> & {
       width?: number;


### PR DESCRIPTION
Introduced by #2994, was never released, I will merge it before the next release if no review :+1: 

The variable wording was approximate and I did not test enough.
`rowCount` was refering to the index of the last element of the page + 1

A few examples:
- `rows.length: 100, page: 0, pageSize: 10` => `rowCount: 10`
- `rows.length: 100, page: 1, pageSize: 10` => `rowCount: 20`
- `rows.length: 14, page: 1, pageSize: 10` => `rowCount: 14`

I will probably clean those methods later to add explicit comments on each instruction. 
Because `// we go to the current row, first col, or last col!` is not very explicit to me.