### PR TITLE
[DataGrid] Block multi-rows updates in `apiRef.current.updateRows` on the free plan

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -238,7 +238,7 @@ export const useGridRows = (
         // TODO: Add test with direct call to `apiRef.current.updateRows` in DataGrid after enabling the `apiRef` on the free plan.
         throw new Error(
           [
-            "MUI: You can't update several rows at once in `apiRef.current.updateRows` on the free plan",
+            "MUI: You can't update several rows at once in `apiRef.current.updateRows` on the DataGrid.",
             'You need to upgrade to the DataGridPro component to unlock this feature.',
           ].join('\n'),
         );

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -297,7 +297,7 @@ export const useGridRows = (
 
       throttledRowsChange(state, true);
     },
-    [apiRef, props.getRowId, throttledRowsChange],
+    [apiRef, props.getRowId, throttledRowsChange, props.signature],
   );
 
   const getRowModels = React.useCallback<GridRowApi['getRowModels']>(() => {

--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -22,7 +22,7 @@ import {
   gridRowTreeSelector,
   gridRowIdsSelector,
 } from './gridRowsSelector';
-import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
+import { GridSignature, useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridRowGroupParams } from '../../core/rowGroupsPerProcessing';
 
 interface GridRowsInternalCacheState {
@@ -138,7 +138,10 @@ const INITIAL_GRID_ROWS_INTERNAL_CACHE: GridRowsInternalCache = {
  */
 export const useGridRows = (
   apiRef: GridApiRef,
-  props: Pick<GridComponentProps, 'rows' | 'getRowId' | 'rowCount' | 'throttleRowsMs'>,
+  props: Pick<
+    GridComponentProps,
+    'rows' | 'getRowId' | 'rowCount' | 'throttleRowsMs' | 'signature'
+  >,
 ): void => {
   if (process.env.NODE_ENV !== 'production') {
     // Freeze rows for immutability
@@ -231,6 +234,16 @@ export const useGridRows = (
 
   const updateRows = React.useCallback<GridRowApi['updateRows']>(
     (updates) => {
+      if (props.signature === GridSignature.DataGrid && updates.length > 1) {
+        // TODO: Add test with direct call to `apiRef.current.updateRows` in DataGrid after enabling the `apiRef` on the free plan.
+        throw new Error(
+          [
+            "MUI: You can't update several rows at once in `apiRef.current.updateRows` on the free plan",
+            'You need to upgrade to the DataGridPro component to unlock this feature.',
+          ].join('\n'),
+        );
+      }
+
       // we removes duplicate updates. A server can batch updates, and send several updates for the same row in one fn call.
       const uniqUpdates = new Map<GridRowId, GridRowModel>();
 


### PR DESCRIPTION
Preparing for the unlocking of the `apiRef` on the free plan.

I did not create a `disableMultiRowUpdates` prop with a forced value on the `DataGrid` like for `disableMultipleColumnsFiltering` because I don't see any situation where a user of the pro version would want to limit the updates to one row.
So for me it would only flood the prop list.

We could also add the prop only on `GridComponentProps` and set a forced value at `true` on `DataGrid` and `false` on `DataGridPro`.
But I think checking directly the signature is simpler.