### PR TITLE
[DataGrid] Close other actions menus when opening a new one

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridActionsCell.tsx
@@ -27,10 +27,7 @@ const GridActionsCell = (props: GridActionsCellProps) => {
     throw new Error('MUI: Missing the `getActions` property in the `GridColDef`.');
   }
 
-  const showMenu = (event: React.MouseEvent) => {
-    event.stopPropagation();
-    setOpen(true);
-  };
+  const showMenu = () => setOpen(true);
 
   const hideMenu = () => setOpen(false);
 

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -19,13 +19,12 @@ import {
 import { gridPaginatedVisibleSortedGridRowIdsSelector } from '../pagination';
 import { gridVisibleSortedRowIdsSelector } from '../filter/gridFilterSelector';
 import { GRID_CHECKBOX_SELECTION_COL_DEF, GridColDef } from '../../../models';
-import { getDataGridUtilityClass } from '../../../gridClasses';
+import { getDataGridUtilityClass, gridClasses } from '../../../gridClasses';
 import { useGridStateInit } from '../../utils/useGridStateInit';
 import { GridPreProcessingGroup, useGridRegisterPreProcessor } from '../../core/preProcessing';
 import { GridCellModes } from '../../../models/gridEditRowModel';
 import { GridColumnsRawState } from '../columns/gridColumnsState';
 import { isKeyboardEvent } from '../../../utils/keyboardUtils';
-import { gridClasses } from '../../..';
 
 type OwnerState = { classes: GridComponentProps['classes'] };
 

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -10,7 +10,7 @@ import { useGridApiMethod } from '../../utils/useGridApiMethod';
 import { useGridLogger } from '../../utils/useGridLogger';
 import { useGridState } from '../../utils/useGridState';
 import { gridRowsLookupSelector } from '../rows/gridRowsSelector';
-import { isGridCellRoot } from '../../../utils/domUtils';
+import { findParentElementFromClassName, isGridCellRoot } from '../../../utils/domUtils';
 import {
   gridSelectionStateSelector,
   selectedGridRowsSelector,
@@ -25,6 +25,7 @@ import { GridPreProcessingGroup, useGridRegisterPreProcessor } from '../../core/
 import { GridCellModes } from '../../../models/gridEditRowModel';
 import { GridColumnsRawState } from '../columns/gridColumnsState';
 import { isKeyboardEvent } from '../../../utils/keyboardUtils';
+import { gridClasses } from '../../..';
 
 type OwnerState = { classes: GridComponentProps['classes'] };
 
@@ -331,6 +332,18 @@ export const useGridSelection = (
         return;
       }
 
+      const cellClicked = findParentElementFromClassName(
+        event.target as HTMLElement,
+        gridClasses.cell,
+      );
+      const field = cellClicked?.getAttribute('data-field');
+      if (field) {
+        const column = apiRef.current.getColumn(field);
+        if (column.type === 'actions') {
+          return;
+        }
+      }
+
       if (event.shiftKey && (canHaveMultipleSelection || checkboxSelection)) {
         expandRowRangeSelection(params.id);
       } else {
@@ -338,11 +351,12 @@ export const useGridSelection = (
       }
     },
     [
+      disableSelectionOnClick,
+      canHaveMultipleSelection,
+      checkboxSelection,
+      apiRef,
       expandRowRangeSelection,
       handleSingleRowSelection,
-      canHaveMultipleSelection,
-      disableSelectionOnClick,
-      checkboxSelection,
     ],
   );
 


### PR DESCRIPTION
Fixes #3489

Preview: https://deploy-preview-3492--material-ui-x.netlify.app/components/data-grid/columns/#special-properties

If we continue to add more column types with interactive elements, then it makes sense to add a per-column `disableSelectionOnClick`.