### PR TITLE
[DataGrid] Remove `line-height` from `GridCell`

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -154,7 +154,6 @@ function GridCell(props: GridCellProps) {
     maxWidth: width,
     minHeight: height,
     maxHeight: height,
-    lineHeight: `${height - 1}px`,
   };
 
   React.useLayoutEffect(() => {

--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -259,26 +259,14 @@ export const GridRootStyles = styled('div', {
       borderRight: `1px solid ${borderColor}`,
     },
     [`& .${gridClasses['cell--textLeft']}`]: {
-      textAlign: 'left',
+      justifyContent: 'flex-start',
     },
-    [`& .${gridClasses['cell--textLeft']}.${gridClasses['cell--withRenderer']}, & .${gridClasses['cell--textLeft']}.${gridClasses['cell--editing']}`]:
-      {
-        justifyContent: 'flex-start',
-      },
     [`& .${gridClasses['cell--textRight']}`]: {
-      textAlign: 'right',
+      justifyContent: 'flex-end',
     },
-    [`& .${gridClasses['cell--textRight']}.${gridClasses['cell--withRenderer']}, & .${gridClasses['cell--textRight']}.${gridClasses['cell--editing']}`]:
-      {
-        justifyContent: 'flex-end',
-      },
     [`& .${gridClasses['cell--textCenter']}`]: {
-      textAlign: 'center',
+      justifyContent: 'center',
     },
-    [`& .${gridClasses['cell--textCenter']}.${gridClasses['cell--withRenderer']}, & .${gridClasses['cell--textCenter']}.${gridClasses['cell--editing']}`]:
-      {
-        justifyContent: 'center',
-      },
     [`& .${gridClasses.columnHeaderDraggableContainer}`]: {
       display: 'flex',
       width: '100%',

--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -213,7 +213,8 @@ export const GridRootStyles = styled('div', {
       },
     },
     [`& .${gridClasses.cell}`]: {
-      display: 'block',
+      display: 'flex',
+      alignItems: 'center',
       overflow: 'hidden',
       textOverflow: 'ellipsis',
       whiteSpace: 'nowrap',
@@ -253,10 +254,6 @@ export const GridRootStyles = styled('div', {
       display: 'inline-flex',
       alignItems: 'center',
       gridGap: theme.spacing(1),
-    },
-    [`& .${gridClasses['cell--withRenderer']}`]: {
-      display: 'flex',
-      alignItems: 'center',
     },
     [`& .${gridClasses.withBorder}`]: {
       borderRight: `1px solid ${borderColor}`,

--- a/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
+++ b/packages/grid/_modules_/grid/components/containers/GridRootStyles.ts
@@ -12,6 +12,7 @@ export const GridRootStyles = styled('div', {
     { [`& .${gridClasses['cell--textCenter']}`]: styles['cell--textCenter'] },
     { [`& .${gridClasses['cell--textLeft']}`]: styles['cell--textLeft'] },
     { [`& .${gridClasses['cell--textRight']}`]: styles['cell--textRight'] },
+    // TODO: v6 - remove
     { [`& .${gridClasses['cell--withRenderer']}`]: styles['cell--withRenderer'] },
     { [`& .${gridClasses.cell}`]: styles.cell },
     { [`& .${gridClasses.cellCheckbox}`]: styles.cellCheckbox },


### PR DESCRIPTION
Fixes #2859 

A small change to the way we center content in grid cells - the result is to enable multi-lines in grid cells.