### PR TITLE
[core] Use 'unstable_' prefix instead of 'unsafe_'

### DIFF
--- a/packages/grid/_modules_/grid/hooks/core/useGridControlState.ts
+++ b/packages/grid/_modules_/grid/hooks/core/useGridControlState.ts
@@ -9,7 +9,7 @@ import { useGridApiMethod } from '../utils/useGridApiMethod';
 export function useGridControlState(apiRef: GridApiRef, props: GridComponentProps) {
   const controlStateMapRef = React.useRef<Record<string, GridControlStateItem<any>>>({});
 
-  const updateControlState = React.useCallback<GridControlStateApi['unsafe_updateControlState']>(
+  const updateControlState = React.useCallback<GridControlStateApi['unstable_updateControlState']>(
     (controlStateItem) => {
       const { stateId, ...others } = controlStateItem;
 
@@ -22,7 +22,7 @@ export function useGridControlState(apiRef: GridApiRef, props: GridComponentProp
   );
 
   const applyControlStateConstraint = React.useCallback<
-    GridControlStateApi['unsafe_applyControlStateConstraint']
+    GridControlStateApi['unstable_applyControlStateConstraint']
   >(
     (newState) => {
       let ignoreSetState = false;
@@ -83,8 +83,8 @@ export function useGridControlState(apiRef: GridApiRef, props: GridComponentProp
   );
 
   const controlStateApi: GridControlStateApi = {
-    unsafe_updateControlState: updateControlState,
-    unsafe_applyControlStateConstraint: applyControlStateConstraint,
+    unstable_updateControlState: updateControlState,
+    unstable_applyControlStateConstraint: applyControlStateConstraint,
   };
   useGridApiMethod(apiRef, controlStateApi, 'controlStateApi');
 }

--- a/packages/grid/_modules_/grid/hooks/features/clipboard/useGridClipboard.ts
+++ b/packages/grid/_modules_/grid/hooks/features/clipboard/useGridClipboard.ts
@@ -64,7 +64,7 @@ export const useGridClipboard = (apiRef: GridApiRef): void => {
         return;
       }
 
-      apiRef.current.unsafe_copySelectedRowsToClipboard(event.altKey);
+      apiRef.current.unstable_copySelectedRowsToClipboard(event.altKey);
     },
     [apiRef],
   );
@@ -72,7 +72,7 @@ export const useGridClipboard = (apiRef: GridApiRef): void => {
   useGridNativeEventListener(apiRef, apiRef.current.rootElementRef!, 'keydown', handleKeydown);
 
   const clipboardApi: GridClipboardApi = {
-    unsafe_copySelectedRowsToClipboard: copySelectedRowsToClipboard,
+    unstable_copySelectedRowsToClipboard: copySelectedRowsToClipboard,
   };
 
   useGridApiMethod(apiRef, clipboardApi, 'GridClipboardApi');

--- a/packages/grid/_modules_/grid/hooks/features/editRows/useGridEditRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/editRows/useGridEditRows.ts
@@ -71,7 +71,7 @@ export function useGridEditRows(
   const nextFocusedCell = React.useRef<GridCellParams | null>(null);
   const columns = useGridSelector(apiRef, allGridColumnsSelector);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'editRows',
     propModel: props.editRowsModel,
     propOnChange: props.onEditRowsModelChange,

--- a/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
+++ b/packages/grid/_modules_/grid/hooks/features/filter/useGridFilter.ts
@@ -73,7 +73,7 @@ export const useGridFilter = (
 
   const [, setGridState, forceUpdate] = useGridState(apiRef);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'filter',
     propModel: props.filterModel,
     propOnChange: props.onFilterModelChange,
@@ -153,7 +153,7 @@ export const useGridFilter = (
    * Generate the `visibleRowsLookup` and `visibleDescendantsCountLookup` for the current `filterModel`
    * If the tree is not flat, we have to create the lookups even with "server" filtering or 0 filter item to remove to collapsed rows.
    */
-  const applyFilters = React.useCallback<GridFilterApi['unsafe_applyFilters']>(() => {
+  const applyFilters = React.useCallback<GridFilterApi['unstable_applyFilters']>(() => {
     setGridState((state) => {
       const filterModel = gridFilterModelSelector(state);
       const rowIds = gridRowIdsSelector(state);
@@ -300,7 +300,7 @@ export const useGridFilter = (
           filter: { ...state.filter, filterModel: { ...state.filter.filterModel, items } },
         };
       });
-      apiRef.current.unsafe_applyFilters();
+      apiRef.current.unstable_applyFilters();
     },
     [apiRef, logger, setGridState, props.disableMultipleColumnsFiltering],
   );
@@ -321,7 +321,7 @@ export const useGridFilter = (
       if (gridFilterModelSelector(apiRef.current.state).items.length === 0) {
         apiRef.current.upsertFilterItem({});
       } else {
-        apiRef.current.unsafe_applyFilters();
+        apiRef.current.unstable_applyFilters();
       }
     },
     [apiRef, logger, setGridState],
@@ -356,7 +356,7 @@ export const useGridFilter = (
         ...state,
         filter: { ...state.filter, filterModel: { ...state.filter.filterModel, linkOperator } },
       }));
-      apiRef.current.unsafe_applyFilters();
+      apiRef.current.unstable_applyFilters();
     },
     [apiRef, logger, setGridState],
   );
@@ -375,7 +375,7 @@ export const useGridFilter = (
             filterModel: model,
           },
         }));
-        apiRef.current.unsafe_applyFilters();
+        apiRef.current.unstable_applyFilters();
       }
     },
     [apiRef, logger, setGridState],
@@ -390,7 +390,7 @@ export const useGridFilter = (
     apiRef,
     {
       setFilterLinkOperator,
-      unsafe_applyFilters: applyFilters,
+      unstable_applyFilters: applyFilters,
       deleteFilterItem,
       upsertFilterItem,
       setFilterModel,
@@ -426,12 +426,16 @@ export const useGridFilter = (
       isFirstRender.current = false;
       return;
     }
-    apiRef.current.unsafe_applyFilters();
+    apiRef.current.unstable_applyFilters();
   }, [apiRef, props.disableChildrenFiltering]);
 
-  useFirstRender(() => apiRef.current.unsafe_applyFilters());
+  useFirstRender(() => apiRef.current.unstable_applyFilters());
 
-  useGridApiEventHandler(apiRef, GridEvents.rowsSet, apiRef.current.unsafe_applyFilters);
-  useGridApiEventHandler(apiRef, GridEvents.rowExpansionChange, apiRef.current.unsafe_applyFilters);
+  useGridApiEventHandler(apiRef, GridEvents.rowsSet, apiRef.current.unstable_applyFilters);
+  useGridApiEventHandler(
+    apiRef,
+    GridEvents.rowExpansionChange,
+    apiRef.current.unstable_applyFilters,
+  );
   useGridApiEventHandler(apiRef, GridEvents.columnsChange, onColUpdated);
 };

--- a/packages/grid/_modules_/grid/hooks/features/pagination/useGridPage.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/useGridPage.ts
@@ -58,7 +58,7 @@ export const useGridPage = (
 
   const visibleTopLevelRowCount = useGridSelector(apiRef, gridVisibleTopLevelRowCountSelector);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'page',
     propModel: props.page,
     propOnChange: props.onPageChange,

--- a/packages/grid/_modules_/grid/hooks/features/pagination/useGridPageSize.ts
+++ b/packages/grid/_modules_/grid/hooks/features/pagination/useGridPageSize.ts
@@ -27,7 +27,7 @@ export const useGridPageSize = (
 
   const containerSizes = useGridSelector(apiRef, unstable_gridContainerSizesSelector);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'pageSize',
     propModel: props.pageSize,
     propOnChange: props.onPageSizeChange,

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -84,7 +84,7 @@ export const useGridSelection = (
   const classes = useUtilityClasses(ownerState);
   const lastRowToggled = React.useRef<GridRowId | null>(null);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'selection',
     propModel: propSelectionModel,
     propOnChange: props.onSelectionModelChange,

--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -61,7 +61,7 @@ export const useGridSorting = (
 
   const [, setGridState, forceUpdate] = useGridState(apiRef);
 
-  apiRef.current.unsafe_updateControlState({
+  apiRef.current.unstable_updateControlState({
     stateId: 'sortModel',
     propModel: props.sortModel,
     propOnChange: props.onSortModelChange,

--- a/packages/grid/_modules_/grid/hooks/utils/useGridState.ts
+++ b/packages/grid/_modules_/grid/hooks/utils/useGridState.ts
@@ -22,7 +22,7 @@ export const useGridState = (
       }
 
       const { ignoreSetState, postUpdate } =
-        apiRef.current.unsafe_applyControlStateConstraint(newState);
+        apiRef.current.unstable_applyControlStateConstraint(newState);
 
       if (!ignoreSetState) {
         // We always assign it as we mutate rows for perf reason.

--- a/packages/grid/_modules_/grid/models/api/gridClipboardApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridClipboardApi.ts
@@ -8,5 +8,5 @@ export interface GridClipboardApi {
    * @param {boolean} includeHeaders Whether to include the headers or not. Default is `false`.
    * @ignore - do not document.
    */
-  unsafe_copySelectedRowsToClipboard: (includeHeaders?: boolean) => void;
+  unstable_copySelectedRowsToClipboard: (includeHeaders?: boolean) => void;
 }

--- a/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridControlStateApi.ts
@@ -10,14 +10,14 @@ export interface GridControlStateApi {
    * @param {GridControlStateItem<TModel>} controlState The [[GridControlStateItem]] to be registered.
    * @ignore - do not document.
    */
-  unsafe_updateControlState: <TModel>(controlState: GridControlStateItem<TModel>) => void;
+  unstable_updateControlState: <TModel>(controlState: GridControlStateItem<TModel>) => void;
   /**
    * Allows the internal grid state to apply the registered control state constraint.
    * @param {GridState} state The new modified state that would be the next if the state is not controlled.
    * @returns {{ ignoreSetState: boolean, postUpdate: () => void }} ignoreSetState let the state know if it should update, and postUpdate is a callback function triggered if the state has updated.
    * @ignore - do not document.
    */
-  unsafe_applyControlStateConstraint: (state: GridState) => {
+  unstable_applyControlStateConstraint: (state: GridState) => {
     ignoreSetState: boolean;
     postUpdate: () => void;
   };

--- a/packages/grid/_modules_/grid/models/api/gridFilterApi.ts
+++ b/packages/grid/_modules_/grid/models/api/gridFilterApi.ts
@@ -24,7 +24,7 @@ export interface GridFilterApi {
    * Applies all filters on all rows.
    * @ignore - do not document.
    */
-  unsafe_applyFilters: () => void;
+  unstable_applyFilters: () => void;
   /**
    * Deletes a [[GridFilterItem]].
    * @param {GridFilterItem} item The filter to delete.

--- a/packages/grid/x-grid/src/tests/clipboard.DataGridPro.test.tsx
+++ b/packages/grid/x-grid/src/tests/clipboard.DataGridPro.test.tsx
@@ -76,14 +76,14 @@ describe('<DataGridPro /> - Clipboard', () => {
     it('should copy the selected rows to the clipboard', () => {
       render(<Test />);
       apiRef.current.selectRows([0, 1]);
-      apiRef.current.unsafe_copySelectedRowsToClipboard();
+      apiRef.current.unstable_copySelectedRowsToClipboard();
       expect(writeText.firstCall.args[0]).to.equal(['0\tNike', '1\tAdidas'].join('\r\n'));
     });
 
     it('should include the headers when includeHeaders=true', () => {
       render(<Test />);
       apiRef.current.selectRows([0, 1]);
-      apiRef.current.unsafe_copySelectedRowsToClipboard(true);
+      apiRef.current.unstable_copySelectedRowsToClipboard(true);
       expect(writeText.firstCall.args[0]).to.equal(
         ['id\tBrand', '0\tNike', '1\tAdidas'].join('\r\n'),
       );


### PR DESCRIPTION
This wrong naming was introduced in https://github.com/mui-org/material-ui-x/pull/2985 