### PR TITLE
[docs] move sentence about disabling multi rows selection

### DIFF
--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -65,18 +65,18 @@ Use the arrow keys to move the focus.
 
 ### Selection
 
-|                                                                                               Keys | Description                                                          |
-| -------------------------------------------------------------------------------------------------: | :------------------------------------------------------------------- |
-|                                        <kbd class="key">Shift</kbd> + <kbd class="key">Space</kbd> | Select the current row                                               |
-| <kbd class="key">Shift</kbd> + <kbd class="key">Space</kbd> + <kbd class="key">Arrow Up/Down</kbd> | Select the current row and the row above or below                    |
-|                                                       <kbd class="key">Shift</kbd> + Click on cell | Select the range of rows between the first and the last clicked rows |
-|                                             <kbd class="key">CTRL</kbd> + <kbd class="key">A</kbd> | Select all rows                                                      |
-|                                             <kbd class="key">CTRL</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s)                                   |
-|                                              <kbd class="key">ALT</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s) including headers                 |
-|                                                        <kbd class="key">CTRL</kbd> + Click on cell | Enable multi-selection                                               |
-|                                              <kbd class="key">CTRL</kbd> + Click on a selected row | Deselect the row                                                     |
-|                                                                       <kbd class="key">Enter</kbd> | Sort column when column header is focused                            |
-|                                         <kbd class="key">CTRL</kbd> + <kbd class="key">Enter</kbd> | Open column menu when column header is focused                       |
+|                                                                Keys | Description                                                          |
+| ------------------------------------------------------------------: | :------------------------------------------------------------------- |
+|         <kbd class="key">Shift</kbd> + <kbd class="key">Space</kbd> | Select the current row                                               |
+| <kbd class="key">Shift</kbd> + <kbd class="key">Arrow Up/Down</kbd> | Select the current row and the row above or below                    |
+|                        <kbd class="key">Shift</kbd> + Click on cell | Select the range of rows between the first and the last clicked rows |
+|              <kbd class="key">CTRL</kbd> + <kbd class="key">A</kbd> | Select all rows                                                      |
+|              <kbd class="key">CTRL</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s)                                   |
+|               <kbd class="key">ALT</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s) including headers                 |
+|                         <kbd class="key">CTRL</kbd> + Click on cell | Enable multi-selection                                               |
+|               <kbd class="key">CTRL</kbd> + Click on a selected row | Deselect the row                                                     |
+|                                        <kbd class="key">Enter</kbd> | Sort column when column header is focused                            |
+|          <kbd class="key">CTRL</kbd> + <kbd class="key">Enter</kbd> | Open column menu when column header is focused                       |
 
 ### Sorting
 

--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -75,8 +75,6 @@ Use the arrow keys to move the focus.
 |               <kbd class="key">ALT</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s) including headers                 |
 |                         <kbd class="key">CTRL</kbd> + Click on cell | Enable multi-selection                                               |
 |               <kbd class="key">CTRL</kbd> + Click on a selected row | Deselect the row                                                     |
-|                                        <kbd class="key">Enter</kbd> | Sort column when column header is focused                            |
-|          <kbd class="key">CTRL</kbd> + <kbd class="key">Enter</kbd> | Open column menu when column header is focused                       |
 
 ### Sorting
 
@@ -85,6 +83,8 @@ Use the arrow keys to move the focus.
 |               <kbd class="key">CTRL</kbd> + Click on header | Enable multi-sorting                               |
 |              <kbd class="key">Shift</kbd> + Click on header | Enable multi-sorting                               |
 | <kbd class="key">Shift</kbd> + <kbd class="key">Enter</kbd> | Enable multi-sorting when column header is focused |
+|                                <kbd class="key">Enter</kbd> | Sort column when column header is focused          |
+|  <kbd class="key">CTRL</kbd> + <kbd class="key">Enter</kbd> | Open column menu when column header is focused     |
 
 ### Key assignment conventions
 

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -28,7 +28,6 @@ Row selection can be performed with a simple mouse click, or using the [keyboard
 
 Single row selection is enable by default with the `DataGrid` component.
 To unselect a row, hold the <kbd class="key">CTRL</kbd> key and click on it.
-For the `DataGridPro`, you need to disable multiple row selection with `disableMultipleSelection={true}`.
 
 {{"demo": "pages/components/data-grid/selection/SingleRowSelectionGrid.js", "bg": "inline"}}
 
@@ -38,6 +37,7 @@ On the `DataGridPro` component, you can select multiple rows in two ways:
 
 - To select multiple independent rows, hold the <kbd class="key">CTRL</kbd> key while selecting rows.
 - To select a range of rows, hold the <kbd class="key">SHIFT</kbd> key while selecting rows.
+- To disable multiple row selection use `disableMultipleSelection={true}`.
 
 {{"demo": "pages/components/data-grid/selection/MultipleRowSelectionGrid.js", "disableAd": true, "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/selection/selection.md
+++ b/docs/src/pages/components/data-grid/selection/selection.md
@@ -37,7 +37,7 @@ On the `DataGridPro` component, you can select multiple rows in two ways:
 
 - To select multiple independent rows, hold the <kbd class="key">CTRL</kbd> key while selecting rows.
 - To select a range of rows, hold the <kbd class="key">SHIFT</kbd> key while selecting rows.
-- To disable multiple row selection use `disableMultipleSelection={true}`.
+- To disable multiple row selection, use `disableMultipleSelection={true}`.
 
 {{"demo": "pages/components/data-grid/selection/MultipleRowSelectionGrid.js", "disableAd": true, "bg": "inline"}}
 


### PR DESCRIPTION
Some explanations in the doc seems to be wrong/out dated

- Disabling multi rows selection is not necessary to unselect row with ctrl key
- To select a range of rows, "Shift + Arrow Up/Down" is enough. No need of "Space"
- Some key for sorting columns was in the table about "Selection" instead of "Sorting"