### PR TITLE
[docs] Fix broken code example on the localization page

### DIFF
--- a/docs/src/pages/components/data-grid/localization/localization.md
+++ b/docs/src/pages/components/data-grid/localization/localization.md
@@ -69,7 +69,7 @@ If you want to pass language translations directly to the grid without using `cr
 ```jsx
 import { DataGrid, nlNL } from '@mui/x-data-grid';
 
-<DataGrid localeText={nlNL.props.MuiDataGrid.localeText} />;
+<DataGrid localeText={nlNL.components.MuiDataGrid.defaultProps.localeText} />;
 ```
 
 ### Supported locales


### PR DESCRIPTION
We probably missed this one during the v5 migration