### PR TITLE
[core] Fix missing LICENSE file

### DIFF
--- a/packages/grid/rollup.x-data-grid-pro.config.js
+++ b/packages/grid/rollup.x-data-grid-pro.config.js
@@ -68,7 +68,7 @@ export default [
             {
               src: [
                 './x-data-grid-pro/README.md',
-                './x-data-grid-pro/LICENSE.md',
+                './x-data-grid-pro/LICENSE',
                 '../../CHANGELOG.md',
               ],
               dest: './x-data-grid-pro/build',

--- a/packages/x-license-pro/rollup.config.js
+++ b/packages/x-license-pro/rollup.config.js
@@ -44,7 +44,7 @@ export default [
         copy({
           targets: [
             {
-              src: ['./README.md', './LICENSE.md', '../../CHANGELOG.md', './bin'],
+              src: ['./README.md', './LICENSE', '../../CHANGELOG.md', './bin'],
               dest: './build',
             },
             {


### PR DESCRIPTION
It's a regression from #3278. See how there are no license files in https://unpkg.com/browse/@mui/x-data-grid-pro@5.1.0/.