### PR TITLE
[docs] Fix double MUI in the title

### DIFF
--- a/docs/src/modules/components/ApiPage.js
+++ b/docs/src/modules/components/ApiPage.js
@@ -1,3 +1,7 @@
+/**
+ * TODO replace file with:
+ * import ApiPage from 'docs/src/modules/components/ApiPage';
+ */
 /* eslint-disable react/no-danger */
 import * as React from 'react';
 import PropTypes from 'prop-types';
@@ -270,7 +274,7 @@ import { ${componentName} } from '@mui/x-data-grid-pro';`;
       disableAd={false}
       disableToc={false}
       location={apiSourceLocation}
-      title={`${componentName} API – MUI`}
+      title={`${componentName} API`}
       toc={toc}
     >
       <MarkdownElement>


### PR DESCRIPTION
I recall fixing this in the main repo https://github.com/mui-org/material-ui/pull/28634. However, we **forked** the component so the fix didn't propagate here:

<img width="437" alt="Screenshot 2021-12-04 at 15 17 27" src="https://user-images.githubusercontent.com/3165635/144712813-3ad867bc-008a-40cc-b661-939c96c4f013.png">

How did I find this? Looking at the [ahrefs crawl audit](https://app.ahrefs.com/site-audit/2944028/16/data-explorer?columns=pageRating%2Curl%2Ctraffic%2Ctitle%2Cserp_title%2Cis_page_title_used_in_serp%2Ctop_keyword%2Ctop_keyword_position&filterCollapsed=true&filterId=a18e81583b7c422e0270e064cd41b3cf&issueId=d69246c2-225a-11ec-8456-06d2f2f613d8).