### PR TITLE
[core] Add funding field

### DIFF
--- a/packages/grid/x-data-grid/package.json
+++ b/packages/grid/x-data-grid/package.json
@@ -11,6 +11,10 @@
     "url": "https://github.com/mui-org/material-ui-x/issues"
   },
   "homepage": "https://mui.com/components/data-grid/",
+  "funding": {
+    "type": "opencollective",
+    "url": "https://opencollective.com/mui"
+  },
   "sideEffects": false,
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
Add an incentive for donation to the MUI non-profit, to sustain the MIT effort. We use the same field in MUI Core, you can find the same in https://unpkg.com/react-table@7.7.0/package.json. In practice, I doubt that it will have much impact. Donations are <1% of our funding.