### PR TITLE
[docs] Disable the ad when not MIT

### DIFF
--- a/docs/pages/components/data-grid/events.js
+++ b/docs/pages/components/data-grid/events.js
@@ -7,5 +7,5 @@ import {
 } from 'docsx/src/pages/components/data-grid/events/events.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
 }

--- a/docs/pages/components/data-grid/group-pivot.js
+++ b/docs/pages/components/data-grid/group-pivot.js
@@ -7,5 +7,5 @@ import {
 } from 'docsx/src/pages/components/data-grid/group-pivot/group-pivot.md?@mui/markdown';
 
 export default function Page() {
-  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} />;
+  return <MarkdownDocs demos={demos} docs={docs} demoComponents={demoComponents} disableAd />;
 }

--- a/docs/src/pages/components/data-grid/editing/editing.md
+++ b/docs/src/pages/components/data-grid/editing/editing.md
@@ -207,7 +207,7 @@ Once at the least one field has the `error` attribute equals to true no new valu
 
 The following demo requires a value for the "Payment method" column if the "Is paid?" column was checked.
 
-{{"demo": "pages/components/data-grid/editing/ConditionalValidationGrid.js", "bg": "inline", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/editing/ConditionalValidationGrid.js", "disableAd": true, "bg": "inline", "defaultCodeOpen": false}}
 
 > The conditional validation can also be implemented with the [controlled editing](#controlled-editing-2).
 > This approach can be used in the free version of the DataGrid.
@@ -235,7 +235,7 @@ To access the new values for the row, use `apiRef.current.getEditRowsModel` to g
 
 You can then decide if you want to send the whole row or only the modified fields, by checking them against the previous row values.
 
-{{"demo": "pages/components/data-grid/editing/RowEditServerSidePersistence.js", "bg": "inline", "defaultCodeOpen": false}}
+{{"demo": "pages/components/data-grid/editing/RowEditServerSidePersistence.js", "disableAd": true, "bg": "inline", "defaultCodeOpen": false}}
 
 ### Events [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
 

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -4,11 +4,11 @@ title: Data Grid - Group & Pivot
 
 # Data Grid - Group & Pivot
 
-<p class="description">Use grouping, pivoting and more to analyse the data in depth.</p>
+<p class="description">Use grouping, pivoting, and more to analyze the data in depth.</p>
 
 ## Tree Data [<span class="plan-pro"></span>](https://mui.com/store/items/material-ui-pro/)
 
-Tree Data allows to display data with parent / child relationships.
+Tree Data allows to display data with parent/child relationships.
 
 To enable the Tree Data, you simply have to use the `treeData` prop as well as provide a `getTreeDataPath` prop.
 The `getTreeDataPath` function returns an array of strings which represents the path to a given row.
@@ -86,7 +86,7 @@ A node is included if one of the following criteria is met:
 - it is passing the filters
 
 By default, the filtering is applied to every depth of the tree.
-You can limit the filtering to the top level rows with the `disableChildrenFiltering` prop.
+You can limit the filtering to the top-level rows with the `disableChildrenFiltering` prop.
 
 {{"demo": "pages/components/data-grid/group-pivot/DisableChildrenFilteringTreeData.js", "bg": "inline", "defaultCodeOpen": false}}
 
@@ -108,7 +108,7 @@ You can limit the sorting to the top level rows with the `disableChildrenSorting
 > const invalidRows = [{ path: ['A'] }, { path: ['B'] }, { path: ['A', 'A'] }];
 > ```
 
-### Full Example
+### Full example
 
 {{"demo": "pages/components/data-grid/group-pivot/TreeDataFullExample.js", "bg": "inline", "defaultCodeOpen": false}}
 


### PR DESCRIPTION
Take https://mui.com/components/data-grid/events/ as an example:

<img width="609" alt="Screenshot 2021-12-05 at 00 09 46" src="https://user-images.githubusercontent.com/3165635/144727366-4a9970f5-42d1-4de0-99bc-58952e09b253.png">

We display an ad at the top and below the demos:

<img width="852" alt="Screenshot 2021-12-05 at 00 10 48" src="https://user-images.githubusercontent.com/3165635/144727386-13f2343b-b45b-4609-8d09-87c461776050.png">

This is not needed for commercial licensed software.

