### PR TITLE
[core] Renovate should not try to update node

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -69,8 +69,13 @@
       "matchPackagePatterns": "@storybook/*"
     },
     {
-      "groupName": "ag-grid",
+      "groupName": "AG Grid",
       "matchPackagePatterns": "ag-grid-*"
+    },
+    {
+      "groupName": "node",
+      "matchPackageNames": ["node"],
+      "enabled": false
     },
     {
       "groupName": "MUI Core",


### PR DESCRIPTION
I'm doing https://github.com/mui-org/material-ui-x/pull/3362#issuecomment-986722279. This is done manually, for each major. I have left a note in https://github.com/mui-org/material-ui-x/issues/3287 for MUI X v6. The solution is based on https://github.com/renovatebot/config-help/issues/81

So far, we have [closed 11 times PRs](https://github.com/mui-org/material-ui-x/pulls?q=is%3Apr+%22Bump+Node.js+to%22+is%3Aclosed) that try to upgrade Node manually, this is no good, a distraction and a risk to break the next release.

Closes #3643 
Closes #3638


