### PR TITLE
[DataGridPro] Temporarily remove the callback version of the `groupingColDef` prop

### DIFF
--- a/docs/pages/api-docs/data-grid/data-grid-pro.json
+++ b/docs/pages/api-docs/data-grid/data-grid-pro.json
@@ -66,7 +66,7 @@
     "getRowClassName": { "type": { "name": "func" } },
     "getRowId": { "type": { "name": "func" } },
     "getTreeDataPath": { "type": { "name": "func" } },
-    "groupingColDef": { "type": { "name": "union", "description": "func<br>&#124;&nbsp;object" } },
+    "groupingColDef": { "type": { "name": "object" } },
     "headerHeight": { "type": { "name": "number" }, "default": "56" },
     "hideFooter": { "type": { "name": "bool" } },
     "hideFooterPagination": { "type": { "name": "bool" } },

--- a/packages/grid/_modules_/grid/GridComponentProps.ts
+++ b/packages/grid/_modules_/grid/GridComponentProps.ts
@@ -3,11 +3,7 @@ import { SxProps } from '@mui/system';
 import { Theme } from '@mui/material/styles';
 import { GridInitialState } from './models/gridState';
 import { GridApiRef } from './models/api/gridApiRef';
-import {
-  GridColDefOverride,
-  GridColDefOverrideCallback,
-  GridColumns,
-} from './models/colDef/gridColDef';
+import { GridColDefOverride, GridColumns } from './models/colDef/gridColDef';
 import {
   GridSimpleOptions,
   GridProcessedMergedOptions,
@@ -399,9 +395,8 @@ interface GridComponentOtherProps extends CommonProps {
   /**
    * The grouping column used by the tree data.
    */
-  groupingColDef?:
-    | GridColDefOverride<'field' | 'editable'>
-    | GridColDefOverrideCallback<'field' | 'editable'>;
+  groupingColDef?: GridColDefOverride<'field' | 'editable'>;
+
   /**
    * The system prop that allows defining system overrides as well as additional CSS styles.
    */

--- a/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.ts
+++ b/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.ts
@@ -7,7 +7,7 @@ import {
 } from './gridTreeDataGroupColDef';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridEvents, GridEventListener } from '../../../models/events';
-import { GridColDef, GridColDefOverrideParams } from '../../../models';
+import { GridColDef } from '../../../models';
 import { isSpaceKey } from '../../../utils/keyboardUtils';
 import { useFirstRender } from '../../utils/useFirstRender';
 import { buildRowTree, BuildRowTreeGroupingCriteria } from '../../../utils/tree/buildRowTree';

--- a/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.ts
+++ b/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.ts
@@ -36,17 +36,18 @@ export const useGridTreeData = (
       headerName: apiRef.current.getLocaleText('treeDataGroupingHeaderName'),
       ...GRID_TREE_DATA_GROUP_COL_DEF_FORCED_FIELDS,
     };
-    let colDefOverride: Partial<GridColDef>;
-
-    if (typeof propGroupingColDef === 'function') {
-      const params: GridColDefOverrideParams = {
-        colDef: baseColDef,
-      };
-
-      colDefOverride = propGroupingColDef(params);
-    } else {
-      colDefOverride = propGroupingColDef ?? {};
-    }
+    const colDefOverride: Partial<GridColDef> = propGroupingColDef ?? {};
+    // let colDefOverride: Partial<GridColDef>;
+    //
+    // if (typeof propGroupingColDef === 'function') {
+    //   const params: GridColDefOverrideParams = {
+    //     colDef: baseColDef,
+    //   };
+    //
+    //   colDefOverride = propGroupingColDef(params);
+    // } else {
+    //   colDefOverride = propGroupingColDef ?? {};
+    // }
 
     return {
       ...baseColDef,

--- a/packages/grid/x-data-grid-pro/src/DataGridPro.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridPro.tsx
@@ -283,7 +283,7 @@ DataGridProRaw.propTypes = {
   /**
    * The grouping column used by the tree data.
    */
-  groupingColDef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  groupingColDef: PropTypes.object,
   /**
    * Set the height in pixel of the column headers in the grid.
    * @default 56


### PR DESCRIPTION
The format will evolve and we want to avoid breaking changes so we are disabling this feature before releasing it.