### PR TITLE
[DataGrid] Fix browser keyboard shortcuts not working when header cell is focused

### DIFF
--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -233,6 +233,11 @@ export const useGridKeyboardNavigation = (
           break;
         }
 
+        case ' ': {
+          event.preventDefault(); // prevent Space event from scrolling
+          break;
+        }
+
         default: {
           shouldPreventDefault = false;
         }

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -55,7 +55,6 @@ export const useGridKeyboardNavigation = (
     GridEventListener<GridEvents.cellNavigationKeyDown>
   >(
     (params, event) => {
-      event.preventDefault();
       const dimensions = apiRef.current.getRootDimensions();
       if (!currentPage.range || !dimensions) {
         return;
@@ -70,6 +69,7 @@ export const useGridKeyboardNavigation = (
       const lastRowIndexInPage = currentPage.range.lastRowIndex;
       const firstColIndex = 0;
       const lastColIndex = colCount - 1;
+      let shouldPreventDefault = true;
 
       // eslint-disable-next-line default-case
       switch (event.key) {
@@ -152,6 +152,14 @@ export const useGridKeyboardNavigation = (
           }
           break;
         }
+
+        default: {
+          shouldPreventDefault = false;
+        }
+      }
+
+      if (shouldPreventDefault) {
+        event.preventDefault();
       }
     },
     [apiRef, visibleSortedRows, colCount, currentPage, goToCell, goToHeader],
@@ -161,7 +169,6 @@ export const useGridKeyboardNavigation = (
     GridEventListener<GridEvents.columnHeaderNavigationKeyDown>
   >(
     (params, event) => {
-      event.preventDefault();
       if (!params.field) {
         return;
       }
@@ -176,6 +183,7 @@ export const useGridKeyboardNavigation = (
       const lastRowIndexInPage = currentPage.range?.lastRowIndex ?? null;
       const firstColIndex = 0;
       const lastColIndex = colCount - 1;
+      let shouldPreventDefault = true;
 
       // eslint-disable-next-line default-case
       switch (event.key) {
@@ -227,10 +235,13 @@ export const useGridKeyboardNavigation = (
           break;
         }
 
-        case ' ': {
-          event.preventDefault(); // prevent Space event from scrolling
-          break;
+        default: {
+          shouldPreventDefault = false;
         }
+      }
+
+      if (shouldPreventDefault) {
+        event.preventDefault();
       }
     },
     [apiRef, colCount, currentPage, goToCell, goToHeader],

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -71,7 +71,7 @@ export const useGridKeyboardNavigation = (
       const lastColIndex = colCount - 1;
       let shouldPreventDefault = true;
 
-      // eslint-disable-next-line default-case
+       
       switch (event.key) {
         case 'ArrowDown':
         case 'Enter': {
@@ -185,7 +185,7 @@ export const useGridKeyboardNavigation = (
       const lastColIndex = colCount - 1;
       let shouldPreventDefault = true;
 
-      // eslint-disable-next-line default-case
+       
       switch (event.key) {
         case 'ArrowDown': {
           if (firstRowIndexInPage !== null) {

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -71,7 +71,6 @@ export const useGridKeyboardNavigation = (
       const lastColIndex = colCount - 1;
       let shouldPreventDefault = true;
 
-       
       switch (event.key) {
         case 'ArrowDown':
         case 'Enter': {
@@ -185,7 +184,6 @@ export const useGridKeyboardNavigation = (
       const lastColIndex = colCount - 1;
       let shouldPreventDefault = true;
 
-       
       switch (event.key) {
         case 'ArrowDown': {
           if (firstRowIndexInPage !== null) {

--- a/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
+++ b/packages/grid/_modules_/grid/hooks/features/keyboard/useGridKeyboardNavigation.ts
@@ -234,7 +234,7 @@ export const useGridKeyboardNavigation = (
         }
 
         case ' ': {
-          event.preventDefault(); // prevent Space event from scrolling
+          // prevent Space event from scrolling
           break;
         }
 


### PR DESCRIPTION
Fixes #3477 by only preventing default for non registered shortcuts. This behavior applies both for cells and column headers.

Preview: https://deploy-preview-3692--material-ui-x.netlify.app/components/data-grid/demo/

## The issue
When a cell / header cell had focus, no keyboard shortcuts would work. The problem was on the `useGridKeyboardNavigation` hook which was `event.preventDefault()` to any key press.

## The solution
Only prevent default behavior to shortcuts / keys we are expecting. 

Solution provided by @m4theushw