### PR TITLE
[core] Reflect the change of default branch

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@ _DO NOT USE NPM, use Yarn to install the dependencies._
 
 ## How can I add a new demo to the documentation?
 
-[You can follow this guide](https://github.com/mui-org/material-ui/blob/next/CONTRIBUTING.md)
+[You can follow this guide](https://github.com/mui-org/material-ui/blob/HEAD/CONTRIBUTING.md)
 on how to get started contributing to MUI.
 
 ## How do I help to improve the translations?

--- a/docs/next.config.js
+++ b/docs/next.config.js
@@ -41,7 +41,8 @@ module.exports = {
     REACT_STRICT_MODE: reactStrictMode,
     // Set by Netlify
     GRID_EXPERIMENTAL_ENABLED: process.env.PULL_REQUEST === 'false' ? 'false' : 'true',
-    SOURCE_CODE_ROOT_URL: 'https://github.com/mui-org/material-ui-x/blob/next',
+    // #default-branch-switch
+    SOURCE_CODE_ROOT_URL: 'https://github.com/mui-org/material-ui-x/blob/master',
     SOURCE_CODE_REPO: 'https://github.com/mui-org/material-ui-x',
   },
   webpack5: true,


### PR DESCRIPTION
A follow-up on the change of the default branch from *next* to *master*.

Note that I also had to update the baseline branch of Argos-CI manually in the DB:

<img width="207" alt="Screenshot 2021-11-21 at 00 52 08" src="https://user-images.githubusercontent.com/3165635/142744229-a3b2a630-e12b-4b8b-a6a9-636b1d617c51.png">