### PR TITLE
[DataGrid] Fix `updateRows` to not use rows from other instances

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
+++ b/packages/grid/_modules_/grid/hooks/features/rows/useGridRows.ts
@@ -115,23 +115,6 @@ const getRowsStateFromCache = (
   return { ...groupingResponse, totalRowCount, totalTopLevelRowCount };
 };
 
-// The cache is always redefined synchronously in `useGridStateInit` so this object don't need to be regenerated across DataGrid instances.
-const INITIAL_GRID_ROWS_INTERNAL_CACHE: GridRowsInternalCache = {
-  state: {
-    value: {
-      idRowsLookup: {},
-      ids: [],
-    },
-    props: {
-      rowCount: undefined,
-      getRowId: undefined,
-    },
-    rowsBeforePartialUpdates: [],
-  },
-  timeout: null,
-  lastUpdateMs: 0,
-};
-
 /**
  * @requires useGridRowGroupsPreProcessing (method)
  * @requires useGridSorting (method) - can be after, async only (TODO: Remove after moving the `getRowIndex` and `getRowIdFromIndex` to `useGridSorting`)
@@ -149,7 +132,21 @@ export const useGridRows = (
   }
 
   const logger = useGridLogger(apiRef, 'useGridRows');
-  const rowsCache = React.useRef(INITIAL_GRID_ROWS_INTERNAL_CACHE);
+  const rowsCache = React.useRef<GridRowsInternalCache>({
+    state: {
+      value: {
+        idRowsLookup: {},
+        ids: [],
+      },
+      props: {
+        rowCount: undefined,
+        getRowId: undefined,
+      },
+      rowsBeforePartialUpdates: [],
+    },
+    timeout: null,
+    lastUpdateMs: 0,
+  });
 
   useGridStateInit(apiRef, (state) => {
     rowsCache.current.state = convertGridRowsPropToState({


### PR DESCRIPTION
Preview: https://deploy-preview-3127--material-ui-x.netlify.app/components/data-grid/editing/#client-side-validation

A regression from #2996 

When there're more than one instance of the DataGrid, calling `updateRows` will mess with all rows because it reuses the same rows from the other instance. This method is called, for example, on the cell editing to commit the new value.

#### How to reproduce:

1. Open https://next--material-ui-x.netlify.app/components/data-grid/editing/#client-side-validation
2. Double-click a cell to edit it
3. Click outside the cell

I didn't add tests because this behavior only happens with multiple instances.