### PR TITLE
[docs] Use relative links

### DIFF
--- a/docs/src/pages/components/data-grid/getting-started/migration-v4.md
+++ b/docs/src/pages/components/data-grid/getting-started/migration-v4.md
@@ -168,7 +168,7 @@ The following interactive demo shows how these steps tie together:
   - `onRowLeave`
 
   If you depend on them, you can use `componentsProps.row` and `componentsProps.cell` to pass custom props to the row or cell.
-  For more information, check [this page](https://mui.com/components/data-grid/components/#row). Example:
+  For more information, check [this page](/components/data-grid/components/#row). Example:
 
   ```diff
   -<DataGrid onRowOver={handleRowOver} />;

--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -101,9 +101,7 @@ import { DataGrid, nlNL } from '@mui/x-data-grid';
 You can [find the source](https://github.com/mui-org/material-ui-x/blob/HEAD/packages/grid/_modules_/grid/locales) in the GitHub repository.
 
 To create your own translation or to customize the English text, copy this file to your project, make any changes needed and import the locale from there.
-
-Please do consider contributing new translations back to MUI by opening a pull request. However, MUI aims to support the 100 most popular locales. We might not accept contributions for locales that are not frequently used, for instance, `gl-ES` that has "only" 2.5 million native speakers.
-See the [Docs](https://mui.com/components/data-grid/localization/) for more details.
+Note that these translations of the Data grid component depend on the [Localization strategy](/guides/localization/) of the whole library.
 
 ## API
 

--- a/docs/src/pages/components/data-grid/overview/overview.md
+++ b/docs/src/pages/components/data-grid/overview/overview.md
@@ -14,8 +14,8 @@ Data tables display information in a grid-like format of rows and columns. They 
 
 The data grid comes with two different licenses:
 
-- [DataGrid](https://mui.com/api/data-grid/data-grid/), it's [MIT licensed](https://tldrlegal.com/license/mit-license) and available on npm as `@mui/x-data-grid`.
-- [DataGridPro](https://mui.com/api/data-grid/data-grid-pro/), it's **Commercially licensed** and available on npm as `@mui/x-data-grid-pro`.
+- [DataGrid](/api/data-grid/data-grid/), it's [MIT licensed](https://tldrlegal.com/license/mit-license) and available on npm as `@mui/x-data-grid`.
+- [DataGridPro](/data-grid/data-grid-pro/), it's **Commercially licensed** and available on npm as `@mui/x-data-grid-pro`.
   The features only available in the commercial version are suffixed with a <span class="pro"></span> icon for the Pro plan or a <span class="premium"></span> icon for the Premium plan.
 
   <img src="/static/x/header-icon.png" style="width: 454px; margin-bottom: 2rem;" alt="">
@@ -27,7 +27,7 @@ The data grid comes with two different licenses:
 
 ### MIT version
 
-The first version is meant to simplify the [Table demo](https://mui.com/components/tables/#sorting-amp-selecting) with a clean abstraction.
+The first version is meant to simplify the [Table demo](/components/tables/#sorting-amp-selecting) with a clean abstraction.
 This abstraction also set constraints that allow the component to implement new features.
 
 ```js


### PR DESCRIPTION
Older versions of the documentation are hosted on a subdomain, e.g. https://v4.mui.com/components/data-grid/. Using relative links would help keep the user on the **same version** of the documentation.