### PR TITLE
[DataGrid] Indeterminate checkbox behavior

### DIFF
--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -83,7 +83,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridHeaderSelectionCheckboxParams = {
-        value: event.target.dataset.indeterminate === 'true' || event.target.checked,
+        value: isIndeterminate || event.target.checked,
       };
 
       apiRef.current.publishEvent(GridEvents.headerSelectionCheckboxChange, params);

--- a/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
+++ b/packages/grid/_modules_/grid/components/columnSelection/GridHeaderCheckbox.tsx
@@ -83,7 +83,7 @@ const GridHeaderCheckbox = React.forwardRef<HTMLInputElement, GridColumnHeaderPa
 
     const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
       const params: GridHeaderSelectionCheckboxParams = {
-        value: event.target.checked,
+        value: event.target.dataset.indeterminate === 'true' || event.target.checked,
       };
 
       apiRef.current.publishEvent(GridEvents.headerSelectionCheckboxChange, params);

--- a/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/selection.DataGridPro.test.tsx
@@ -64,7 +64,7 @@ describe('<DataGridPro /> - Selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should unselect all rows of all the pages if 1 row of another page is selected', () => {
+    it('should select all rows of all the pages if 1 row of another page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
@@ -80,8 +80,8 @@ describe('<DataGridPro /> - Selection', () => {
         name: /select all rows checkbox/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.length(0);
-      expect(selectAllCheckbox.checked).to.equal(false);
+      expect(apiRef.current.getSelectedRows()).to.have.length(4);
+      expect(selectAllCheckbox.checked).to.equal(true);
     });
 
     it('should select all visible rows if pagination is not enabled', () => {
@@ -159,7 +159,7 @@ describe('<DataGridPro /> - Selection', () => {
       expect(selectAllCheckbox.checked).to.equal(true);
     });
 
-    it('should unselect all the rows of the current page if 1 row of the current page is selected', () => {
+    it('should select all the rows of the current page if 1 row of the current page is selected', () => {
       render(
         <TestDataGridSelection
           checkboxSelection
@@ -178,8 +178,8 @@ describe('<DataGridPro /> - Selection', () => {
         name: /select all rows checkbox/i,
       });
       fireEvent.click(selectAllCheckbox);
-      expect(apiRef.current.getSelectedRows()).to.have.keys([0]);
-      expect(selectAllCheckbox.checked).to.equal(false);
+      expect(apiRef.current.getSelectedRows()).to.have.keys([0, 2, 3]);
+      expect(selectAllCheckbox.checked).to.equal(true);
     });
 
     it('should not set the header checkbox in a indeterminate state when some rows of other pages are not selected', () => {


### PR DESCRIPTION
Fix for #3309 

Changes the default behavior of an indeterminate checkbox click from _uncheck_ all to _check_ all.