### PR TITLE
[DataGrid] Fix line break characters breaking CSV rows 

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/export/serializers/csvSerializer.ts
+++ b/packages/grid/_modules_/grid/hooks/features/export/serializers/csvSerializer.ts
@@ -9,7 +9,13 @@ import {
 const serialiseCellValue = (value: GridCellValue, delimiterCharacter: string) => {
   if (typeof value === 'string') {
     const formattedValue = value.replace(/"/g, '""');
-    return formattedValue.includes(delimiterCharacter) ? `"${formattedValue}"` : formattedValue;
+
+    // Make sure value containing delimiter or line break won't be splitted into multiple rows
+    if ([delimiterCharacter, '\n', '\r'].some((delimiter) => formattedValue.includes(delimiter))) {
+      return `"${formattedValue}"`;
+    }
+
+    return formattedValue;
   }
 
   return value;

--- a/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
@@ -191,7 +191,13 @@ describe('<DataGridPro /> - Export', () => {
 
       render(<TestCaseCSVExport />);
       expect(apiRef.current.getDataAsCsv()).to.equal(
-        ['id,Brand', '0,"Nike \n Nike"', '1,"Adidas \n Adidas"', '2,"Puma \r\n Puma"', '3,"Reebok \n\r Reebok"'].join('\r\n'),
+        [
+          'id,Brand',
+          '0,"Nike \n Nike"',
+          '1,"Adidas \n Adidas"',
+          '2,"Puma \r\n Puma"',
+          '3,"Reebok \n\r Reebok"',
+        ].join('\r\n'),
       );
     });
 

--- a/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/export.DataGridPro.test.tsx
@@ -157,6 +157,44 @@ describe('<DataGridPro /> - Export', () => {
       );
     });
 
+    it('should work with newline', () => {
+      const TestCaseCSVExport = () => {
+        apiRef = useGridApiRef();
+        return (
+          <div style={{ width: 300, height: 300 }}>
+            <DataGridPro
+              {...baselineProps}
+              apiRef={apiRef}
+              columns={columns}
+              rows={[
+                {
+                  id: 0,
+                  brand: `Nike \n Nike`,
+                },
+                {
+                  id: 1,
+                  brand: 'Adidas \n Adidas',
+                },
+                {
+                  id: 2,
+                  brand: 'Puma \r\n Puma',
+                },
+                {
+                  id: 3,
+                  brand: 'Reebok \n\r Reebok',
+                },
+              ]}
+            />
+          </div>
+        );
+      };
+
+      render(<TestCaseCSVExport />);
+      expect(apiRef.current.getDataAsCsv()).to.equal(
+        ['id,Brand', '0,"Nike \n Nike"', '1,"Adidas \n Adidas"', '2,"Puma \r\n Puma"', '3,"Reebok \n\r Reebok"'].join('\r\n'),
+      );
+    });
+
     it('should allow to change the delimiter', () => {
       const TestCaseCSVExport = () => {
         apiRef = useGridApiRef();


### PR DESCRIPTION
Fixes #2860

When cell value contains line break character, CSV export results in broken CSV since part of the value goes to the next line.
Wrapping value into quotes in this case fixes the issue.