### PR TITLE
[docs] Fix inline previews

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,8 @@
     "export": "rimraf docs/export && next export --threads=3 -o export && yarn build-sw",
     "icons": "rimraf public/static/icons/* && node ./scripts/buildIcons.js",
     "typescript": "tsc -p tsconfig.json",
-    "typescript:transpile": "node scripts/formattedTSDemos",
-    "typescript:transpile:dev": "node scripts/formattedTSDemos --watch"
+    "typescript:transpile": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" scripts/formattedTSDemos",
+    "typescript:transpile:dev": "cross-env BABEL_ENV=development babel-node --extensions \".tsx,.ts,.js\" scripts/formattedTSDemos --watch"
   },
   "dependencies": {
     "@babel/core": "^7.16.0",

--- a/docs/scripts/formattedTSDemos.js
+++ b/docs/scripts/formattedTSDemos.js
@@ -75,7 +75,17 @@ async function transpileFile(tsxPath, program, ignoreCache = false) {
 
     const source = await fse.readFile(tsxPath, 'utf8');
 
-    const { code } = await babel.transformAsync(source, { ...babelConfig, filename: tsxPath });
+    const transformOptions = { ...babelConfig, filename: tsxPath };
+    const enableJSXPreview = !tsxPath.includes(path.join('pages', 'premium-themes'));
+    if (enableJSXPreview) {
+      transformOptions.plugins = transformOptions.plugins.concat([
+        [
+          require.resolve('docsx/src/modules/utils/babel-plugin-jsx-preview'),
+          { maxLines: 16, outputFilename: `${tsxPath}.preview` },
+        ],
+      ]);
+    }
+    const { code } = await babel.transformAsync(source, transformOptions);
 
     if (/import \w* from 'prop-types'/.test(code)) {
       throw new Error('TypeScript demo contains prop-types, please remove them');

--- a/docs/src/modules/utils/babel-plugin-jsx-preview.js
+++ b/docs/src/modules/utils/babel-plugin-jsx-preview.js
@@ -1,0 +1,102 @@
+const fs = require('fs');
+
+const pluginName = 'babel-plugin-jsx-preview';
+
+/**
+ * @returns {import('@babel/core').PluginObj}
+ */
+export default function babelPluginJsxPreview() {
+  const wrapperTypes = ['div', 'Box', 'Stack'];
+
+  /**
+   * @type {import('@babel/core').types.JSXElement | import('@babel/core').types.JSXElement['children']}
+   */
+  let previewNode = null;
+
+  return {
+    name: pluginName,
+    visitor: {
+      ExportDefaultDeclaration(path) {
+        const { declaration } = path.node;
+        if (declaration.type !== 'FunctionDeclaration') {
+          return;
+        }
+        const { body } = declaration.body;
+        /**
+         * @type {import('@babel/core').types.ReturnStatement[]}
+         */
+        const [lastReturn] = body
+          .filter((statement) => {
+            return statement.type === 'ReturnStatement';
+          })
+          .reverse();
+
+        const returnedJSX = lastReturn.argument;
+        if (returnedJSX.type === 'JSXElement') {
+          previewNode = returnedJSX;
+          if (
+            wrapperTypes.includes(previewNode.openingElement.name.name) &&
+            previewNode.children.length > 0
+          ) {
+            // Trim blank JSXText to normalize
+            // return (
+            //   <div />
+            // )
+            // and
+            // return (
+            //   <Stack>
+            //     <div />
+            // ^^^^ Blank JSXText including newline
+            //   </Stacke>
+            // )
+            previewNode = previewNode.children.filter((child, index, children) => {
+              const isSurroundingBlankJSXText =
+                (index === 0 || index === children.length - 1) &&
+                child.type === 'JSXText' &&
+                !/[^\s]+/.test(child.value);
+              return !isSurroundingBlankJSXText;
+            });
+          }
+        }
+      },
+    },
+    post(state) {
+      const { maxLines, outputFilename } = state.opts.plugins.find((plugin) => {
+        return plugin.key === pluginName;
+      }).options;
+
+      let hasPreview = false;
+      if (previewNode !== null) {
+        const [startNode, endNode] = Array.isArray(previewNode)
+          ? [previewNode[0], previewNode.slice(-1)[0]]
+          : [previewNode, previewNode];
+        const preview = state.code.slice(startNode.start, endNode.end);
+
+        const previewLines = preview.split(/\n/);
+        // The first line is already trimmed either due to trimmed blank JSXText or because it's a single node which babel already trims.
+        // The last line is therefore the meassure for indendation
+        const indendation = previewLines.slice(-1)[0].match(/^\s*/)[0].length;
+        const deindentedPreviewLines = preview.split(/\n/).map((line, index) => {
+          if (index === 0) {
+            return line;
+          }
+          return line.slice(indendation);
+        });
+
+        if (deindentedPreviewLines.length <= maxLines) {
+          fs.writeFileSync(outputFilename, deindentedPreviewLines.join('\n'));
+          hasPreview = true;
+        }
+      }
+
+      if (!hasPreview) {
+        try {
+          fs.unlinkSync(outputFilename);
+        } catch (error) {
+          // Would throw if the file doesn't exist.
+          // But we do want to ensure that the file doesn't exist so the error is fine.
+        }
+      }
+    },
+  };
+}

--- a/docs/src/pages/components/data-grid/accessibility/DensitySelectorGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/accessibility/DensitySelectorGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  components={{
+    Toolbar: CustomToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/accessibility/DensitySelectorSmallGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/accessibility/DensitySelectorSmallGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  {...data}
+  density="compact"
+  components={{
+    Toolbar: CustomToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/columns/BasicColumnsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/BasicColumnsGrid.tsx.preview
@@ -1,0 +1,10 @@
+<DataGrid
+  columns={[{ field: 'username' }, { field: 'age' }]}
+  rows={[
+    {
+      id: 1,
+      username: '@MUI',
+      age: 20,
+    },
+  ]}
+/>

--- a/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnMenuGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid {...data} disableColumnMenu />

--- a/docs/src/pages/components/data-grid/columns/ColumnMinWidthGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnMinWidthGrid.tsx.preview
@@ -1,0 +1,4 @@
+<DataGrid
+  columns={[{ field: 'username', minWidth: 150 }, { field: 'age' }]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/ColumnOrderingDisabledGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnOrderingDisabledGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGridPro
+  columns={[
+    { field: 'id' },
+    { field: 'username' },
+    { field: 'age', disableReorder: true },
+  ]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/ColumnOrderingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnOrderingGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGridPro {...data} />

--- a/docs/src/pages/components/data-grid/columns/ColumnSelectorGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnSelectorGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  components={{
+    Toolbar: GridToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/columns/ColumnSizingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnSizingGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGridPro
+  columns={[
+    { field: 'id' },
+    { field: 'username', minWidth: 150 },
+    { field: 'age', resizable: false },
+  ]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/ColumnTypesGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnTypesGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid columns={columns} rows={rows} />

--- a/docs/src/pages/components/data-grid/columns/ColumnWidthGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ColumnWidthGrid.tsx.preview
@@ -1,0 +1,4 @@
+<DataGrid
+  columns={[{ field: 'username', width: 200 }, { field: 'age' }]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/CustomColumnTypesGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/CustomColumnTypesGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  columns={[
+    { field: 'status', width: 130 },
+    { field: 'subTotal', ...usdPrice },
+    { field: 'total', ...usdPrice },
+  ]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/HeaderColumnsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/HeaderColumnsGrid.tsx.preview
@@ -1,0 +1,12 @@
+<DataGrid
+  columns={[
+    {
+      field: 'username',
+      headerName: 'Username',
+      description:
+        'The identification used by the person with access to the online service.',
+    },
+    { field: 'age', headerName: 'Age' },
+  ]}
+  rows={rows}
+/>

--- a/docs/src/pages/components/data-grid/columns/RenderCellGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/RenderCellGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/columns/RenderExpandCellGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/RenderExpandCellGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/columns/RenderHeaderGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/RenderHeaderGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/columns/ValueGetterGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/columns/ValueGetterGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/components/CustomEmptyOverlayGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/CustomEmptyOverlayGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  components={{
+    NoRowsOverlay: CustomNoRowsOverlay,
+  }}
+  rows={[]}
+  columns={data.columns}
+/>

--- a/docs/src/pages/components/data-grid/components/CustomLoadingOverlayGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/CustomLoadingOverlayGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  components={{
+    LoadingOverlay: CustomLoadingOverlay,
+  }}
+  loading
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/components/CustomPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/CustomPaginationGrid.tsx.preview
@@ -1,0 +1,9 @@
+<DataGrid
+  pagination
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  components={{
+    Pagination: CustomPagination,
+  }}
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/components/CustomSortIcons.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/CustomSortIcons.tsx.preview
@@ -1,0 +1,12 @@
+<DataGrid
+  columns={columns}
+  rows={rows}
+  sortModel={[
+    { field: 'name', sort: 'asc' },
+    { field: 'stars', sort: 'desc' },
+  ]}
+  components={{
+    ColumnSortedDescendingIcon: SortedDescendingIcon,
+    ColumnSortedAscendingIcon: SortedAscendingIcon,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/components/CustomToolbarGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/CustomToolbarGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  components={{
+    Toolbar: CustomToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/components/ToolbarGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/components/ToolbarGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  components={{
+    Toolbar: GridToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/editing/BasicEditingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/BasicEditingGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/editing/BasicRowEditingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/BasicRowEditingGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid editMode="row" rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/editing/CatchEditingEventsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/CatchEditingEventsGrid.tsx.preview
@@ -1,0 +1,8 @@
+<div style={{ height: 180, width: '100%' }}>
+  <DataGridPro rows={rows} columns={columns} apiRef={apiRef} />
+</div>
+{message && (
+  <Alert severity="info" style={{ marginTop: 8 }}>
+    {message}
+  </Alert>
+)}

--- a/docs/src/pages/components/data-grid/editing/CellEditControlGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/CellEditControlGrid.tsx.preview
@@ -1,0 +1,11 @@
+<Alert severity="info" style={{ marginBottom: 8 }}>
+  <code>editRowsModel: {JSON.stringify(editRowsModel)}</code>
+</Alert>
+<div style={{ height: 400, width: '100%' }}>
+  <DataGrid
+    rows={rows}
+    columns={columns}
+    editRowsModel={editRowsModel}
+    onEditRowsModelChange={handleEditRowsModelChange}
+  />
+</div>

--- a/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  className={classes.root}
+  rows={rows}
+  columns={columns}
+  editMode="row"
+  editRowsModel={editRowsModel}
+  onEditRowsModelChange={handleEditRowsModelChange}
+/>

--- a/docs/src/pages/components/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/FullFeaturedCrudGrid.tsx.preview
@@ -1,0 +1,15 @@
+<DataGridPro
+  rows={rows}
+  columns={columns}
+  apiRef={apiRef}
+  editMode="row"
+  onRowEditStart={handleRowEditStart}
+  onRowEditStop={handleRowEditStop}
+  onCellFocusOut={handleCellFocusOut}
+  components={{
+    Toolbar: EditToolbar,
+  }}
+  componentsProps={{
+    toolbar: { apiRef },
+  }}
+/>

--- a/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/IsCellEditableGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  className={classes.root}
+  rows={rows}
+  columns={columns}
+  isCellEditable={(params) => params.row.age % 2 === 0}
+/>

--- a/docs/src/pages/components/data-grid/editing/RenderRatingEditCellGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/RenderRatingEditCellGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/editing/RowEditControlGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/RowEditControlGrid.tsx.preview
@@ -1,0 +1,12 @@
+<div style={{ height: 400, width: '100%' }}>
+  <DataGrid
+    rows={rows}
+    columns={columns}
+    editRowsModel={editRowsModel}
+    editMode="row"
+    onEditRowsModelChange={handleEditRowsModelChange}
+  />
+</div>
+<Alert severity="info" style={{ marginTop: 8 }}>
+  <code>editRowsModel: {JSON.stringify(editRowsModel)}</code>
+</Alert>

--- a/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  className={classes.root}
+  rows={rows}
+  columns={columns}
+  editRowsModel={editRowsModel}
+  onEditRowsModelChange={handleEditRowsModelChange}
+/>

--- a/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGridPro
+  className={classes.root}
+  apiRef={apiRef}
+  rows={rows}
+  columns={columns}
+  onEditCellPropsChange={handleCellEditPropsChange}
+  isCellEditable={(params) => params.row.id === 5}
+/>

--- a/docs/src/pages/components/data-grid/editing/ValueGetterSetterGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/editing/ValueGetterSetterGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={defaultRows} columns={columns} />

--- a/docs/src/pages/components/data-grid/events/DoubleClickWithCtrlToEdit.tsx.preview
+++ b/docs/src/pages/components/data-grid/events/DoubleClickWithCtrlToEdit.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  onCellDoubleClick={(params, event) => {
+    if (!event.ctrlKey) {
+      event.defaultMuiPrevented = true;
+    }
+  }}
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/events/SubscribeToEvents.tsx.preview
+++ b/docs/src/pages/components/data-grid/events/SubscribeToEvents.tsx.preview
@@ -1,0 +1,8 @@
+<div style={{ height: 180, width: '100%' }}>
+  <DataGridPro apiRef={apiRef} {...data} />
+</div>
+{message && (
+  <Alert severity="info" style={{ marginTop: 8 }}>
+    {message}
+  </Alert>
+)}

--- a/docs/src/pages/components/data-grid/export/ExportSelectorGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/export/ExportSelectorGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  components={{
+    Toolbar: CustomToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/ColumnTypeFilteringGrid.tsx.preview
@@ -1,0 +1,14 @@
+<DataGrid
+  rows={data.rows}
+  columns={columns}
+  columnTypes={{ price: priceColumnType }}
+  initialState={{
+    filter: {
+      filterModel: {
+        items: [
+          { columnField: 'totalPrice', value: '3000000', operatorValue: '>' },
+        ],
+      },
+    },
+  }}
+/>

--- a/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/CustomRatingOperator.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  rows={data.rows}
+  columns={columns}
+  filterModel={filterModel}
+  onFilterModelChange={(model) => setFilterModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/filtering/DisableFilteringGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/DisableFilteringGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  {...data}
+  columns={data.columns.map((column) => ({
+    ...column,
+    filterable: false,
+  }))}
+/>

--- a/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/ExtendNumericOperator.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  rows={data.rows}
+  columns={columns}
+  filterModel={filterModel}
+  onFilterModelChange={(model) => setFilterModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/FilterOperators.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={data.rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/filtering/MultiFilteringGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/MultiFilteringGrid.tsx.preview
@@ -1,0 +1,5 @@
+<DataGridPro
+  {...data}
+  filterModel={filterModel}
+  onFilterModelChange={(model) => setFilterModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/filtering/MultiFilteringWithOrGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/MultiFilteringWithOrGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGridPro {...data} initialState={{ filter: { filterModel } }} />

--- a/docs/src/pages/components/data-grid/filtering/QuickFilteringGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/QuickFilteringGrid.tsx.preview
@@ -1,0 +1,13 @@
+<DataGrid
+  components={{ Toolbar: QuickSearchToolbar }}
+  rows={rows}
+  columns={data.columns}
+  componentsProps={{
+    toolbar: {
+      value: searchText,
+      onChange: (event: React.ChangeEvent<HTMLInputElement>) =>
+        requestSearch(event.target.value),
+      clearSearch: () => requestSearch(''),
+    },
+  }}
+/>

--- a/docs/src/pages/components/data-grid/filtering/ServerFilterGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/filtering/ServerFilterGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  rows={rows}
+  columns={columns}
+  filterMode="server"
+  onFilterModelChange={onFilterChange}
+  loading={loading}
+/>

--- a/docs/src/pages/components/data-grid/layout/AutoHeightGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/layout/AutoHeightGrid.tsx.preview
@@ -1,0 +1,2 @@
+<DataGrid autoHeight {...data} />
+<p>more content</p>

--- a/docs/src/pages/components/data-grid/layout/FixedSizeGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/layout/FixedSizeGrid.tsx.preview
@@ -1,0 +1,3 @@
+<div style={{ height: 350, width: '100%' }}>
+  <DataGrid {...data} />
+</div>

--- a/docs/src/pages/components/data-grid/layout/FlexLayoutGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/layout/FlexLayoutGrid.tsx.preview
@@ -1,0 +1,5 @@
+<div style={{ display: 'flex', height: '100%' }}>
+  <div style={{ flexGrow: 1 }}>
+    <DataGrid {...data} />
+  </div>
+</div>

--- a/docs/src/pages/components/data-grid/localization/CustomLocaleTextGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/localization/CustomLocaleTextGrid.tsx.preview
@@ -1,0 +1,13 @@
+<DataGrid
+  {...data}
+  localeText={{
+    toolbarDensity: 'Size',
+    toolbarDensityLabel: 'Size',
+    toolbarDensityCompact: 'Small',
+    toolbarDensityStandard: 'Medium',
+    toolbarDensityComfortable: 'Large',
+  }}
+  components={{
+    Toolbar: GridToolbar,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/overview/DataGridDemo.tsx.preview
+++ b/docs/src/pages/components/data-grid/overview/DataGridDemo.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  rows={rows}
+  columns={columns}
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  checkboxSelection
+  disableSelectionOnClick
+/>

--- a/docs/src/pages/components/data-grid/overview/DataGridProDemo.tsx.preview
+++ b/docs/src/pages/components/data-grid/overview/DataGridProDemo.tsx.preview
@@ -1,0 +1,7 @@
+<DataGridPro
+  {...data}
+  loading={data.rows.length === 0}
+  rowHeight={38}
+  checkboxSelection
+  disableSelectionOnClick
+/>

--- a/docs/src/pages/components/data-grid/pagination/200PaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/200PaginationGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGridPro pagination pageSize={200} rowsPerPageOptions={[200]} {...data} />

--- a/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/ApiRefPaginationGrid.tsx.preview
@@ -1,0 +1,12 @@
+<Button color="primary" variant="outlined" onClick={handleClick}>
+  Set page 2
+</Button>
+<div style={{ height: 400, width: '100%', marginTop: 16 }}>
+  <DataGridPro
+    pagination
+    pageSize={5}
+    rowsPerPageOptions={[5]}
+    apiRef={apiRef}
+    {...data}
+  />
+</div>

--- a/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/AutoPaginationGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid autoPageSize pagination {...data} />

--- a/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/BasicPaginationGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid pagination {...data} />

--- a/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/ControlledPaginationGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  page={page}
+  onPageChange={(newPage) => setPage(newPage)}
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  pagination
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/CursorPaginationGrid.tsx.preview
@@ -1,0 +1,12 @@
+<DataGrid
+  rows={rows}
+  columns={data.columns}
+  pagination
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  rowCount={100}
+  paginationMode="server"
+  onPageChange={handlePageChange}
+  page={page}
+  loading={loading}
+/>

--- a/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/ServerPaginationGrid.tsx.preview
@@ -1,0 +1,11 @@
+<DataGrid
+  rows={rows}
+  columns={data.columns}
+  pagination
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  rowCount={100}
+  paginationMode="server"
+  onPageChange={(newPage) => setPage(newPage)}
+  loading={loading}
+/>

--- a/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/pagination/SizePaginationGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  pageSize={pageSize}
+  onPageSizeChange={(newPageSize) => setPageSize(newPageSize)}
+  rowsPerPageOptions={[5, 10, 20]}
+  pagination
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/rows/ApiRefRowsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/ApiRefRowsGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGridPro rows={rows} columns={columns} apiRef={apiRef} />

--- a/docs/src/pages/components/data-grid/rows/DenseHeightGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/DenseHeightGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rowHeight={25} {...data} />

--- a/docs/src/pages/components/data-grid/rows/InfiniteLoadingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/InfiniteLoadingGrid.tsx.preview
@@ -1,0 +1,10 @@
+<DataGridPro
+  {...data}
+  rows={data.rows.concat(loadedRows)}
+  loading={loading}
+  hideFooterPagination
+  onRowsScrollEnd={handleOnRowsScrollEnd}
+  components={{
+    LoadingOverlay: CustomLoadingOverlay,
+  }}
+/>

--- a/docs/src/pages/components/data-grid/rows/RowsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/RowsGrid.tsx.preview
@@ -1,0 +1,9 @@
+<DataGrid
+  columns={[{ field: 'name' }]}
+  rows={
+    [
+      { id: 1, name: 'React' },
+      { id: 2, name: 'MUI' },
+    ] as GridRowModel[]
+  }
+/>

--- a/docs/src/pages/components/data-grid/rows/ThrottledRowsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/ThrottledRowsGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGridPro
+  rows={rows}
+  columns={columns}
+  apiRef={apiRef}
+  throttleRowsMs={2000}
+/>

--- a/docs/src/pages/components/data-grid/selection/CheckboxSelectionGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/CheckboxSelectionGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid checkboxSelection {...data} />

--- a/docs/src/pages/components/data-grid/selection/ControlledSelectionGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/ControlledSelectionGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  checkboxSelection
+  onSelectionModelChange={(newSelectionModel) => {
+    setSelectionModel(newSelectionModel);
+  }}
+  selectionModel={selectionModel}
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/selection/DisableClickSelectionGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/DisableClickSelectionGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid checkboxSelection disableSelectionOnClick {...data} />

--- a/docs/src/pages/components/data-grid/selection/DisableRowSelection.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/DisableRowSelection.tsx.preview
@@ -1,0 +1,5 @@
+<DataGrid
+  {...data}
+  isRowSelectable={(params: GridRowParams) => params.row.quantity > 50000}
+  checkboxSelection
+/>

--- a/docs/src/pages/components/data-grid/selection/MultipleRowSelectionGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/MultipleRowSelectionGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGridPro {...data} pagination pageSize={10} />

--- a/docs/src/pages/components/data-grid/selection/SingleRowSelectionGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/selection/SingleRowSelectionGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid {...data} />

--- a/docs/src/pages/components/data-grid/sorting/BasicSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/BasicSortingGrid.tsx.preview
@@ -1,0 +1,5 @@
+<DataGrid
+  {...data}
+  sortModel={sortModel}
+  onSortModelChange={(model) => setSortModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/sorting/ComparatorSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/ComparatorSortingGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  sortModel={sortModel}
+  rows={rows}
+  columns={columns}
+  onSortModelChange={(model) => setSortModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/sorting/DisableSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/DisableSortingGrid.tsx.preview
@@ -1,0 +1,7 @@
+<DataGrid
+  {...data}
+  columns={data.columns.map((column) => ({
+    ...column,
+    sortable: false,
+  }))}
+/>

--- a/docs/src/pages/components/data-grid/sorting/MultiSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/MultiSortingGrid.tsx.preview
@@ -1,0 +1,5 @@
+<DataGridPro
+  {...data}
+  sortModel={sortModel}
+  onSortModelChange={(model) => setSortModel(model)}
+/>

--- a/docs/src/pages/components/data-grid/sorting/OrderSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/OrderSortingGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  sortingOrder={['desc', 'asc']}
+  sortModel={sortModel}
+  onSortModelChange={(model) => setSortModel(model)}
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/sorting/ServerSortingGrid.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  rows={rows}
+  columns={data.columns}
+  sortingMode="server"
+  sortModel={sortModel}
+  onSortModelChange={handleSortModelChange}
+  loading={loading}
+/>

--- a/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/style/AntDesignGrid.tsx.preview
@@ -1,0 +1,10 @@
+<DataGrid
+  className={classes.root}
+  checkboxSelection
+  pageSize={5}
+  rowsPerPageOptions={[5]}
+  components={{
+    Pagination: CustomPagination,
+  }}
+  {...data}
+/>

--- a/docs/src/pages/components/data-grid/style/StylingAllCells.tsx.preview
+++ b/docs/src/pages/components/data-grid/style/StylingAllCells.tsx.preview
@@ -1,0 +1,10 @@
+<DataGrid
+  rows={rows}
+  columns={columns}
+  getCellClassName={(params: GridCellParams<number>) => {
+    if (params.field === 'city') {
+      return '';
+    }
+    return params.value >= 15 ? 'hot' : 'cold';
+  }}
+/>

--- a/docs/src/pages/components/data-grid/style/StylingCellsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/style/StylingCellsGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/style/StylingHeaderGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/style/StylingHeaderGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid rows={rows} columns={columns} />

--- a/docs/src/pages/components/data-grid/style/StylingRowsGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/style/StylingRowsGrid.tsx.preview
@@ -1,0 +1,6 @@
+<DataGrid
+  {...data}
+  getRowClassName={(params) =>
+    `super-app-theme--${params.getValue(params.id, 'status')}`
+  }
+/>

--- a/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.tsx.preview
+++ b/docs/src/pages/components/data-grid/virtualization/ColumnVirtualizationGrid.tsx.preview
@@ -1,0 +1,1 @@
+<DataGrid {...data} columnBuffer={2} columnThreshold={2} />


### PR DESCRIPTION
Fixes #2990 

Based on https://github.com/mui-org/material-ui/pull/28215

The diff is so big because the previews need to be generated.

Preview -> https://deploy-preview-3081--material-ui-x.netlify.app/components/data-grid/columns/#column-definitions