### PR TITLE
[DataGrid] Do not debounce the initial resizing of the grid

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/_modules_/grid/hooks/features/dimensions/useGridDimensions.ts
@@ -176,6 +176,8 @@ export function useGridDimensions(
 
   const debounceResize = React.useMemo(() => debounce(resize, 60), [resize]);
 
+  const isFirstSizing = React.useRef(true)
+
   const handleResize = React.useCallback(
     (size: ElementSize) => {
       rootDimensionsRef.current = size;
@@ -213,6 +215,14 @@ export function useGridDimensions(
       if (isTestEnvironment) {
         // We don't need to debounce the resize for tests.
         resize();
+        isFirstSizing.current = false
+        return;
+      }
+
+      if (isFirstSizing.current) {
+        // We want to initialize the grid dimensions as soon as possible to avoid flickering
+        resize()
+        isFirstSizing.current = false
         return;
       }
 

--- a/packages/grid/_modules_/grid/hooks/features/dimensions/useGridDimensions.ts
+++ b/packages/grid/_modules_/grid/hooks/features/dimensions/useGridDimensions.ts
@@ -176,7 +176,7 @@ export function useGridDimensions(
 
   const debounceResize = React.useMemo(() => debounce(resize, 60), [resize]);
 
-  const isFirstSizing = React.useRef(true)
+  const isFirstSizing = React.useRef(true);
 
   const handleResize = React.useCallback(
     (size: ElementSize) => {
@@ -215,14 +215,14 @@ export function useGridDimensions(
       if (isTestEnvironment) {
         // We don't need to debounce the resize for tests.
         resize();
-        isFirstSizing.current = false
+        isFirstSizing.current = false;
         return;
       }
 
       if (isFirstSizing.current) {
         // We want to initialize the grid dimensions as soon as possible to avoid flickering
-        resize()
-        isFirstSizing.current = false
+        resize();
+        isFirstSizing.current = false;
         return;
       }
 


### PR DESCRIPTION
Fixes #3212, little regression introduced in #3007

We are debouncing the resize event to avoid resizing the grid dozens of time when resizing the window.
But debouncing even the 1st resize event mean that the initialization is debounced, causing a render to squeeze between the column init without there flex size (to now if we need a scrollbar) and there update with there flex size.


- With this PR no-flickering: https://codesandbox.io/s/columnfluidwidthgrid-material-demo-forked-i546y
- On v5.0.1 flickering:  https://codesandbox.io/s/3q8ue?file=/package.json
- On v5.0.0-beta.7 no flickering: https://codesandbox.io/s/columnfluidwidthgrid-material-demo-forked-bvyg6

It revert the only Argos snapshot changes of #3007 because the `onRowScrollEnd` is called on initialization, like before #3007
It does not make a lot of sense to me but I don't think it's worth spending to much time on it for now.