### PR TITLE
[core] Use official MUI repo as monorepo dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@emotion/react": "^11.5.0",
     "@emotion/styled": "^11.3.0",
     "@eps1lon/enzyme-adapter-react-17": "^0.1.0",
-    "@material-ui/monorepo": "https://github.com/m4theushw/material-ui-fork.git#master",
+    "@material-ui/monorepo": "https://github.com/mui-org/material-ui.git#master",
     "@mui/icons-material": "^5.0.5",
     "@mui/material": "^5.0.6",
     "@mui/styles": "^5.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2302,9 +2302,9 @@
   dependencies:
     "@babel/runtime" "^7.14.8"
 
-"@material-ui/monorepo@https://github.com/m4theushw/material-ui-fork.git#master":
+"@material-ui/monorepo@https://github.com/mui-org/material-ui.git#master":
   version "5.0.6"
-  resolved "https://github.com/m4theushw/material-ui-fork.git#7a24bc10f4fe0a2e9a07b391e2d4f649f266b06b"
+  resolved "https://github.com/mui-org/material-ui.git#eb01f34ed9b680f4b893cacd73b846c2284a429a"
 
 "@material-ui/private-theming@5.0.0-beta.5":
   version "5.0.0-beta.5"


### PR DESCRIPTION
Revert to use the official repo instead of my fork.