### PR TITLE
[DataGrid] Fix focus when blur event rerender the grid

### DIFF
--- a/packages/grid/_modules_/grid/components/cell/GridCell.tsx
+++ b/packages/grid/_modules_/grid/components/cell/GridCell.tsx
@@ -175,7 +175,7 @@ function GridCell(props: GridCellProps) {
         apiRef.current.scroll(scrollPosition);
       }
     }
-  });
+  }, [hasFocus, cellMode, apiRef]);
 
   return (
     <div


### PR DESCRIPTION
fix #3716 

The `overrideResolver` of the `PinnedColumns` was not defined. I also added `pinnedColumns--left`, `pinnedColumns--right`, and same for `pinnedColumnHeaders`.

I did not find any other missing `overrideResolver`. I'm not sure it worths it to search for a linter ensuring the `overrideResolver` is defined for native components