### PR TITLE
[DataGrid] Use color-scheme to set dark mode on native components

### DIFF
--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -50,7 +50,7 @@ export const GridRootStyles = styled('div', {
       ? lighten(alpha(theme.palette.divider, 1), 0.88)
       : darken(alpha(theme.palette.divider, 1), 0.68);
 
-  let gridStyle: CSSInterpolation = {
+  const gridStyle: CSSInterpolation = {
     flex: 1,
     boxSizing: 'border-box',
     position: 'relative',
@@ -62,6 +62,7 @@ export const GridRootStyles = styled('div', {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
+    colorScheme: theme.palette.mode,
     [`&.${gridClasses.autoHeight}`]: {
       height: 'auto',
     },
@@ -290,38 +291,5 @@ export const GridRootStyles = styled('div', {
     },
   };
 
-  if (theme.palette.mode === 'dark') {
-    // Values coming from mac OS.
-    const track = '#202022';
-    const thumb = '#585859';
-    const active = '#838384';
-
-    // We style the scroll bar for dark mode.
-    gridStyle = {
-      ...gridStyle,
-      scrollbarColor: `${thumb} ${track}`,
-      '& *::-webkit-scrollbar': {
-        backgroundColor: track,
-      },
-      '& *::-webkit-scrollbar-thumb': {
-        borderRadius: 8,
-        backgroundColor: thumb,
-        minHeight: 24,
-        border: `3px solid ${track}`,
-      },
-      '& *::-webkit-scrollbar-thumb:focus': {
-        backgroundColor: active,
-      },
-      '& *::-webkit-scrollbar-thumb:active': {
-        backgroundColor: active,
-      },
-      '& *::-webkit-scrollbar-thumb:hover': {
-        backgroundColor: active,
-      },
-      '& *::-webkit-scrollbar-corner': {
-        backgroundColor: track,
-      },
-    };
-  }
   return gridStyle;
 });

--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -62,7 +62,6 @@ export const GridRootStyles = styled('div', {
     height: '100%',
     display: 'flex',
     flexDirection: 'column',
-    colorScheme: theme.palette.mode,
     [`&.${gridClasses.autoHeight}`]: {
       height: 'auto',
     },


### PR DESCRIPTION
Fixes #1805

Instead of modifying the style of the scroll bar, we set `color-scheme` property on the root div according to the palette mode.

### Doc modification

- For users with @mui/material (v5.1.0)
	They have to remove the `darkScrollbar()` from their theme and use `enableColorScheme` prop. The  `color-scheme` property will be defined twice (once in the `<html>` and once in the `DataGrid` root `<div>`) but It is not a problem.

- For user bellow @mui/material (v5.1.0)
	I'm not sure. They can avoid using `darkScrollbar()` in the app style to avoid overriding the native scrollbar style. But this would lead to a page scrollbar unadapted. I'm wondering if they could not simply use
```jsx
MuiCssBaseline: {
	styleOverrides: {
		html: {
			colorScheme: theme.palette.mode 
		},
	},
},
```
instead of
```jsx
MuiCssBaseline: {
	styleOverrides: {
		body: theme.palette.mode === 'dark' ? darkScrollbar() : null,
	},
},
```