### PR TITLE
[DataGridPro] Expose the field of the tree data grouping column as a constant

### DIFF
--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -61,6 +61,22 @@ Use the `groupingColDef` prop to customize the rendering of the grouping column.
 
 {{"demo": "pages/components/data-grid/group-pivot/CustomGroupingColumnTreeData.js", "bg": "inline", "defaultCodeOpen": false}}
 
+#### Accessing the grouping column field
+
+If you want to access the grouping column field, for instance to pin it, you can use the `GRID_TREE_DATA_GROUPING_FIELD` constant.
+
+```tsx
+<DataGrid
+  treeData
+  initialState={{
+    pinnedColumns: {
+      left: [GRID_TREE_DATA_GROUPING_FIELD],
+    },
+  }}
+  {...otherProps}
+/>
+```
+
 ### Group expansion
 
 Use the `defaultGroupingExpansionDepth` prop to expand all the groups up to a given depth when loading the data.

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -66,7 +66,7 @@ Use the `groupingColDef` prop to customize the rendering of the grouping column.
 If you want to access the grouping column field, for instance to pin it, you can use the `GRID_TREE_DATA_GROUPING_FIELD` constant.
 
 ```tsx
-<DataGrid
+<DataGridPro
   treeData
   initialState={{
     pinnedColumns: {

--- a/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
+++ b/docs/src/pages/components/data-grid/group-pivot/group-pivot.md
@@ -63,7 +63,7 @@ Use the `groupingColDef` prop to customize the rendering of the grouping column.
 
 #### Accessing the grouping column field
 
-If you want to access the grouping column field, for instance to pin it, you can use the `GRID_TREE_DATA_GROUPING_FIELD` constant.
+If you want to access the grouping column field, for instance, to use it with column pinning, the `GRID_TREE_DATA_GROUPING_FIELD` constant is available.
 
 ```tsx
 <DataGridPro

--- a/packages/grid/_modules_/grid/hooks/features/index.ts
+++ b/packages/grid/_modules_/grid/hooks/features/index.ts
@@ -13,3 +13,4 @@ export * from './rows';
 export * from './selection';
 export * from './sorting';
 export * from './dimensions';
+export * from './treeData';

--- a/packages/grid/_modules_/grid/hooks/features/treeData/gridTreeDataGroupColDef.ts
+++ b/packages/grid/_modules_/grid/hooks/features/treeData/gridTreeDataGroupColDef.ts
@@ -5,7 +5,7 @@ import { GridValueGetterFullParams } from '../../../models';
 /**
  * TODO: Add sorting and filtering on the value and the filteredDescendantCount
  */
-export const GRID_TREE_DATA_GROUP_COL_DEF: Omit<GridColDef, 'field' | 'editable'> = {
+export const GRID_TREE_DATA_GROUPING_COL_DEF: Omit<GridColDef, 'field' | 'editable'> = {
   ...GRID_STRING_COL_DEF,
   type: 'treeDataGroup',
   sortable: false,
@@ -17,10 +17,12 @@ export const GRID_TREE_DATA_GROUP_COL_DEF: Omit<GridColDef, 'field' | 'editable'
   valueGetter: (params) => (params as GridValueGetterFullParams).rowNode.groupingKey,
 };
 
-export const GRID_TREE_DATA_GROUP_COL_DEF_FORCED_PROPERTIES: Pick<
+export const GRID_TREE_DATA_GROUPING_FIELD = '__tree_data_group__';
+
+export const GRID_TREE_DATA_GROUPING_COL_DEF_FORCED_PROPERTIES: Pick<
   GridColDef,
   'field' | 'editable'
 > = {
-  field: '__tree_data_group__',
+  field: GRID_TREE_DATA_GROUPING_FIELD,
   editable: false,
 };

--- a/packages/grid/_modules_/grid/hooks/features/treeData/index.ts
+++ b/packages/grid/_modules_/grid/hooks/features/treeData/index.ts
@@ -1,0 +1,1 @@
+export { GRID_TREE_DATA_GROUPING_FIELD } from './gridTreeDataGroupColDef';

--- a/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/treeData/useGridTreeData.tsx
@@ -2,8 +2,8 @@ import * as React from 'react';
 import { GridApiRef } from '../../../models/api/gridApiRef';
 import { GridComponentProps } from '../../../GridComponentProps';
 import {
-  GRID_TREE_DATA_GROUP_COL_DEF,
-  GRID_TREE_DATA_GROUP_COL_DEF_FORCED_PROPERTIES,
+  GRID_TREE_DATA_GROUPING_COL_DEF,
+  GRID_TREE_DATA_GROUPING_COL_DEF_FORCED_PROPERTIES,
 } from './gridTreeDataGroupColDef';
 import { useGridApiEventHandler } from '../../utils/useGridApiEventHandler';
 import { GridEventListener, GridEvents } from '../../../models/events';
@@ -123,7 +123,7 @@ export const useGridTreeData = (
     const { hideDescendantCount, ...colDefOverrideProperties } = colDefOverride ?? {};
 
     const commonProperties: Omit<GridColDef, 'field' | 'editable'> = {
-      ...GRID_TREE_DATA_GROUP_COL_DEF,
+      ...GRID_TREE_DATA_GROUPING_COL_DEF,
       renderCell: (params) => (
         <GridTreeDataGroupingCell {...params} hideDescendantCount={hideDescendantCount} />
       ),
@@ -133,13 +133,13 @@ export const useGridTreeData = (
     return {
       ...commonProperties,
       ...colDefOverrideProperties,
-      ...GRID_TREE_DATA_GROUP_COL_DEF_FORCED_PROPERTIES,
+      ...GRID_TREE_DATA_GROUPING_COL_DEF_FORCED_PROPERTIES,
     };
   }, [apiRef, props.groupingColDef]);
 
   const updateGroupingColumn = React.useCallback(
     (columnsState: GridColumnsRawState) => {
-      const groupingColDefField = GRID_TREE_DATA_GROUP_COL_DEF_FORCED_PROPERTIES.field;
+      const groupingColDefField = GRID_TREE_DATA_GROUPING_COL_DEF_FORCED_PROPERTIES.field;
 
       const shouldHaveGroupingColumn = props.treeData;
       const haveGroupingColumn = columnsState.lookup[groupingColDefField] != null;

--- a/scripts/x-data-grid-pro.exports.json
+++ b/scripts/x-data-grid-pro.exports.json
@@ -41,6 +41,7 @@
   { "name": "GRID_NUMERIC_COL_DEF", "kind": "Variable" },
   { "name": "GRID_SINGLE_SELECT_COL_DEF", "kind": "Variable" },
   { "name": "GRID_STRING_COL_DEF", "kind": "Variable" },
+  { "name": "GRID_TREE_DATA_GROUPING_FIELD", "kind": "ExportSpecifier" },
   { "name": "GridActionsCell", "kind": "ExportSpecifier" },
   { "name": "GridActionsCellItem", "kind": "ExportSpecifier" },
   { "name": "GridActionsCellItemProps", "kind": "TypeAlias" },

--- a/scripts/x-data-grid.exports.json
+++ b/scripts/x-data-grid.exports.json
@@ -41,6 +41,7 @@
   { "name": "GRID_NUMERIC_COL_DEF", "kind": "Variable" },
   { "name": "GRID_SINGLE_SELECT_COL_DEF", "kind": "Variable" },
   { "name": "GRID_STRING_COL_DEF", "kind": "Variable" },
+  { "name": "GRID_TREE_DATA_GROUPING_FIELD", "kind": "ExportSpecifier" },
   { "name": "GridActionsCell", "kind": "ExportSpecifier" },
   { "name": "GridActionsCellItem", "kind": "ExportSpecifier" },
   { "name": "GridActionsCellItemProps", "kind": "TypeAlias" },


### PR DESCRIPTION
Fixes #3434

I renamed the column internal variables with `GROUPING` instead of `GROUP` to follow the convention of #212.