### PR TITLE
[DataGrid] Fix focus when blur event rerender the grid

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -175,7 +175,7 @@ function GridCell(props: GridCellProps) {
         apiRef.current.scroll(scrollPosition);
       }
     }
-  });
+  }, [hasFocus, cellMode, apiRef]);
 
   return (
     <div


### PR DESCRIPTION
Fix #3712 

### The bug in brief

When a click outside of the grid implies a rerender of the grig, the focus goes back to the previous cell.

### What appends

The problem is that rows rerendering occur before the `handleDocumentClick` which is responsible for removing the focus in the internal state. So when the click causes a rendering we have:
- The browser focus is moved to the clicked element
- The rows rerender and the internal state is such that one cell will have prop `hasFocus=true`
- The `handleDocumentClick` is run which clean the `state.focus`


I do not understand why the `handleDocumentClick` is executed after.