### PR TITLE
[DataGridPro] Avoid filtering columns if no column is pinned

### DIFF
--- a/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
@@ -21,6 +21,10 @@ import {
 } from '../../_modules_/grid/models/api/gridColumnPinningApi';
 
 export const filterColumns = (pinnedColumns: GridPinnedColumns, columns: string[]) => {
+  if (!Array.isArray(pinnedColumns.left) && !Array.isArray(pinnedColumns.right)) {
+    return [[], []];
+  }
+
   const filter = (newPinnedColumns: any[] | undefined, remaningColumns: string[]) => {
     if (!Array.isArray(newPinnedColumns)) {
       return [];

--- a/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
@@ -25,6 +25,10 @@ export const filterColumns = (pinnedColumns: GridPinnedColumns, columns: string[
     return [[], []];
   }
 
+  if (pinnedColumns.left?.length === 0 && pinnedColumns.right?.length === 0) {
+    return [[], []];
+  }
+
   const filter = (newPinnedColumns: any[] | undefined, remaningColumns: string[]) => {
     if (!Array.isArray(newPinnedColumns)) {
       return [];


### PR DESCRIPTION
There was a performance hit when scrolling because it was filtering the columns on every render.