### PR TITLE
[DataGrid] Should not crash when a sort item uses a non-existing column

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
+++ b/packages/grid/_modules_/grid/hooks/features/sorting/useGridSorting.ts
@@ -9,11 +9,11 @@ import { GridFeatureModeConstant } from '../../../models/gridFeatureMode';
 import { GridColumnHeaderParams } from '../../../models/params/gridColumnHeaderParams';
 import { GridRowId, GridRowTreeNodeConfig } from '../../../models/gridRows';
 import {
-  GridFieldComparator,
   GridSortItem,
   GridSortModel,
   GridSortDirection,
   GridSortCellParams,
+  GridComparatorFn,
 } from '../../../models/gridSortModel';
 import { isDesc, nextGridSortDirection } from '../../../utils/sortingUtils';
 import { isEnterKey } from '../../../utils/keyboardUtils';
@@ -30,6 +30,8 @@ import {
 import { gridRowIdsSelector, gridRowTreeDepthSelector, gridRowTreeSelector } from '../rows';
 import { useGridStateInit } from '../../utils/useGridStateInit';
 import { useFirstRender } from '../../utils/useFirstRender';
+
+type GridFieldComparator = { field: string; comparator: GridComparatorFn };
 
 /**
  * @requires useGridRows (state, event)

--- a/packages/grid/_modules_/grid/models/gridSortModel.ts
+++ b/packages/grid/_modules_/grid/models/gridSortModel.ts
@@ -3,7 +3,7 @@ import { GridRowId } from './gridRows';
 
 export type GridSortDirection = 'asc' | 'desc' | null | undefined;
 
-export type GridFieldComparatorList = { field: string; comparator: GridComparatorFn }[];
+export type GridFieldComparator = { field: string; comparator: GridComparatorFn };
 
 export interface GridSortCellParams {
   id: GridRowId;

--- a/packages/grid/_modules_/grid/models/gridSortModel.ts
+++ b/packages/grid/_modules_/grid/models/gridSortModel.ts
@@ -3,8 +3,6 @@ import { GridRowId } from './gridRows';
 
 export type GridSortDirection = 'asc' | 'desc' | null | undefined;
 
-export type GridFieldComparator = { field: string; comparator: GridComparatorFn };
-
 export interface GridSortCellParams {
   id: GridRowId;
   field: string;

--- a/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -220,7 +220,7 @@ describe('<DataGrid /> - Sorting', () => {
     expect(getColumnValues()).to.deep.equal(['France', 'UK', 'US']);
   });
 
-  it.only('should support new dataset in control mode', () => {
+  it('should support new dataset in control mode', () => {
     const TestCase = (props: DataGridProps) => {
       const { rows, columns } = props;
       const [sortModel, setSortModel] = React.useState<GridSortModel>();

--- a/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/sorting.DataGrid.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { createRenderer, fireEvent, screen } from '@material-ui/monorepo/test/utils';
 import { expect } from 'chai';
-import { DataGrid, DataGridProps } from '@mui/x-data-grid';
+import { DataGrid, DataGridProps, GridSortModel } from '@mui/x-data-grid';
 import { getColumnValues, getColumnHeaderCell } from 'test/utils/helperFn';
 
 const isJSDOM = /jsdom/.test(window.navigator.userAgent);
@@ -182,11 +182,58 @@ describe('<DataGrid /> - Sorting', () => {
   });
 
   it('should support new dataset', () => {
-    const TestCase = (props: { rows: any[]; columns: any[] }) => {
+    const TestCase = (props: DataGridProps) => {
       const { rows, columns } = props;
       return (
         <div style={{ width: 300, height: 300 }}>
           <DataGrid autoHeight={isJSDOM} rows={rows} columns={columns} />
+        </div>
+      );
+    };
+
+    const { setProps } = render(<TestCase {...baselineProps} />);
+
+    const header = screen
+      .getByRole('columnheader', { name: 'brand' })
+      .querySelector('.MuiDataGrid-columnHeaderTitleContainer');
+    expect(getColumnValues()).to.deep.equal(['Nike', 'Adidas', 'Puma']);
+    fireEvent.click(header);
+    expect(getColumnValues()).to.deep.equal(['Adidas', 'Nike', 'Puma']);
+    const newData = {
+      rows: [
+        {
+          id: 0,
+          country: 'France',
+        },
+        {
+          id: 1,
+          country: 'UK',
+        },
+        {
+          id: 12,
+          country: 'US',
+        },
+      ],
+      columns: [{ field: 'country' }],
+    };
+    setProps(newData);
+    expect(getColumnValues()).to.deep.equal(['France', 'UK', 'US']);
+  });
+
+  it.only('should support new dataset in control mode', () => {
+    const TestCase = (props: DataGridProps) => {
+      const { rows, columns } = props;
+      const [sortModel, setSortModel] = React.useState<GridSortModel>();
+
+      return (
+        <div style={{ width: 300, height: 300 }}>
+          <DataGrid
+            autoHeight={isJSDOM}
+            rows={rows}
+            columns={columns}
+            sortModel={sortModel}
+            onSortModelChange={(newSortModel) => setSortModel(newSortModel)}
+          />
         </div>
       );
     };

--- a/scripts/exportsSnapshot.json
+++ b/scripts/exportsSnapshot.json
@@ -164,7 +164,6 @@
   { "name": "GridEnrichedColDef", "kind": "Type alias" },
   { "name": "GridExportFormat", "kind": "Type alias" },
   { "name": "GridFeatureMode", "kind": "Type alias" },
-  { "name": "GridFieldComparatorList", "kind": "Type alias" },
   { "name": "GridFilterActiveItemsLookup", "kind": "Type alias" },
   { "name": "GridFooterContainerProps", "kind": "Type alias" },
   { "name": "GridInputSelectionModel", "kind": "Type alias" },


### PR DESCRIPTION
Fixes #3020
It unifies the behavior with the filter. If we have an item that uses a non-existing column, we just ignore it.
This is necessary when the `sortModel` is controlled. When we change the columns, we automatically clean the `sortModel`. But when it is controlled, the update can be async and occurs after the `applySorting` triggered by the row change. So we have an `applySorting` with the new columns but the old `sortModel`, which causes a crash.

Before: https://codesandbox.io/s/datagriddemo-material-demo-forked-r27yc?file=/demo.tsx