### PR TITLE
[test] Force effect to run on location change

### DIFF
--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { useLocation } from 'react-router-dom';
 import clsx from 'clsx';
 import { useFakeTimers } from 'sinon';
 import { withStyles } from '@mui/styles';
@@ -54,10 +55,13 @@ function MockTime(props) {
 
 function LoadFont(props) {
   const { children, ...other } = props;
+  const location = useLocation();
   // We're simulating `act(() => ReactDOM.render(children))`
   // In the end children passive effects should've been flushed.
   // React doesn't have any such guarantee outside of `act()` so we're approximating it.
   const [ready, setReady] = React.useState(false);
+  // In react-router v6, with multiple routes sharing the same element,
+  // this effect will only run once if no dependency is passed.
   React.useEffect(() => {
     function handleFontsEvent(event) {
       if (event.type === 'loading') {
@@ -87,7 +91,7 @@ function LoadFont(props) {
       document.fonts.removeEventListener('loading', handleFontsEvent);
       document.fonts.removeEventListener('loadingdone', handleFontsEvent);
     };
-  }, []);
+  }, [location]);
 
   return (
     <div aria-busy={!ready} data-testid="testcase" {...other}>

--- a/test/regressions/index.test.js
+++ b/test/regressions/index.test.js
@@ -107,12 +107,6 @@ async function main() {
           '[data-testid="testcase"]:not([aria-busy="true"])',
         );
 
-        // Added during the migration from react-router-dom v5 to v6
-        // Without it, the screenshot is taken while the loading indicator is still visible
-        if (pathURL === '/docs-components-data-grid-filtering/ServerFilterGrid') {
-          await sleep(500); // TODO Investigate how to remove it
-        }
-
         await testcase.screenshot({ path: screenshotPath, type: 'png' });
       });
 


### PR DESCRIPTION
During the migration to react-router v6 in #3119, one of the regression tests was not working correctly. The `setTimeout` was never running, although it should since the clock is mocked. I tried one workaround of waiting a bit but it was not very reliable. This PR contains the proper fix. It turns out that since the same component is used for every route, React doesn't remount the component so the mount effect never run when the route changes. The mount effect was responsible for running all pending timers. It worked with react-router-dom v5 because, in this version, the route component was cloned before, instead of only returned.