### PR TITLE
[l10n] Improve German (de_DE) locale

### DIFF
--- a/packages/grid/_modules_/grid/locales/deDE.ts
+++ b/packages/grid/_modules_/grid/locales/deDE.ts
@@ -108,9 +108,9 @@ const deDEGrid: Partial<GridLocaleText> = {
   actionsCellMore: 'Mehr',
 
   // Tree Data
-  // treeDataGroupingHeaderName: 'Group',
-  // treeDataExpand: 'see children',
-  // treeDataCollapse: 'hide children',
+  treeDataGroupingHeaderName: 'Gruppe',
+  treeDataExpand: 'Kinder einblenden',
+  treeDataCollapse: 'Kinder ausblenden',
 };
 
 export const deDE: Localization = getGridLocalization(deDEGrid, deDECore);


### PR DESCRIPTION
This PR adds the missing tree data labels for the de_DE locale.