### PR TITLE
[l10n] Improve German (de-DE) locale 

### DIFF
--- a/packages/grid/_modules_/grid/locales/deDE.ts
+++ b/packages/grid/_modules_/grid/locales/deDE.ts
@@ -108,9 +108,9 @@ const deDEGrid: Partial<GridLocaleText> = {
   actionsCellMore: 'Mehr',
 
   // Column pinning text
-  // pinToLeft: 'Pin to left',
-  // pinToRight: 'Pin to right',
-  // unpin: 'Unpin',
+  pinToLeft: 'Links anheften',
+  pinToRight: 'Rechts anheften',
+  unpin: 'Loslösen',
 
   // Tree Data
   treeDataGroupingHeaderName: 'Gruppe',


### PR DESCRIPTION
This PR adds the missing column pinning translations for the German (de-DE) locale.