### PR TITLE
[l10n] Improve French (frFR) locale

### DIFF
--- a/packages/grid/_modules_/grid/locales/frFR.ts
+++ b/packages/grid/_modules_/grid/locales/frFR.ts
@@ -31,7 +31,7 @@ const frFRGrid: Partial<GridLocaleText> = {
   toolbarExport: 'Exporter',
   toolbarExportLabel: 'Exporter',
   toolbarExportCSV: 'Télécharger en CSV',
-  // toolbarExportPrint: 'Print',
+  toolbarExportPrint: 'Imprimer',
 
   // Columns panel text
   columnsPanelTextFieldLabel: 'Chercher colonne',


### PR DESCRIPTION
The `Print` option of the `DataGrid` wasn't translated.  
This PR should fix this.