### PR TITLE
[docs] Make inputs to extend full height of the cell

### DIFF
--- a/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.js
+++ b/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.js
@@ -10,6 +10,9 @@ const StyledBox = styled(Box)(({ theme }) => ({
   '& .MuiDataGrid-cell--editing': {
     backgroundColor: 'rgb(255,215,115, 0.19)',
     color: '#1a3e72',
+    '& .MuiInputBase-root': {
+      height: '100%',
+    },
   },
   '& .Mui-error': {
     backgroundColor: `rgb(126,10,15, ${theme.palette.mode === 'dark' ? 0 : 0.1})`,

--- a/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/ConditionalValidationGrid.tsx
@@ -15,6 +15,9 @@ const StyledBox = styled(Box)(({ theme }) => ({
   '& .MuiDataGrid-cell--editing': {
     backgroundColor: 'rgb(255,215,115, 0.19)',
     color: '#1a3e72',
+    '& .MuiInputBase-root': {
+      height: '100%',
+    },
   },
   '& .Mui-error': {
     backgroundColor: `rgb(126,10,15, ${theme.palette.mode === 'dark' ? 0 : 0.1})`,

--- a/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.js
+++ b/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.js
@@ -23,6 +23,9 @@ export default function ValidateRowModelControlGrid() {
         '& .MuiDataGrid-cell--editing': {
           bgcolor: 'rgb(255,215,115, 0.19)',
           color: '#1a3e72',
+          '& .MuiInputBase-root': {
+            height: '100%',
+          },
         },
         '& .Mui-error': {
           bgcolor: (theme) =>

--- a/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/ValidateRowModelControlGrid.tsx
@@ -23,6 +23,9 @@ export default function ValidateRowModelControlGrid() {
         '& .MuiDataGrid-cell--editing': {
           bgcolor: 'rgb(255,215,115, 0.19)',
           color: '#1a3e72',
+          '& .MuiInputBase-root': {
+            height: '100%',
+          },
         },
         '& .Mui-error': {
           bgcolor: (theme) =>

--- a/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.js
+++ b/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.js
@@ -8,6 +8,9 @@ const StyledBox = styled(Box)(({ theme }) => ({
   width: '100%',
   '& .MuiDataGrid-cell--editable': {
     backgroundColor: theme.palette.mode === 'dark' ? '#376331' : 'rgb(217 243 190)',
+    '& .MuiInputBase-root': {
+      height: '100%',
+    },
   },
   '& .Mui-error': {
     backgroundColor: `rgb(126,10,15, ${theme.palette.mode === 'dark' ? 0 : 0.1})`,

--- a/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx
+++ b/docs/src/pages/components/data-grid/editing/ValidateServerNameGrid.tsx
@@ -15,6 +15,9 @@ const StyledBox = styled(Box)(({ theme }) => ({
   width: '100%',
   '& .MuiDataGrid-cell--editable': {
     backgroundColor: theme.palette.mode === 'dark' ? '#376331' : 'rgb(217 243 190)',
+    '& .MuiInputBase-root': {
+      height: '100%',
+    },
   },
   '& .Mui-error': {
     backgroundColor: `rgb(126,10,15, ${theme.palette.mode === 'dark' ? 0 : 0.1})`,

--- a/packages/storybook/src/stories/grid-rows.stories.tsx
+++ b/packages/storybook/src/stories/grid-rows.stories.tsx
@@ -451,6 +451,9 @@ const useEditCellStyles = makeStyles({
     '& .MuiDataGrid-cell--editing': {
       backgroundColor: 'rgb(255,215,115, 0.19)',
       color: '#1a3e72',
+      '& .MuiInputBase-root': {
+        height: '100%',
+      },
     },
     '& .Mui-error': {
       backgroundColor: 'rgb(126,10,15, 0.1)',


### PR DESCRIPTION
In #3446 we didn't update the demos.

Preview: https://deploy-preview-3567--material-ui-x.netlify.app/components/data-grid/editing/#client-side-validation

Before:

![image](https://user-images.githubusercontent.com/42154031/148630031-4a52d186-0315-4c6e-b103-bc6d9fbe66bd.png)

After:

![msedge_Es8KnKVPYW](https://user-images.githubusercontent.com/42154031/148630046-1a0d85e6-6d10-41ac-8166-8fec6bf6bf23.png)
