### PR TITLE
[core] Call `useGridColumnPinning` before `useGridColumns`

### DIFF
--- a/packages/grid/x-data-grid-pro/src/useDataGridProComponent.tsx
+++ b/packages/grid/x-data-grid-pro/src/useDataGridProComponent.tsx
@@ -35,6 +35,7 @@ export const useDataGridProComponent = (apiRef: GridApiRef, props: DataGridProPr
   useGridInitialization(apiRef, props);
   useGridTreeData(apiRef, props);
   useGridRowGrouping(apiRef, props);
+  useGridColumnPinning(apiRef, props);
   useGridSelection(apiRef, props);
   useGridColumns(apiRef, props);
   useGridRows(apiRef, props);
@@ -58,6 +59,5 @@ export const useDataGridProComponent = (apiRef: GridApiRef, props: DataGridProPr
   useGridPrintExport(apiRef, props);
   useGridClipboard(apiRef);
   useGridDimensions(apiRef, props);
-  useGridColumnPinning(apiRef, props);
   useGridEvents(apiRef, props);
 };


### PR DESCRIPTION
Each hook using `GridPreProcessingGroup.hydrateColumns` and called **after** `useGridColumns` causes a full additional pre-processing on mount because the columns need to be pre-processed **before** and **after** the 1st call of the feature hook.
Whereas if the feature hook is before, the pre-processing will only run once when `useGridColumns` is called.

The same applies to other pre-processings but this one is especially heavy when we have a lot of columns and has a lot of hooks hooked to it, so we could quickly run 5 or more useless pre-processings if we don't take care.

To more we move toward event listeners and pre-processors, the more `useGridRows` and `useGridColumns` should be late in the feature hook call order.

Same things as described here https://github.com/mui-org/material-ui-x/pull/3387#discussion_r786594279