### PR TITLE
[DataGridPro] Keep row children expansion when updating the rows

### DIFF
--- a/packages/grid/_modules_/grid/hooks/core/rowGroupsPerProcessing/gridRowGroupsPreProcessingApi.ts
+++ b/packages/grid/_modules_/grid/hooks/core/rowGroupsPerProcessing/gridRowGroupsPreProcessingApi.ts
@@ -3,6 +3,7 @@ import { GridRowTreeConfig, GridRowId, GridRowsLookup } from '../../../models/gr
 export interface GridRowGroupParams {
   ids: GridRowId[];
   idRowsLookup: GridRowsLookup;
+  previousTree: GridRowTreeConfig | null;
 }
 
 export interface GridRowGroupingResult {

--- a/packages/grid/_modules_/grid/utils/tree/buildRowTree.test.ts
+++ b/packages/grid/_modules_/grid/utils/tree/buildRowTree.test.ts
@@ -18,6 +18,7 @@ describe('buildRowTree', () => {
         { id: 2, path: [{ key: 'C', field: null }] },
       ],
       defaultGroupingExpansionDepth: 0,
+      previousTree: null,
     });
 
     expect(
@@ -26,9 +27,9 @@ describe('buildRowTree', () => {
         childrenExpanded: node.childrenExpanded,
       })),
     ).to.deep.equal([
-      { id: 0, childrenExpanded: false },
-      { id: 1, childrenExpanded: false },
-      { id: 2, childrenExpanded: false },
+      { id: 0, childrenExpanded: undefined },
+      { id: 1, childrenExpanded: undefined },
+      { id: 2, childrenExpanded: undefined },
     ]);
   });
 
@@ -60,6 +61,7 @@ describe('buildRowTree', () => {
         },
       ],
       defaultGroupingExpansionDepth: 2,
+      previousTree: null,
     });
 
     expect(
@@ -70,7 +72,7 @@ describe('buildRowTree', () => {
     ).to.deep.equal([
       { id: 0, childrenExpanded: true },
       { id: 1, childrenExpanded: true },
-      { id: 2, childrenExpanded: false },
+      { id: 2, childrenExpanded: undefined },
     ]);
   });
 
@@ -102,6 +104,7 @@ describe('buildRowTree', () => {
         },
       ],
       defaultGroupingExpansionDepth: -1,
+      previousTree: null,
     });
 
     expect(
@@ -112,7 +115,7 @@ describe('buildRowTree', () => {
     ).to.deep.equal([
       { id: 0, childrenExpanded: true },
       { id: 1, childrenExpanded: true },
-      { id: 2, childrenExpanded: false },
+      { id: 2, childrenExpanded: undefined },
     ]);
   });
 
@@ -153,6 +156,7 @@ describe('buildRowTree', () => {
         },
       ],
       defaultGroupingExpansionDepth: 0,
+      previousTree: null,
     });
 
     expect(
@@ -206,6 +210,7 @@ describe('buildRowTree', () => {
         },
       ],
       defaultGroupingExpansionDepth: 0,
+      previousTree: null,
     });
 
     expect(response.treeDepth).to.equal(3);
@@ -231,6 +236,7 @@ describe('buildRowTree', () => {
         },
       ],
       defaultGroupingExpansionDepth: 0,
+      previousTree: null,
     });
 
     expect(response).to.deep.equal({
@@ -266,7 +272,7 @@ describe('buildRowTree', () => {
         1: {
           children: undefined,
           depth: 2,
-          childrenExpanded: false,
+          childrenExpanded: undefined,
           groupingField: null,
           groupingKey: 'A',
           id: 1,

--- a/packages/grid/_modules_/grid/utils/tree/buildRowTree.ts
+++ b/packages/grid/_modules_/grid/utils/tree/buildRowTree.ts
@@ -71,6 +71,11 @@ export const buildRowTree = (params: BuildRowTreeParams): GridRowGroupingResult 
   const groupingCriteriaToIdTree: GridGroupingCriteriaToIdTree = {};
 
   const isGroupExpandedByDefault = (node: GridRowTreeNodeConfig) => {
+    const previousExpansion = params.previousTree?.[node.id]?.childrenExpanded;
+    if (previousExpansion != null) {
+      return previousExpansion;
+    }
+
     if (!node.children || !node.children.length) {
       return false;
     }

--- a/packages/grid/_modules_/grid/utils/tree/buildRowTree.ts
+++ b/packages/grid/_modules_/grid/utils/tree/buildRowTree.ts
@@ -77,7 +77,7 @@ export const buildRowTree = (params: BuildRowTreeParams): GridRowGroupingResult 
     }
 
     if (!node.children || !node.children.length) {
-      return false;
+      return undefined;
     }
 
     if (params.isGroupExpandedByDefault) {

--- a/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/treeData.DataGridPro.test.tsx
@@ -158,6 +158,17 @@ describe('<DataGridPro /> - Tree Data', () => {
       expect(getColumnHeadersTextContent()).to.deep.equal(['Group', 'nameBis']);
       expect(getColumnValues(1)).to.deep.equal(['1', '2']);
     });
+
+    it('should keep children expansion when changing some of the rows', () => {
+      const { setProps } = render(<Test rows={[{ name: 'A' }, { name: 'A.A' }]} />);
+      expect(getColumnValues(1)).to.deep.equal(['A']);
+      apiRef.current.setRowChildrenExpansion('A', true);
+      expect(getColumnValues(1)).to.deep.equal(['A', 'A.A']);
+      setProps({
+        rows: [{ name: 'A' }, { name: 'A.A' }, { name: 'B' }, { name: 'B.A' }],
+      });
+      expect(getColumnValues(1)).to.deep.equal(['A', 'A.A', 'B']);
+    });
   });
 
   describe('prop: getTreeDataPath', () => {


### PR DESCRIPTION
Part of #3377 

With this enhancement, we should be able to add a working demo with row children lazy loading implemented by users.