### PR TITLE
[test] Row checkbox selection is handled by click and space key

### DIFF
--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -339,6 +339,26 @@ describe('<DataGrid /> - Selection', () => {
       expect(checkbox).to.have.attribute('tabindex', '0');
       expect(checkboxCell).to.have.attribute('tabindex', '-1');
     });
+
+    it('should select/unselect all rows when pressing space', async () => {
+      render(<TestDataGridSelection checkboxSelection />);
+
+      const selectAllCell = document.querySelector(
+        '[role="columnheader"][data-field="__check__"] input',
+      ) as HTMLElement;
+      selectAllCell.focus();
+
+      fireEvent.keyDown(selectAllCell, {
+        key: ' ',
+      });
+
+      expect(getSelectedRowIds()).to.deep.equal([0, 1, 2, 3]);
+      fireEvent.keyDown(selectAllCell, {
+        key: ' ',
+      });
+
+      expect(getSelectedRowIds()).to.deep.equal([]);
+    });
   });
 
   describe('props: isRowSelectable', () => {


### PR DESCRIPTION
Fix #1431

Add tests to verify the row can be selected by pressing `Space`. This test must be in e2e test, because the onChange of the checkbox is only fired by click in react-testing-library (https://github.com/testing-library/react-testing-library/issues/156).

I also removed `Space` from the keys entering edit mode, because it was overriding two accessibility keys presented in the [Doc](https://mui.com/components/data-grid/accessibility/#selection)

keys | action
:--: | --
<kbd>Space</kbd> | Navigate to the next scrollable page
<kbd>Shift</kbd> + <kbd>Space</kbd> | Select the current row





