### PR TITLE
[DataGridPro] Improve license file

### DIFF
--- a/packages/grid/x-data-grid-pro/LICENSE
+++ b/packages/grid/x-data-grid-pro/LICENSE
@@ -1,0 +1,12 @@
+Commercial License
+
+Copyright (c) 2020 Material-UI SAS
+
+MUI X Pro (https://mui.com/pricing/) is a commercial software. You must
+agree to the End User License Agreement (https://mui.com/x/license/)
+to be able to use it.
+
+A commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
+MUI also provides Evaluation (trial) licenses. You are free to install
+and try the SOFTWARE as long as it is not used for the development of a
+feature intended for production.

--- a/packages/grid/x-data-grid-pro/LICENSE
+++ b/packages/grid/x-data-grid-pro/LICENSE
@@ -2,11 +2,11 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Pro (https://mui.com/pricing/) is a commercial software. You must
-agree to the End User License Agreement (https://mui.com/x/license/)
-to be able to use it.
+MUI X Pro (https://mui.com/pricing/) is commercial software. You must purchase
+a license and agree to the End User License Agreement (EULA: https://mui.com/x/license/)
+to be able to use the software.
 
-A commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
-MUI also provides Evaluation (trial) licenses. You are free to install
-and try the SOFTWARE as long as it is not used for the development of a
-feature intended for production.
+Commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
+You are free to install and try the software without a license key as long as it
+is not used for the development of a feature intended for production use. You can
+find more details under the "Evaluation (trial) licenses" section of the EULA.

--- a/packages/grid/x-data-grid-pro/LICENSE.md
+++ b/packages/grid/x-data-grid-pro/LICENSE.md
@@ -1,7 +1,0 @@
-# [MUI X](https://mui.com/x/)
-
-This is commercial software.
-To use it, you need to agree to the [**End User License Agreement for MUI X**](https://mui.com/x/license/).
-If you do not own a commercial license, this file shall be governed by the trial license terms.
-
-All available MUI commercial licenses may be obtained at https://mui.com/store/items/material-ui-pro/.

--- a/packages/x-license-pro/LICENSE
+++ b/packages/x-license-pro/LICENSE
@@ -1,0 +1,12 @@
+Commercial License
+
+Copyright (c) 2020 Material-UI SAS
+
+MUI X Pro (https://mui.com/pricing/) is a commercial software. You must
+agree to the End User License Agreement (https://mui.com/x/license/)
+to be able to use it.
+
+A commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
+MUI also provides Evaluation (trial) licenses. You are free to install
+and try the SOFTWARE as long as it is not used for the development of a
+feature intended for production.

--- a/packages/x-license-pro/LICENSE
+++ b/packages/x-license-pro/LICENSE
@@ -2,11 +2,11 @@ Commercial License
 
 Copyright (c) 2020 Material-UI SAS
 
-MUI X Pro (https://mui.com/pricing/) is a commercial software. You must
-agree to the End User License Agreement (https://mui.com/x/license/)
-to be able to use it.
+MUI X Pro (https://mui.com/pricing/) is commercial software. You must purchase
+a license and agree to the End User License Agreement (EULA: https://mui.com/x/license/)
+to be able to use the software.
 
-A commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
-MUI also provides Evaluation (trial) licenses. You are free to install
-and try the SOFTWARE as long as it is not used for the development of a
-feature intended for production.
+Commercial licenses can be obtained at https://mui.com/store/items/material-ui-pro/.
+You are free to install and try the software without a license key as long as it
+is not used for the development of a feature intended for production use. You can
+find more details under the "Evaluation (trial) licenses" section of the EULA.

--- a/packages/x-license-pro/LICENSE.md
+++ b/packages/x-license-pro/LICENSE.md
@@ -1,7 +1,0 @@
-# [MUI X Pro](https://mui.com/pricing/)
-
-This is commercial software.
-To use it, you need to agree to the [**End User License Agreement for MUI X Pro**](https://mui.com/x/license/).
-If you do not own a commercial license, this file shall be governed by the trial license terms.
-
-All available MUI commercial licenses may be obtained at https://mui.com/store/items/material-ui-pro/.


### PR DESCRIPTION
This change is meant to improve the DX when browsing the license files. The PR removes the `.md` extension.

<img width="404" alt="Screenshot 2021-11-24 at 19 11 26" src="https://user-images.githubusercontent.com/3165635/143292592-9fec3442-98b6-4f83-b49d-3e5f4243b919.png">

In https://mui.com/pricing/, we try to explain to the audience how to navigate the license file:

- https://unpkg.com/@mui/material@5.0.1/LICENSE 200
- https://unpkg.com/@mui/x-data-grid@5.0.1/LICENSE 200
- https://unpkg.com/@mui/x-data-grid-pro@5.0.1/LICENSE 404 ❌

I think that I was wrong to make the second link a markdown, it's never interpreted as such.