### PR TITLE
[docs] Mention row `id` requirement and document `getRowId` prop

### DIFF
--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.js
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import { DataGrid } from '@mui/x-data-grid';
 
 export default function RowsGridWithGetRowId() {
-  const getRowId = React.useCallback((row) => row.internalId, []);
   return (
     <div style={{ height: 250, width: '100%' }}>
       <DataGrid
@@ -11,7 +10,7 @@ export default function RowsGridWithGetRowId() {
           { internalId: 1, name: 'React' },
           { internalId: 2, name: 'MUI' },
         ]}
-        getRowId={getRowId}
+        getRowId={(row) => row.internalId}
       />
     </div>
   );

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.js
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { DataGrid } from '@mui/x-data-grid';
+
+export default function RowsGridWithGetRowId() {
+  const getRowId = React.useCallback((row) => row.internalId, []);
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <DataGrid
+        columns={[{ field: 'name' }]}
+        rows={[
+          { internalId: 1, name: 'React' },
+          { internalId: 2, name: 'MUI' },
+        ]}
+        getRowId={getRowId}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import { DataGrid, GridRowIdGetter } from '@mui/x-data-grid';
+
+export default function RowsGridWithGetRowId() {
+  const getRowId = React.useCallback<GridRowIdGetter>((row) => row.internalId, []);
+  return (
+    <div style={{ height: 250, width: '100%' }}>
+      <DataGrid
+        columns={[{ field: 'name' }]}
+        rows={[
+          { internalId: 1, name: 'React' },
+          { internalId: 2, name: 'MUI' },
+        ]}
+        getRowId={getRowId}
+      />
+    </div>
+  );
+}

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { DataGrid, GridRowIdGetter } from '@mui/x-data-grid';
+import { DataGrid } from '@mui/x-data-grid';
 
 export default function RowsGridWithGetRowId() {
-  const getRowId = React.useCallback<GridRowIdGetter>((row) => row.internalId, []);
   return (
     <div style={{ height: 250, width: '100%' }}>
       <DataGrid
@@ -11,7 +10,7 @@ export default function RowsGridWithGetRowId() {
           { internalId: 1, name: 'React' },
           { internalId: 2, name: 'MUI' },
         ]}
-        getRowId={getRowId}
+        getRowId={(row) => row.internalId}
       />
     </div>
   );

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  columns={[{ field: 'name' }]}
+  rows={[
+    { internalId: 1, name: 'React' },
+    { internalId: 2, name: 'MUI' },
+  ]}
+  getRowId={(row) => row.internalId}
+/>

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
@@ -1,8 +1,0 @@
-<DataGrid
-  columns={[{ field: 'name' }]}
-  rows={[
-    { internalId: 1, name: 'React' },
-    { internalId: 2, name: 'MUI' },
-  ]}
-  getRowId={(row) => row.internalId}
-/>

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
@@ -1,0 +1,8 @@
+<DataGrid
+  columns={[{ field: 'name' }]}
+  rows={[
+    { internalId: 1, name: 'React' },
+    { internalId: 2, name: 'MUI' },
+  ]}
+  getRowId={(row) => row.internalId}
+/>;

--- a/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
+++ b/docs/src/pages/components/data-grid/rows/RowsGridWithGetRowId.tsx.preview
@@ -5,4 +5,4 @@
     { internalId: 2, name: 'MUI' },
   ]}
   getRowId={(row) => row.internalId}
-/>;
+/>

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -24,7 +24,7 @@ The rows can be defined with the `rows` prop, which expects an array of objects.
 > <DataGrid getRowId={(row) => row.internalId} />
 > ```
 
-{{"demo": "pages/components/data-grid/rows/RowsGridWithGetRowId.js", "bg": "inline"}}
+{{"demo": "pages/components/data-grid/rows/RowsGridWithGetRowId.js", "bg": "inline", "defaultCodeOpen": false}}
 
 ## Updating rows
 

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -16,7 +16,7 @@ The rows can be defined with the `rows` prop, which expects an array of objects.
 {{"demo": "pages/components/data-grid/rows/RowsGrid.js", "bg": "inline"}}
 
 > ⚠️ Each row object should have a field that uniquely identifies the row.
-> By default, the grid will use the `id` property of the row.
+> By default, the grid will use the `id` property of the row. Note that [column definition](/components/data-grid/columns/#column-definitions) for `id` field is not required.
 >
 > When using dataset without a unique `id` property, you can use the `getRowId` prop to specify a custom id for each row.
 >

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -15,9 +15,14 @@ The rows can be defined with the `rows` prop, which expects an array of objects.
 
 {{"demo": "pages/components/data-grid/rows/RowsGrid.js", "bg": "inline"}}
 
-Note that `DataGrid` requires all rows to have a unique `id` property.
-
-Alternatively, you can pass `getRowId` prop to generate an id for each row.
+> ⚠️ Each row should have a unique id.
+> By default, the grid will use the `id` property of the row.
+>
+> When using dataset without a unique `id` property, you can use the `getRowId` prop to specify a custom id for each row.
+>
+> ```tsx
+> <DataGrid getRowId={(row) => row.internalId} />
+> ```
 
 {{"demo": "pages/components/data-grid/rows/RowsGridWithGetRowId.js", "bg": "inline"}}
 

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -15,7 +15,7 @@ The rows can be defined with the `rows` prop, which expects an array of objects.
 
 {{"demo": "pages/components/data-grid/rows/RowsGrid.js", "bg": "inline"}}
 
-> ⚠️ Each row should have a unique id.
+> ⚠️ Each row object should have a field that uniquely identifies the row.
 > By default, the grid will use the `id` property of the row.
 >
 > When using dataset without a unique `id` property, you can use the `getRowId` prop to specify a custom id for each row.

--- a/docs/src/pages/components/data-grid/rows/rows.md
+++ b/docs/src/pages/components/data-grid/rows/rows.md
@@ -15,6 +15,12 @@ The rows can be defined with the `rows` prop, which expects an array of objects.
 
 {{"demo": "pages/components/data-grid/rows/RowsGrid.js", "bg": "inline"}}
 
+Note that `DataGrid` requires all rows to have a unique `id` property.
+
+Alternatively, you can pass `getRowId` prop to generate an id for each row.
+
+{{"demo": "pages/components/data-grid/rows/RowsGridWithGetRowId.js", "bg": "inline"}}
+
 ## Updating rows
 
 ### The `rows` prop

--- a/packages/grid/_modules_/grid/models/gridRows.ts
+++ b/packages/grid/_modules_/grid/models/gridRows.ts
@@ -87,7 +87,8 @@ export function checkGridRowIdIsValid(
   if (id == null) {
     throw new Error(
       [
-        'MUI: The data grid component requires all rows to have a unique id property.',
+        'MUI: The data grid component requires all rows to have a unique `id` property.',
+        'Alternatively, you can pass `getRowId` prop to generate an id for each row',
         detailErrorMessage,
         JSON.stringify(row),
       ].join('\n'),

--- a/packages/grid/_modules_/grid/models/gridRows.ts
+++ b/packages/grid/_modules_/grid/models/gridRows.ts
@@ -88,7 +88,7 @@ export function checkGridRowIdIsValid(
     throw new Error(
       [
         'MUI: The data grid component requires all rows to have a unique `id` property.',
-        'Alternatively, you can pass `getRowId` prop to generate an id for each row',
+        'Alternatively, you can use the `getRowId` prop to specify a custom id for each row.',
         detailErrorMessage,
         JSON.stringify(row),
       ].join('\n'),

--- a/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
+++ b/packages/grid/x-data-grid/src/tests/layout.DataGrid.test.tsx
@@ -847,12 +847,12 @@ describe('<DataGrid /> - Layout & Warnings', () => {
           </ErrorBoundary>,
         );
       }).toErrorDev([
-        'The data grid component requires all rows to have a unique id property',
+        'The data grid component requires all rows to have a unique `id` property',
         'The above error occurred in the <ForwardRef(DataGrid)> component',
       ]);
       expect((errorRef.current as any).errors).to.have.length(1);
       expect((errorRef.current as any).errors[0].toString()).to.include(
-        'The data grid component requires all rows to have a unique id property',
+        'The data grid component requires all rows to have a unique `id` property',
       );
     });
   });


### PR DESCRIPTION
Currently `DataGrid` throws an error if row doesn't have an `id` property.
This is not documented though, and there's `getRowId` prop that can be used instead.
I've updated the error message to mention `getRowId` prop as well.

Preview: https://deploy-preview-3765--material-ui-x.netlify.app/components/data-grid/rows/