### PR TITLE
[DataGrid] Fix focus on checkbox cells

### DIFF
--- a/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridCellCheckboxRenderer.tsx
@@ -40,10 +40,6 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellPa
       apiRef.current.publishEvent(GridEvents.rowSelectionCheckboxChange, params, event);
     };
 
-    const handleClick = (event: React.MouseEvent<HTMLInputElement>) => {
-      event.stopPropagation();
-    };
-
     React.useLayoutEffect(() => {
       if (tabIndex === 0 && element) {
         element!.tabIndex = -1;
@@ -78,7 +74,6 @@ const GridCellCheckboxForwardRef = React.forwardRef<HTMLInputElement, GridCellPa
         tabIndex={tabIndex}
         checked={!!value}
         onChange={handleChange}
-        onClick={handleClick}
         className={classes.root}
         color="primary"
         inputProps={{ 'aria-label': 'Select Row checkbox' }}

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -338,7 +338,7 @@ export const useGridSelection = (
         gridClasses.cell,
       );
       const field = cellClicked?.getAttribute('data-field');
-      if (field === '__check__') {
+      if (field === GRID_CHECKBOX_SELECTION_COL_DEF.field) {
         // click on checkbox should not trigger row selection
         return;
       }

--- a/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
+++ b/packages/grid/_modules_/grid/hooks/features/selection/useGridSelection.ts
@@ -338,6 +338,10 @@ export const useGridSelection = (
         gridClasses.cell,
       );
       const field = cellClicked?.getAttribute('data-field');
+      if (field === '__check__') {
+        // click on checkbox should not trigger row selection
+        return;
+      }
       if (field) {
         const column = apiRef.current.getColumn(field);
         if (column.type === 'actions') {

--- a/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
@@ -73,7 +73,7 @@ describe('<DataGridPro /> - Selection', () => {
           rowsPerPageOptions={[2]}
         />,
       );
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 0).querySelector('input'));
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       const selectAllCheckbox = screen.getByRole('checkbox', {
@@ -118,8 +118,8 @@ describe('<DataGridPro /> - Selection', () => {
         name: /select all rows checkbox/i,
       });
 
-      fireEvent.click(getCell(0, 0));
-      fireEvent.click(getCell(1, 0));
+      fireEvent.click(getCell(0, 0).querySelector('input'));
+      fireEvent.click(getCell(1, 0).querySelector('input'));
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       expect(selectAllCheckbox).to.have.attr('data-indeterminate', 'true');
     });
@@ -148,7 +148,7 @@ describe('<DataGridPro /> - Selection', () => {
           rowsPerPageOptions={[2]}
         />,
       );
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 0).querySelector('input'));
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
       const selectAllCheckbox = screen.getByRole('checkbox', {
@@ -169,10 +169,10 @@ describe('<DataGridPro /> - Selection', () => {
           rowsPerPageOptions={[2]}
         />,
       );
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 0).querySelector('input'));
       expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
       fireEvent.click(screen.getByRole('button', { name: /next page/i }));
-      fireEvent.click(getCell(2, 0));
+      fireEvent.click(getCell(2, 0).querySelector('input'));
       expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2]);
       const selectAllCheckbox = screen.getByRole('checkbox', {
         name: /select all rows checkbox/i,

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -198,7 +198,7 @@ describe('<DataGrid /> - Selection', () => {
       expect(getRow(0).querySelector('input')).to.have.property('checked', false);
     });
 
-    it('should set focus ont the cell when clicking the checkbox', () => {
+    it('should set focus on the cell when clicking the checkbox', () => {
       render(<TestDataGridSelection checkboxSelection />);
       expect(getActiveCell()).to.equal(null);
 

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -183,6 +183,19 @@ describe('<DataGrid /> - Selection', () => {
       expect(getRow(0).querySelector('input')).to.have.property('checked', false);
     });
 
+    it('should set focus ont the cell when clicking the checkbox', () => {
+      render(<TestDataGridSelection checkboxSelection />);
+      expect(getActiveCell()).to.equal(null);
+
+      // simulate click
+      const checkboxInput = getCell(0, 0).querySelector('input');
+
+      fireEvent.mouseUp(checkboxInput);
+      fireEvent.click(checkboxInput);
+
+      expect(getActiveCell()).to.equal('0-0');
+    });
+
     it('should select all visible rows regardless of pagination', () => {
       render(<TestDataGridSelection checkboxSelection pageSize={1} rowsPerPageOptions={[1]} />);
       const selectAllCheckbox = document.querySelector('input[type="checkbox"]');

--- a/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/selection.DataGrid.test.tsx
@@ -8,6 +8,7 @@ import {
   getRows,
   getColumnHeaderCell,
   getColumnHeadersTextContent,
+  getActiveCell,
 } from 'test/utils/helperFn';
 import { getData } from 'storybook/src/data/data-service';
 import { spy } from 'sinon';
@@ -174,11 +175,25 @@ describe('<DataGrid /> - Selection', () => {
       expect(getSelectedRowIds()).to.deep.equal([]);
       expect(getRow(0).querySelector('input')).to.have.property('checked', false);
 
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 1));
       expect(getSelectedRowIds()).to.deep.equal([0]);
       expect(getRow(0).querySelector('input')).to.have.property('checked', true);
 
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 1));
+      expect(getSelectedRowIds()).to.deep.equal([]);
+      expect(getRow(0).querySelector('input')).to.have.property('checked', false);
+    });
+
+    it('should check and uncheck when double clicking the checkbox', () => {
+      render(<TestDataGridSelection checkboxSelection />);
+      expect(getSelectedRowIds()).to.deep.equal([]);
+      expect(getRow(0).querySelector('input')).to.have.property('checked', false);
+
+      fireEvent.click(getCell(0, 0).querySelector('input'));
+      expect(getSelectedRowIds()).to.deep.equal([0]);
+      expect(getRow(0).querySelector('input')).to.have.property('checked', true);
+
+      fireEvent.click(getCell(0, 0).querySelector('input'));
       expect(getSelectedRowIds()).to.deep.equal([]);
       expect(getRow(0).querySelector('input')).to.have.property('checked', false);
     });
@@ -239,11 +254,11 @@ describe('<DataGrid /> - Selection', () => {
 
     it('should unselect from last clicked cell to cell after clicked cell if clicking inside a selected range', () => {
       render(<TestDataGridSelection checkboxSelection />);
-      fireEvent.click(getCell(0, 0));
+      fireEvent.click(getCell(0, 0).querySelector('input'));
       expect(getSelectedRowIds()).to.deep.equal([0]);
-      fireEvent.click(getCell(3, 0), { shiftKey: true });
+      fireEvent.click(getCell(3, 0).querySelector('input'), { shiftKey: true });
       expect(getSelectedRowIds()).to.deep.equal([0, 1, 2, 3]);
-      fireEvent.click(getCell(1, 0), { shiftKey: true });
+      fireEvent.click(getCell(1, 0).querySelector('input'), { shiftKey: true });
       expect(getSelectedRowIds()).to.deep.equal([0, 1]);
     });
   });
@@ -532,7 +547,7 @@ describe('<DataGrid /> - Selection', () => {
 
       render(<ControlCase />);
       expect(getSelectedRowIds()).to.deep.equal([]);
-      fireEvent.click(getCell(1, 0));
+      fireEvent.click(getCell(1, 1));
       expect(getSelectedRowIds()).to.deep.equal([1, 2]);
     });
   });


### PR DESCRIPTION
Fix #3382

The stop propagation prevents having the selection event dispatched two times when clicking on the checkbox. One time by checkbox change, and the other one by row click event.

The problem is that it also prevents setting the focus on the cell. So now, interacting with the checkbox set the focus on its cell.

I did not add tests to detect the reported bug, because jsdom does not mock correctly, scrolling.