### PR TITLE
[docs] Include @mui/x-data-grid as dependency in the CodeSandbox

### DIFF
--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -44,13 +44,13 @@ ponyfillGlobal.muiDocConfig = {
 
     if (newDeps['@mui/x-data-grid-pro'] || newDeps['@mui/x-data-grid']) {
       newDeps['@mui/material'] = versions['@mui/material'];
-      newDeps['@mui/styles'] = versions['@mui/styles'];
     }
 
     if (newDeps['@mui/x-data-grid-generator']) {
       newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
-      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
+      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid']; // TS types are imported from @mui/x-data-grid
+      newDeps['@mui/styles'] = versions['@mui/styles'];
     }
 
     return newDeps;

--- a/docs/pages/_app.js
+++ b/docs/pages/_app.js
@@ -50,6 +50,7 @@ ponyfillGlobal.muiDocConfig = {
     if (newDeps['@mui/x-data-grid-generator']) {
       newDeps['@mui/material'] = versions['@mui/material'];
       newDeps['@mui/icons-material'] = versions['@mui/icons-material'];
+      newDeps['@mui/x-data-grid'] = versions['@mui/x-data-grid'];
     }
 
     return newDeps;


### PR DESCRIPTION
- Go to https://mui.com/components/data-grid/pagination/#paginate-gt-100-rows
- Click to open the demo in CodeSandbox
- It doesn't run because `@mui/x-data-grid-generator` needs `@mui/x-data-grid`