### PR TITLE
[docs] Key conbinations should have a nested kbd

### DIFF
--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -49,41 +49,41 @@ The grid responds to keyboard interactions from the user and emits events when k
 
 Use the arrow keys to move the focus.
 
-|                                                      Keys | Description                                   |
-| --------------------------------------------------------: | :-------------------------------------------- |
-|                         <kbd class="key">Arrow Left</kbd> | Navigate between cell elements                |
-|                       <kbd class="key">Arrow Bottom</kbd> | Navigate between cell elements                |
-|                        <kbd class="key">Arrow Right</kbd> | Navigate between cell elements                |
-|                           <kbd class="key">Arrow Up</kbd> | Navigate between cell elements                |
-|                               <kbd class="key">Home</kbd> | Navigate to the first cell of the current row |
-|                                <kbd class="key">End</kbd> | Navigate to the last cell of the current row  |
+|                                                               Keys | Description                                   |
+| -----------------------------------------------------------------: | :-------------------------------------------- |
+|                                  <kbd class="key">Arrow Left</kbd> | Navigate between cell elements                |
+|                                <kbd class="key">Arrow Bottom</kbd> | Navigate between cell elements                |
+|                                 <kbd class="key">Arrow Right</kbd> | Navigate between cell elements                |
+|                                    <kbd class="key">Arrow Up</kbd> | Navigate between cell elements                |
+|                                        <kbd class="key">Home</kbd> | Navigate to the first cell of the current row |
+|                                         <kbd class="key">End</kbd> | Navigate to the last cell of the current row  |
 | <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Home</kbd></kbd> | Navigate to the first cell of the first row   |
 |  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">End</kbd></kbd> | Navigate to the last cell of the last row     |
-|                              <kbd class="key">Space</kbd> | Navigate to the next scrollable page          |
-|                            <kbd class="key">Page Up</kbd> | Navigate to the next scrollable page          |
-|                          <kbd class="key">Page Down</kbd> | Navigate to the previous scrollable page      |
+|                                       <kbd class="key">Space</kbd> | Navigate to the next scrollable page          |
+|                                     <kbd class="key">Page Up</kbd> | Navigate to the next scrollable page          |
+|                                   <kbd class="key">Page Down</kbd> | Navigate to the previous scrollable page      |
 
 ### Selection
 
-|                                                                Keys | Description                                                          |
-| ------------------------------------------------------------------: | :------------------------------------------------------------------- |
+|                                                                         Keys | Description                                                          |
+| ---------------------------------------------------------------------------: | :------------------------------------------------------------------- |
 |         <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Space</kbd></kbd> | Select the current row                                               |
 | <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Arrow Up/Down</kbd></kbd> | Select the current row and the row above or below                    |
-|                        <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
+|                                  <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
 |              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
 |              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s)                                   |
 |               <kbd><kbd class="key">ALT</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s) including headers                 |
-|                         <kbd class="key">CTRL</kbd>+ Click on cell | Enable multi-selection                                               |
-|               <kbd class="key">CTRL</kbd>+ Click on a selected row | Deselect the row                                                     |
+|                                   <kbd class="key">CTRL</kbd>+ Click on cell | Enable multi-selection                                               |
+|                         <kbd class="key">CTRL</kbd>+ Click on a selected row | Deselect the row                                                     |
 
 ### Sorting
 
-|                                                        Keys | Description                                        |
-| ----------------------------------------------------------: | :------------------------------------------------- |
-|               <kbd class="key">CTRL</kbd>+ Click on header | Enable multi-sorting                               |
-|              <kbd class="key">Shift</kbd>+ Click on header | Enable multi-sorting                               |
+|                                                                 Keys | Description                                        |
+| -------------------------------------------------------------------: | :------------------------------------------------- |
+|                         <kbd class="key">CTRL</kbd>+ Click on header | Enable multi-sorting                               |
+|                        <kbd class="key">Shift</kbd>+ Click on header | Enable multi-sorting                               |
 | <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Enter</kbd></kbd> | Enable multi-sorting when column header is focused |
-|                                <kbd class="key">Enter</kbd> | Sort column when column header is focused          |
+|                                         <kbd class="key">Enter</kbd> | Sort column when column header is focused          |
 |  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Enter</kbd></kbd> | Open column menu when column header is focused     |
 
 ### Key assignment conventions

--- a/docs/src/pages/components/data-grid/accessibility/accessibility.md
+++ b/docs/src/pages/components/data-grid/accessibility/accessibility.md
@@ -57,8 +57,8 @@ Use the arrow keys to move the focus.
 |                           <kbd class="key">Arrow Up</kbd> | Navigate between cell elements                |
 |                               <kbd class="key">Home</kbd> | Navigate to the first cell of the current row |
 |                                <kbd class="key">End</kbd> | Navigate to the last cell of the current row  |
-| <kbd class="key">CTRL</kbd> + <kbd class="key">Home</kbd> | Navigate to the first cell of the first row   |
-|  <kbd class="key">CTRL</kbd> + <kbd class="key">End</kbd> | Navigate to the last cell of the last row     |
+| <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Home</kbd></kbd> | Navigate to the first cell of the first row   |
+|  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">End</kbd></kbd> | Navigate to the last cell of the last row     |
 |                              <kbd class="key">Space</kbd> | Navigate to the next scrollable page          |
 |                            <kbd class="key">Page Up</kbd> | Navigate to the next scrollable page          |
 |                          <kbd class="key">Page Down</kbd> | Navigate to the previous scrollable page      |
@@ -67,24 +67,24 @@ Use the arrow keys to move the focus.
 
 |                                                                Keys | Description                                                          |
 | ------------------------------------------------------------------: | :------------------------------------------------------------------- |
-|         <kbd class="key">Shift</kbd> + <kbd class="key">Space</kbd> | Select the current row                                               |
-| <kbd class="key">Shift</kbd> + <kbd class="key">Arrow Up/Down</kbd> | Select the current row and the row above or below                    |
-|                        <kbd class="key">Shift</kbd> + Click on cell | Select the range of rows between the first and the last clicked rows |
-|              <kbd class="key">CTRL</kbd> + <kbd class="key">A</kbd> | Select all rows                                                      |
-|              <kbd class="key">CTRL</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s)                                   |
-|               <kbd class="key">ALT</kbd> + <kbd class="key">C</kbd> | Copy the currently selected row(s) including headers                 |
-|                         <kbd class="key">CTRL</kbd> + Click on cell | Enable multi-selection                                               |
-|               <kbd class="key">CTRL</kbd> + Click on a selected row | Deselect the row                                                     |
+|         <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Space</kbd></kbd> | Select the current row                                               |
+| <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Arrow Up/Down</kbd></kbd> | Select the current row and the row above or below                    |
+|                        <kbd class="key">Shift</kbd>+ Click on cell | Select the range of rows between the first and the last clicked rows |
+|              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">A</kbd></kbd> | Select all rows                                                      |
+|              <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s)                                   |
+|               <kbd><kbd class="key">ALT</kbd>+<kbd class="key">C</kbd></kbd> | Copy the currently selected row(s) including headers                 |
+|                         <kbd class="key">CTRL</kbd>+ Click on cell | Enable multi-selection                                               |
+|               <kbd class="key">CTRL</kbd>+ Click on a selected row | Deselect the row                                                     |
 
 ### Sorting
 
 |                                                        Keys | Description                                        |
 | ----------------------------------------------------------: | :------------------------------------------------- |
-|               <kbd class="key">CTRL</kbd> + Click on header | Enable multi-sorting                               |
-|              <kbd class="key">Shift</kbd> + Click on header | Enable multi-sorting                               |
-| <kbd class="key">Shift</kbd> + <kbd class="key">Enter</kbd> | Enable multi-sorting when column header is focused |
+|               <kbd class="key">CTRL</kbd>+ Click on header | Enable multi-sorting                               |
+|              <kbd class="key">Shift</kbd>+ Click on header | Enable multi-sorting                               |
+| <kbd><kbd class="key">Shift</kbd>+<kbd class="key">Enter</kbd></kbd> | Enable multi-sorting when column header is focused |
 |                                <kbd class="key">Enter</kbd> | Sort column when column header is focused          |
-|  <kbd class="key">CTRL</kbd> + <kbd class="key">Enter</kbd> | Open column menu when column header is focused     |
+|  <kbd><kbd class="key">CTRL</kbd>+<kbd class="key">Enter</kbd></kbd> | Open column menu when column header is focused     |
 
 ### Key assignment conventions
 


### PR DESCRIPTION
> Nesting a `<kbd>` element within another `<kbd>` element represents an actual key or other unit of input as a portion of a larger input.

https://developer.mozilla.org/en-US/docs/Web/HTML/Element/kbd#usage_notes

The a11y page might be one where we want to follow the recommendations more closely. We worked on this problem in https://github.com/mui-org/material-ui/pull/24269. 