### PR TITLE
[core] Increase CI efficiency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,6 @@ commands:
           name: Restore yarn cache
           keys:
             - v8-yarn-{{ checksum "yarn.lock" }}
-            - v8-yarn-
       - run:
           name: Set yarn cache folder
           command: |
@@ -74,8 +73,6 @@ commands:
                 name: Restore playwright cache
                 keys:
                   - v5-playwright-{{ arch }}-{{ checksum "/tmp/playwright_info.json" }}
-                  - v5-playwright-{{ arch }}-
-                  - v5-playwright-
       - run:
           name: Install js dependencies
           command: yarn install --verbose
@@ -111,12 +108,6 @@ jobs:
       - run:
           name: Check for duplicated packages
           command: yarn deduplicate
-      - save_cache:
-          key: v6-yarn-sha-{{ checksum "yarn.lock" }}
-          paths:
-            # Keep path in sync with "Set yarn cache folder"
-            # Can't use environment variables for `save_cache` paths (tested in https://app.circleci.com/pipelines/github/mui-org/material-ui/37813/workflows/5b1e207f-ac8b-44e7-9ba4-d0f9a01f5c55/jobs/223370)
-            - ~/.cache/yarn
   test_unit:
     <<: *defaults
     steps:


### PR DESCRIPTION
I have applied https://github.com/mui-org/material-ui/pull/29040 here. (*a new example to illustrate the pros of mono-repo > multiple-repos*). This is in the scope of the [React infra](https://www.notion.so/mui-org/React-infra-5562c14178aa42af97bc1fa5114000cd) group.

For example, on https://github.com/mui-org/material-ui-x/pull/3437 take the restore cache step of `test_browser`:

<img width="1105" alt="Screenshot 2021-12-15 at 23 56 46" src="https://user-images.githubusercontent.com/3165635/146277745-fdfd4bf4-79d8-498d-bcee-3e7c66e00e6a.png">

It uses 4 GB of storage and takes 2 minutes to happen. Now compare it to the CI build on this PR for `test_browser`:

<img width="1100" alt="Screenshot 2021-12-16 at 00 02 00" src="https://user-images.githubusercontent.com/3165635/146278276-2f85a347-580f-47bc-9d81-4c53348e8332.png">

Better no? 😄