### PR TITLE
[test] Properly wait for promise to resolve before expect

### DIFF
--- a/packages/grid/x-data-grid-pro/src/tests/editRows.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/editRows.DataGridPro.test.tsx
@@ -38,6 +38,8 @@ const generateDate = (
   return rawDate.getTime();
 };
 
+const nativeSetTimeout = setTimeout;
+
 // TODO: Replace `cell.focus()` with `fireEvent.mouseUp(cell)`
 describe('<DataGridPro /> - Edit Rows', () => {
   let baselineProps;
@@ -1541,13 +1543,13 @@ describe('<DataGridPro /> - Edit Rows', () => {
       fireEvent.doubleClick(cell);
       const input = cell.querySelector('input')!;
       fireEvent.change(input, { target: { value: 'Adidas' } });
-      await clock.runToLast();
+      clock.runToLast();
+      await new Promise((resolve) => nativeSetTimeout(resolve));
       expect(apiRef.current.getEditRowsModel()[0].brand.value).to.equal('Adidas');
       fireEvent.keyDown(input, { key: 'Enter' });
-      await waitFor(() => {
-        expect(cell).not.to.have.class('MuiDataGrid-cell--editing');
-        expect(cell).to.have.text('Adidas');
-      });
+      await new Promise((resolve) => nativeSetTimeout(resolve));
+      expect(cell).not.to.have.class('MuiDataGrid-cell--editing');
+      expect(cell).to.have.text('Adidas');
     });
   });
 

--- a/test/cli.js
+++ b/test/cli.js
@@ -1,0 +1,124 @@
+const childProcess = require('child_process');
+const fs = require('fs');
+const glob = require('fast-glob');
+const path = require('path');
+const yargs = require('yargs');
+
+async function run(argv) {
+  const workspaceRoot = path.resolve(__dirname, '../');
+
+  const gitignore = fs.readFileSync(path.join(workspaceRoot, '.gitignore'), { encoding: 'utf-8' });
+  const ignore = gitignore
+    .split(/\r?\n/)
+    .filter((pattern) => {
+      return pattern.length > 0 && !pattern.startsWith('#');
+    })
+    .map((line) => {
+      if (line.startsWith('/')) {
+        // "/" marks the cwd of the ignore file.
+        // Since we declare the dirname of the gitignore the cwd we can prepend "." as a shortcut.
+        return `.${line}`;
+      }
+      return line;
+    });
+  const globPattern = `**/*${argv.testFilePattern.replace(/\\/g, '/')}*`;
+  const spec = glob
+    .sync(globPattern, {
+      cwd: workspaceRoot,
+      ignore,
+    })
+    .filter((relativeFile) => {
+      return /\.test\.(js|ts|tsx)$/.test(relativeFile);
+    });
+
+  if (spec.length === 0) {
+    throw new Error(`Could not find any file test files matching '${globPattern}'`);
+  }
+
+  const args = ['mocha'].concat(spec);
+  if (argv.bail) {
+    args.push('--bail');
+  }
+  if (argv.debug || argv.inspecting) {
+    args.push('--timeout 0');
+  }
+  if (argv.debug) {
+    args.push('--inspect-brk');
+  }
+  if (!argv.single) {
+    args.push('--watch');
+  }
+  if (argv.testNamePattern !== undefined) {
+    args.push(`--grep '${argv.testNamePattern}'`);
+  }
+
+  const mochaProcess = childProcess.spawn('yarn', args, {
+    env: {
+      ...process.env,
+      BABEL_ENV: 'test',
+      NODE_ENV: argv.production ? 'production' : 'test',
+    },
+    shell: true,
+    stdio: ['inherit', 'inherit', 'inherit'],
+  });
+
+  mochaProcess.once('exit', (signal) => {
+    process.exit(signal !== null ? signal : undefined);
+  });
+
+  process.on('SIGINT', () => {
+    // Forward interrupt.
+    // Otherwise cli.js exits and the you get dangling console output from mocha.
+    // "dangling" meaning that you get mocha output in the new terminal input.
+    mochaProcess.kill('SIGINT');
+  });
+}
+
+yargs
+  .command({
+    command: '$0 <testFilePattern>',
+    description: 'Test cli for developing',
+    builder: (command) => {
+      return command
+        .positional('testFilePattern', {
+          description: 'Only test files match "**/*{testFilePattern}*.test.{js,ts,tsx}"',
+          type: 'string',
+        })
+        .option('bail', {
+          alias: 'b',
+          description: 'Stop on first error.',
+          type: 'boolean',
+        })
+        .option('debug', {
+          alias: 'd',
+          description:
+            'Allows attaching a debugger and waits for the debugger to start code execution.',
+          type: 'boolean',
+        })
+        .option('inspecting', {
+          description: 'In case you expect to hit breakpoints that may interrupt a test.',
+          type: 'boolean',
+        })
+        .option('production', {
+          alias: 'p',
+          description:
+            'Run tests in production environment. WARNING: Will not work with most tests.',
+          type: 'boolean',
+        })
+        .option('single', {
+          alias: 's',
+          description: 'Run only once i.e. not in watch mode.',
+          type: 'boolean',
+        })
+        .option('testNamePattern', {
+          alias: 't',
+          description: 'Limit tests by their name given a pattern.',
+          type: 'string',
+        });
+    },
+    handler: run,
+  })
+  .help()
+  .strict(true)
+  .version(false)
+  .parse();


### PR DESCRIPTION
Fixes one test not running in Safari: https://app.circleci.com/pipelines/github/mui-org/material-ui-x/11257/workflows/486e64b7-1fa4-44dc-8afa-e891edf3d561/jobs/65177

The solution is a workaround I proposed in https://github.com/mui-org/material-ui-x/pull/3372#discussion_r766064601. Basically, the unit tests run with a fake clock, which causes `waitFor` to also run with the fake clock. Here I call the native `setTimeout` to make sure that the promise was resolved. With #3558 I think we'll be able to use the fake clock on a per-test case basis, not in the entire suite.

I also took the opportunity to copy `test/cli.js` from the core repo. This allows to debug each unit test using VSCode.