### PR TITLE
[core] Don't bump peer dependency ranges on dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "matchDepTypes": ["peerDependencies"],
+      "rangeStrategy": "widen"
+    },
+    {
       "groupName": "babel",
       "matchPackagePatterns": "@babel/*"
     },


### PR DESCRIPTION
Same fix as https://github.com/mui-org/material-ui/pull/29303 to avoid these kinds of regressions: https://github.com/mui-org/material-ui-x/pull/3630#pullrequestreview-853778223