### PR TITLE
[DataGrid] Fix scroll jump when selection checkbox is checked

### DIFF
--- a/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -25,7 +25,7 @@ const useUtilityClasses = (ownerState: OwnerState) => {
 
 const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellParams>(
   function GridCellCheckboxRenderer(props, ref) {
-    const { field, id, value, tabIndex, hasFocus } = props;
+    const { field, id, value, tabIndex } = props;
     const apiRef = useGridApiContext();
     const rootProps = useGridRootProps();
     const ownerState = { classes: rootProps.classes };
@@ -49,13 +49,6 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellPa
         element!.tabIndex = -1;
       }
     }, [element, tabIndex]);
-
-    React.useLayoutEffect(() => {
-      if (hasFocus && checkboxElement.current) {
-        const input = checkboxElement.current.querySelector('input')!;
-        input!.focus();
-      }
-    }, [hasFocus]);
 
     const handleKeyDown = React.useCallback(
       (event) => {


### PR DESCRIPTION
Fixes #3397 

I removed the `HTMLElement.focus()` call because the cell already puts the focus on the element with `tabindex=0`:

https://github.com/mui-org/material-ui-x/blob/1ed95e17aa46cd1298957b428d2d3b3173acf673/packages/grid/_modules_/grid/components/cell/GridCell.tsx#L168-L172