### PR TITLE
[core] Improve GitHub label workflows

### DIFF
--- a/.github/ISSUE_TEMPLATE/3.pro-support.yml
+++ b/.github/ISSUE_TEMPLATE/3.pro-support.yml
@@ -1,7 +1,7 @@
 name: 'Pro plan: support ❔'
 description: As a Pro plan user, I need support with MUI X.
 title: "[question] "
-labels: ['status: needs triage', 'pro plan', 'question']
+labels: ['status: needs triage', 'pro plan', 'support: commercial']
 body:
   - type: markdown
     attributes:
@@ -35,14 +35,7 @@ body:
           required: true
   - type: textarea
     attributes:
-      label: Summary 💡
-  - type: textarea
-    attributes:
       label: The problem in depth 🔍
-  - type: textarea
-    attributes:
-      label: Context 🔦
-      description: What are you trying to accomplish? How has this issue affected you? Providing context helps us come up with a solution that is more useful in the real world.
   - type: textarea
     attributes:
       label: Your environment 🌎

--- a/.github/workflows/support-stackoverflow.yml
+++ b/.github/workflows/support-stackoverflow.yml
@@ -1,5 +1,5 @@
 # Configuration for support-requests - https://github.com/dessant/support-requests
-name: 'Support Requests'
+name: 'Support StackOverflow'
 
 on:
   issues:
@@ -22,10 +22,10 @@ jobs:
           issue-comment: |
             👋 Thanks for using MUI X!
 
-            We use GitHub issues exclusively as a bug and feature requests tracker, however,
+            We use GitHub issues as a bug and feature requests tracker, however,
             this issue appears to be a support request.
 
-            For support, please check out https://mui.com/getting-started/support/. Thanks!
+            For support, please check out https://mui.com/components/data-grid/getting-started/#support. Thanks!
 
             If you have a question on StackOverflow, you are welcome to link to it here, it might help others.
             If your issue is subsequently confirmed as a bug,  and the report follows the issue template, it can be reopened.

--- a/.github/workflows/support.yml
+++ b/.github/workflows/support.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Label used to mark issues as support requests
-          support-label: 'support'
+          support-label: 'support: StackOverflow'
           # Comment to post on issues marked as support requests. Add a link
           # to a support page, or set to `false` to disable
           issue-comment: |


### PR DESCRIPTION
This change is meant to improve the support workflow. We have:

1. Renamed `support` to `support: StackOverflow` to make it clear about what this is about. It's about fair value sharing. We give MIT components away for free. In exchange, MUI expects developers to give back by contributing. The expectation is not for maintainers to spend even more time to do others' work (when we apply this label), but for maintainers to process new contributions.
2. Renamed `question` to `support: question`. This is similar to the above, but we find the question so *valuable* to answer that we take it in.
3. Add a new `support: commercial` label. It's unlikely that the community will provide a lot of help to each other on the MUI X Pro plan, and will clearly not happen on the MUI X Premium plan. We have to take this in. However, bug reports and features requests should go to the usual channels, so we are simplifying the issue template. 