### PR TITLE
[core] Add link to OpenCollective

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,8 @@
+# These are supported funding model platforms
+
+github: # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+patreon: # Replace with a single Patreon username
+open_collective: mui
+ko_fi: # Replace with a single Ko-fi username
+tidelift: # Replace with a tidelift package name
+custom: # Replace with a single custom sponsorship URL


### PR DESCRIPTION
Same incentive as #3331. This will enable the following button in the header:

<img width="207" alt="Screenshot 2021-12-10 at 14 23 54" src="https://user-images.githubusercontent.com/3165635/145580768-a8938131-ad99-4930-8a7e-74a3c185dc3f.png">
This won't have much impact, only to reinforce that MIT is fueled by the contributions of the community. In an ideal world, we wouldn't need a commercial license to push our mission forward on MUI X. 

I'm working on this as a quick follow-up on a bug we had in MUI Core: https://github.com/mui-org/material-ui/commit/e6558bc2ccf47e8330ec1c35ec23d68d35bd8624.