### PR TITLE
[DataGridPro] Fix grid cell losing focus when scrolling with keyboard

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualScroller.tsx
+++ b/packages/grid/_modules_/grid/hooks/features/virtualization/useGridVirtualScroller.tsx
@@ -157,31 +157,43 @@ export const useGridVirtualScroller = (props: UseGridVirtualScrollerProps) => {
     ];
   };
 
-  const updateRenderZonePosition = (nextRenderContext: GridRenderContext) => {
-    const [firstRowToRender] = getRenderableIndexes({
-      firstIndex: nextRenderContext.firstRowIndex,
-      lastIndex: nextRenderContext.lastRowIndex,
-      minFirstIndex: 0,
-      maxLastIndex: currentPage.range?.lastRowIndex,
-      buffer: rootProps.rowBuffer,
-    });
+  const updateRenderZonePosition = React.useCallback(
+    (nextRenderContext: GridRenderContext) => {
+      const [firstRowToRender] = getRenderableIndexes({
+        firstIndex: nextRenderContext.firstRowIndex,
+        lastIndex: nextRenderContext.lastRowIndex,
+        minFirstIndex: 0,
+        maxLastIndex: currentPage.range?.lastRowIndex,
+        buffer: rootProps.rowBuffer,
+      });
 
-    const [firstColumnToRender] = getRenderableIndexes({
-      firstIndex: nextRenderContext.firstColumnIndex,
-      lastIndex: nextRenderContext.lastColumnIndex,
-      minFirstIndex: renderZoneMinColumnIndex,
-      maxLastIndex: renderZoneMaxColumnIndex,
-      buffer: rootProps.columnBuffer,
-    });
+      const [firstColumnToRender] = getRenderableIndexes({
+        firstIndex: nextRenderContext.firstColumnIndex,
+        lastIndex: nextRenderContext.lastColumnIndex,
+        minFirstIndex: renderZoneMinColumnIndex,
+        maxLastIndex: renderZoneMaxColumnIndex,
+        buffer: rootProps.columnBuffer,
+      });
 
-    const top = firstRowToRender * rowHeight;
-    const left = gridColumnsMetaSelector(apiRef.current.state).positions[firstColumnToRender]; // Call directly the selector because it might be outdated when this method is called
-    renderZoneRef.current!.style.transform = `translate3d(${left}px, ${top}px, 0px)`;
+      const top = firstRowToRender * rowHeight;
+      const left = gridColumnsMetaSelector(apiRef.current.state).positions[firstColumnToRender]; // Call directly the selector because it might be outdated when this method is called
+      renderZoneRef.current!.style.transform = `translate3d(${left}px, ${top}px, 0px)`;
 
-    if (typeof onRenderZonePositioning === 'function') {
-      onRenderZonePositioning({ top, left });
-    }
-  };
+      if (typeof onRenderZonePositioning === 'function') {
+        onRenderZonePositioning({ top, left });
+      }
+    },
+    [
+      apiRef,
+      currentPage.range?.lastRowIndex,
+      onRenderZonePositioning,
+      renderZoneMaxColumnIndex,
+      renderZoneMinColumnIndex,
+      rootProps.columnBuffer,
+      rootProps.rowBuffer,
+      rowHeight,
+    ],
+  );
 
   const handleScroll = (event: React.UIEvent) => {
     const { scrollTop, scrollLeft } = event.currentTarget;

--- a/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
+++ b/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx
@@ -119,14 +119,14 @@ const DataGridProVirtualScroller = React.forwardRef<
   const rightColumns = React.useRef<HTMLDivElement>(null);
   const [shouldExtendContent, setShouldExtendContent] = React.useState(false);
 
-  const handleRenderZonePositioning = ({ top }) => {
+  const handleRenderZonePositioning = React.useCallback(({ top }) => {
     if (leftColumns.current) {
       leftColumns.current!.style.transform = `translate3d(0px, ${top}px, 0px)`;
     }
     if (rightColumns.current) {
       rightColumns.current!.style.transform = `translate3d(0px, ${top}px, 0px)`;
     }
-  };
+  }, []);
 
   const pinnedColumns = useGridSelector(apiRef, gridPinnedColumnsSelector);
   const [leftPinnedColumns, rightPinnedColumns] = filterColumns(pinnedColumns, visibleColumnFields);

--- a/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -116,7 +116,7 @@ describe('<DataGridPro /> - Column pinning', () => {
     fireEvent.mouseDown(separator, { clientX: 100 });
     fireEvent.mouseMove(separator, { clientX: 110, buttons: 1 });
     fireEvent.mouseUp(separator);
-    clock.tick(0);
+    clock.runToLast();
     // @ts-expect-error need to migrate helpers to TypeScript
     expect(renderZone).toHaveInlineStyle({ transform: 'translate3d(110px, 0px, 0px)' });
   });

--- a/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
+++ b/packages/grid/x-data-grid-pro/src/tests/columnPinning.DataGridPro.test.tsx
@@ -116,6 +116,7 @@ describe('<DataGridPro /> - Column pinning', () => {
     fireEvent.mouseDown(separator, { clientX: 100 });
     fireEvent.mouseMove(separator, { clientX: 110, buttons: 1 });
     fireEvent.mouseUp(separator);
+    clock.tick(0);
     // @ts-expect-error need to migrate helpers to TypeScript
     expect(renderZone).toHaveInlineStyle({ transform: 'translate3d(110px, 0px, 0px)' });
   });

--- a/test/e2e/fixtures/DataGridPro/KeyboardNavigationFocus.tsx
+++ b/test/e2e/fixtures/DataGridPro/KeyboardNavigationFocus.tsx
@@ -6,7 +6,7 @@ const baselineProps = {
   columns: [{ field: 'id' }, { field: 'name' }],
 };
 
-export default function ProKeyboardNavigationFocus() {
+export default function KeyboardNavigationFocus() {
   return (
     <React.Fragment>
       <button type="button" autoFocus data-testid="initial-focus">

--- a/test/e2e/fixtures/DataGridPro/KeyboardNavigationFocus.tsx
+++ b/test/e2e/fixtures/DataGridPro/KeyboardNavigationFocus.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import { DataGridPro } from '@mui/x-data-grid-pro';
+
+const baselineProps = {
+  rows: Array.from({ length: 100 }).map((a, index) => ({ id: index, name: index })),
+  columns: [{ field: 'id' }, { field: 'name' }],
+};
+
+export default function ProKeyboardNavigationFocus() {
+  return (
+    <React.Fragment>
+      <button type="button" autoFocus data-testid="initial-focus">
+        initial focus
+      </button>
+      <div style={{ width: 300, height: 200 }}>
+        <DataGridPro {...baselineProps} rowBuffer={1} rowThreshold={1} />
+      </div>
+    </React.Fragment>
+  );
+}

--- a/test/e2e/index.test.ts
+++ b/test/e2e/index.test.ts
@@ -301,5 +301,29 @@ describe('e2e', () => {
         ),
       ).to.equal('1/31/2025, 4:05:00 PM');
     });
+
+    // https://github.com/mui-org/material-ui-x/issues/3613
+    it('should not lose cell focus when scrolling with arrow down', async () => {
+      await renderFixture('DataGridPro/KeyboardNavigationFocus');
+
+      async function keyDown() {
+        await page.keyboard.down('ArrowDown');
+        // wait between keydown events for virtualization
+        await sleep(100);
+      }
+
+      await page.keyboard.down('Tab');
+
+      await keyDown(); // 0
+      await keyDown(); // 1
+      await keyDown(); // 2
+      await keyDown(); // 3
+
+      expect(await page.evaluate(() => document.activeElement?.getAttribute('role'))).to.equal(
+        'cell',
+        'Expected cell to be focused',
+      );
+      expect(await page.evaluate(() => document.activeElement?.textContent)).to.equal('3');
+    });
   });
 });


### PR DESCRIPTION
Fixes #3613
Preview: https://deploy-preview-3667--material-ui-x.netlify.app/components/data-grid/demo/

# Summary

The issue exists only in `DataGridPro`.
It turned out that the root cause of the issue was this place:

https://github.com/mui-org/material-ui-x/blob/b9afc07f87e5cdb7b585dfc08f2b570ed53caed8/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx#L161-L163

It caused duplicated render zone refresh with wrong scrollTop.
I've traced it's dependencies and saw this:

https://github.com/mui-org/material-ui-x/blob/b9afc07f87e5cdb7b585dfc08f2b570ed53caed8/packages/grid/x-data-grid-pro/src/DataGridProVirtualScroller.tsx#L122-L129

After wrapping it with `React.useCallback` the issue was gone.


# Review suggestion

It's easier to review with 'Hide whitespace' option enabled (https://github.blog/2018-05-01-ignore-white-space-in-code-review/)
