### PR TITLE
[core] Remove `x-data-grid` folder from DataGridPro bundle

### DIFF
--- a/packages/grid/rollup.x-data-grid-pro.config.js
+++ b/packages/grid/rollup.x-data-grid-pro.config.js
@@ -93,9 +93,9 @@ export default [
       production &&
         command(
           [
-            `rm -rf ./x-data-grid-pro/build/x-data-grid-pro`,
             `rm -rf ./x-data-grid-pro/build/_modules_`,
-            `rm -rf ./x-data-grid-pro/build/data-grid`,
+            `rm -rf ./x-data-grid-pro/build/x-data-grid`,
+            `rm -rf ./x-data-grid-pro/build/x-data-grid-pro`,
             `rm -rf ./x-data-grid-pro/build/x-data-grid-generator`,
           ],
           {

--- a/packages/grid/rollup.x-data-grid.config.js
+++ b/packages/grid/rollup.x-data-grid.config.js
@@ -84,8 +84,8 @@ export default [
       production &&
         command(
           [
-            `rm -rf ./x-data-grid/build/x-data-grid`,
             `rm -rf ./x-data-grid/build/_modules_ `,
+            `rm -rf ./x-data-grid/build/x-data-grid`,
             `rm -rf ./x-data-grid/build/x-data-grid-pro`,
             `rm -rf ./x-data-grid/build/x-data-grid-generator`,
           ],


### PR DESCRIPTION
The `x-data-grid` folder is being bundled with DataGridPro. See https://unpkg.com/browse/@mui/x-data-grid-pro@5.2.0/. I noticed in #3389.