### PR TITLE
[core] Remove remaining usages of @mui/styles

### DIFF
--- a/benchmark/package.json
+++ b/benchmark/package.json
@@ -11,7 +11,6 @@
     "@material-ui/core": "^5.0.0-beta.5",
     "@material-ui/icons": "^5.0.0-beta.4",
     "@mui/material": "^5.3.1",
-    "@mui/styles": "^5.3.0",
     "@mui/x-data-grid": "^4.0.0",
     "@visx/xychart": "^2.8.0",
     "ag-grid-community": "^26.2.1",

--- a/docs/scripts/api/buildComponentsDocumentation.ts
+++ b/docs/scripts/api/buildComponentsDocumentation.ts
@@ -20,7 +20,7 @@ import {
   getHeaders,
 } from '@mui/monorepo/docs/packages/markdown';
 import { getLineFeed } from '@mui/monorepo/docs/scripts/helpers';
-import createGenerateClassName from '@mui/styles/createGenerateClassName';
+import generateUtilityClass from '@mui/base/generateUtilityClass';
 import {
   DocumentedInterfaces,
   getJsdocDefaultValue,
@@ -29,8 +29,6 @@ import {
   Projects,
   writePrettifiedFile,
 } from './utils';
-
-const generateClassName = createGenerateClassName();
 
 interface ReactApi extends ReactDocgenApi {
   /**
@@ -223,11 +221,8 @@ const buildComponentDocumentation = async (options: {
   reactApi.styles = await parseStyles(reactApi, project.program as any);
   reactApi.styles.name = 'MuiDataGrid'; // TODO it should not be hardcoded
   reactApi.styles.classes.forEach((key) => {
-    reactApi.styles.globalClasses[key] = generateClassName(
-      // @ts-expect-error
-      { key },
-      { options: { name: reactApi.styles.name, theme: {} } },
-    );
+    const globalClass = generateUtilityClass(reactApi.styles.name!, key);
+    reactApi.styles.globalClasses[key] = globalClass;
   });
 
   const componentApi: {

--- a/docs/src/modules/XWrapper.js
+++ b/docs/src/modules/XWrapper.js
@@ -1,27 +1,35 @@
-import { makeStyles } from '@mui/styles';
-
-const useStyles = makeStyles({
-  '@global': {
-    '.plan-pro, .plan-premium': {
-      display: 'inline-block',
-      height: '1em',
-      width: '1em',
-      verticalAlign: 'middle',
-      marginLeft: '0.13em',
-      marginBottom: '0.13em',
-      backgroundSize: 'contain',
-      backgroundRepeat: 'no-repeat',
-    },
-    '.plan-pro': {
-      backgroundImage: 'url(/static/x/pro.svg)',
-    },
-    '.plan-premium': {
-      backgroundImage: 'url(/static/x/premium.svg)',
-    },
-  },
-});
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import GlobalStyles from '@mui/material/GlobalStyles';
 
 export default function XWrapper(props) {
-  useStyles();
-  return props.children;
+  return (
+    <React.Fragment>
+      <GlobalStyles
+        styles={{
+          '.plan-pro, .plan-premium': {
+            display: 'inline-block',
+            height: '1em',
+            width: '1em',
+            verticalAlign: 'middle',
+            marginLeft: '0.13em',
+            marginBottom: '0.13em',
+            backgroundSize: 'contain',
+            backgroundRepeat: 'no-repeat',
+          },
+          '.plan-pro': {
+            backgroundImage: 'url(/static/x/pro.svg)',
+          },
+          '.plan-premium': {
+            backgroundImage: 'url(/static/x/premium.svg)',
+          },
+        }}
+      />
+      {props.children}
+    </React.Fragment>
+  );
 }
+
+XWrapper.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/docs/src/modules/components/ApiDocs.js
+++ b/docs/src/modules/components/ApiDocs.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { makeStyles } from '@mui/styles';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
 import Accordion from '@mui/material/Accordion';
 import AccordionSummary from '@mui/material/AccordionSummary';
 import AccordionDetails from '@mui/material/AccordionDetails';
@@ -8,46 +9,33 @@ import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import PropTypes from 'prop-types';
 import HighlightedCode from 'docs/src/modules/components/HighlightedCode';
 
-const useStyles = makeStyles((theme) => ({
-  root: {
-    width: '100%',
+const PrimaryHeading = styled(Typography)(({ theme }) => ({
+  fontSize: theme.typography.pxToRem(15),
+  flexBasis: '33.33%',
+  flexShrink: 0,
+  direction: 'ltr',
+  lineHeight: 1.4,
+  display: 'inline-block',
+  fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
+  WebkitFontSmoothing: 'subpixel-antialiased',
+}));
+
+const SecondaryHeading = styled(Typography)(({ theme }) => ({
+  fontSize: theme.typography.pxToRem(15),
+  color: theme.palette.text.secondary,
+  '& code': {
+    color: theme.palette.secondary.main,
   },
-  heading: {
-    fontSize: theme.typography.pxToRem(15),
-    flexBasis: '33.33%',
-    flexShrink: 0,
-    direction: 'ltr',
-    lineHeight: 1.4,
-    display: 'inline-block',
-    fontFamily: 'Consolas, "Liberation Mono", Menlo, Courier, monospace',
-    WebkitFontSmoothing: 'subpixel-antialiased',
-  },
-  secondaryHeading: {
-    fontSize: theme.typography.pxToRem(15),
-    color: theme.palette.text.secondary,
-    '& code': {
-      color: theme.palette.secondary.main,
-    },
-    [theme.breakpoints.down('sm')]: {
-      display: 'none',
-    },
-  },
-  content: {
-    display: 'block',
-  },
-  code: {
-    '& pre': {
-      marginBottom: theme.spacing(1),
-    },
+  [theme.breakpoints.down('sm')]: {
+    display: 'none',
   },
 }));
 
 function ApiDocs(props) {
   const { api } = props;
-  const classes = useStyles();
 
   return (
-    <div className={classes.root}>
+    <Box sx={{ w: 1 }}>
       {api.properties.map((property, index) => (
         <Accordion key={index}>
           <AccordionSummary
@@ -56,24 +44,25 @@ function ApiDocs(props) {
             id={`api-property-${index}-header`}
           >
             {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
-            <Typography className={classes.heading}>{`${property.name}()`}</Typography>
-            <Typography
-              className={classes.secondaryHeading}
-              dangerouslySetInnerHTML={{ __html: property.description }}
-            />
+            <PrimaryHeading>{`${property.name}()`}</PrimaryHeading>
+            <SecondaryHeading dangerouslySetInnerHTML={{ __html: property.description }} />
           </AccordionSummary>
-          <AccordionDetails className={classes.content}>
+          <AccordionDetails sx={{ display: 'block' }}>
             {/* eslint-disable-next-line material-ui/no-hardcoded-labels */}
             <Typography variant="subtitle2">Signature:</Typography>
             <HighlightedCode
-              className={classes.code}
               code={`${property.name}: ${property.type}`}
               language="tsx"
+              sx={{
+                '& pre': {
+                  mb: 1,
+                },
+              }}
             />
           </AccordionDetails>
         </Accordion>
       ))}
-    </div>
+    </Box>
   );
 }
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
     "@mui/icons-material": "^5.3.1",
     "@mui/monorepo": "https://github.com/mui-org/material-ui.git#master",
     "@mui/material": "^5.3.1",
-    "@mui/styles": "^5.3.0",
     "@mui/utils": "^5.3.0",
     "@playwright/test": "1.17.1",
     "@octokit/rest": "^18.12.0",

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -2,6 +2,7 @@ import * as React from 'react';
 import PropTypes from 'prop-types';
 import { styled } from '@mui/material/styles';
 import Box from '@mui/material/Box';
+import GlobalStyles from '@mui/material/GlobalStyles';
 import { useLocation } from 'react-router-dom';
 import { useFakeTimers } from 'sinon';
 
@@ -105,9 +106,31 @@ function TestViewer(props) {
   const { children, isDataGridTest } = props;
 
   return (
-    <MockTime>
-      <LoadFont isDataGridTest={isDataGridTest}>{children}</LoadFont>
-    </MockTime>
+    <React.Fragment>
+      <GlobalStyles
+        styles={{
+          html: {
+            WebkitFontSmoothing: 'antialiased', // Antialiasing.
+            MozOsxFontSmoothing: 'grayscale', // Antialiasing.
+            // Do the opposite of the docs in order to help catching issues.
+            boxSizing: 'content-box',
+          },
+          '*, *::before, *::after': {
+            boxSizing: 'inherit',
+            // Disable transitions to avoid flaky screenshots
+            transition: 'none !important',
+            animation: 'none !important',
+          },
+          body: {
+            margin: 0,
+            overflowX: 'hidden',
+          },
+        }}
+      />
+      <MockTime>
+        <LoadFont isDataGridTest={isDataGridTest}>{children}</LoadFont>
+      </MockTime>
+    </React.Fragment>
   );
 }
 

--- a/test/regressions/TestViewer.js
+++ b/test/regressions/TestViewer.js
@@ -1,19 +1,16 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
+import { styled } from '@mui/material/styles';
+import Box from '@mui/material/Box';
 import { useLocation } from 'react-router-dom';
-import clsx from 'clsx';
 import { useFakeTimers } from 'sinon';
-import { withStyles } from '@mui/styles';
-import { createTheme } from '@mui/material/styles';
 
-const styles = (theme) => ({
-  root: {
-    backgroundColor: theme.palette.background.default,
-    padding: theme.spacing(1),
-    display: 'flex',
-    justifyContent: 'center',
-  },
-  dataGridContainer: {
+const StyledBox = styled(Box)(({ theme, isDataGridTest }) => ({
+  backgroundColor: theme.palette.background.default,
+  display: 'flex',
+  padding: theme.spacing(1),
+  justifyContent: 'center',
+  ...(isDataGridTest && {
     minHeight: 400,
     maxWidth: 500,
     // Workaround the min-height limitation
@@ -27,8 +24,8 @@ const styles = (theme) => ({
         bottom: 0,
       },
     },
-  },
-});
+  }),
+}));
 
 let clock;
 
@@ -94,9 +91,9 @@ function LoadFont(props) {
   }, [location]);
 
   return (
-    <div aria-busy={!ready} data-testid="testcase" {...other}>
+    <StyledBox aria-busy={!ready} data-testid="testcase" {...other}>
       {children}
-    </div>
+    </StyledBox>
   );
 }
 
@@ -105,26 +102,18 @@ LoadFont.propTypes = {
 };
 
 function TestViewer(props) {
-  const { children, classes, dataGridContainer } = props;
+  const { children, isDataGridTest } = props;
 
   return (
     <MockTime>
-      <LoadFont
-        className={clsx(classes.root, {
-          [classes.dataGridContainer]: dataGridContainer,
-        })}
-      >
-        {children}
-      </LoadFont>
+      <LoadFont isDataGridTest={isDataGridTest}>{children}</LoadFont>
     </MockTime>
   );
 }
 
 TestViewer.propTypes = {
   children: PropTypes.node.isRequired,
-  classes: PropTypes.object.isRequired,
-  dataGridContainer: PropTypes.bool.isRequired,
+  isDataGridTest: PropTypes.bool.isRequired,
 };
 
-const defaultTheme = createTheme();
-export default withStyles(styles, { defaultTheme })(TestViewer);
+export default TestViewer;

--- a/test/regressions/index.js
+++ b/test/regressions/index.js
@@ -2,7 +2,6 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router, Routes, Route, Link } from 'react-router-dom';
 import { LicenseInfo } from '@mui/x-data-grid-pro';
-import { withStyles } from '@mui/styles';
 import TestViewer from 'test/regressions/TestViewer';
 import { useFakeTimers } from 'sinon';
 import addons, { mockChannel } from '@storybook/addons';
@@ -121,27 +120,6 @@ if (unusedBlacklistPatterns.size > 0) {
   );
 }
 
-const GlobalStyles = withStyles({
-  '@global': {
-    html: {
-      WebkitFontSmoothing: 'antialiased', // Antialiasing.
-      MozOsxFontSmoothing: 'grayscale', // Antialiasing.
-      // Do the opposite of the docs in order to help catching issues.
-      boxSizing: 'content-box',
-    },
-    '*, *::before, *::after': {
-      boxSizing: 'inherit',
-      // Disable transitions to avoid flaky screenshots
-      transition: 'none !important',
-      animation: 'none !important',
-    },
-    body: {
-      margin: 0,
-      overflowX: 'hidden',
-    },
-  },
-})(() => null);
-
 function App() {
   function computeIsDev() {
     if (window.location.hash === '#dev') {
@@ -170,7 +148,6 @@ function App() {
 
   return (
     <Router>
-      <GlobalStyles />
       <Routes>
         {tests.map((test) => {
           const path = computePath(test);
@@ -180,9 +157,9 @@ function App() {
             return null;
           }
 
-          let dataGridContainer = false;
+          let isDataGridTest = false;
           if (path.indexOf('/docs-components-data-grid') === 0 || path.indexOf('/stories-') === 0) {
-            dataGridContainer = true;
+            isDataGridTest = true;
           }
 
           return (
@@ -191,7 +168,7 @@ function App() {
               exact
               path={path}
               element={
-                <TestViewer dataGridContainer={dataGridContainer}>
+                <TestViewer isDataGridTest={isDataGridTest}>
                   <TestCase />
                 </TestViewer>
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12411,54 +12411,54 @@ jsprim@^1.2.2:
     verror "1.10.0"
 
 jss-plugin-camel-case@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.8.2.tgz#8d7f915c8115afaff8cbde08faf610ec9892fba6"
-  integrity sha512-2INyxR+1UdNuKf4v9It3tNfPvf7IPrtkiwzofeKuMd5D58/dxDJVUQYRVg/n460rTlHUfsEQx43hDrcxi9dSPA==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-camel-case/-/jss-plugin-camel-case-10.9.0.tgz#4921b568b38d893f39736ee8c4c5f1c64670aaf7"
+  integrity sha512-UH6uPpnDk413/r/2Olmw4+y54yEF2lRIV8XIZyuYpgPYTITLlPOsq6XB9qeqv+75SQSg3KLocq5jUBXW8qWWww==
   dependencies:
     "@babel/runtime" "^7.3.1"
     hyphenate-style-name "^1.0.3"
-    jss "10.8.2"
+    jss "10.9.0"
 
 jss-plugin-default-unit@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.8.2.tgz#c66f12e02e0815d911b85c02c2a979ee7b4ce69a"
-  integrity sha512-UZ7cwT9NFYSG+SEy7noRU50s4zifulFdjkUNKE+u6mW7vFP960+RglWjTgMfh79G6OENZmaYnjHV/gcKV4nSxg==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-default-unit/-/jss-plugin-default-unit-10.9.0.tgz#bb23a48f075bc0ce852b4b4d3f7582bc002df991"
+  integrity sha512-7Ju4Q9wJ/MZPsxfu4T84mzdn7pLHWeqoGd/D8O3eDNNJ93Xc8PxnLmV8s8ZPNRYkLdxZqKtm1nPQ0BM4JRlq2w==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.8.2"
+    jss "10.9.0"
 
 jss-plugin-global@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.8.2.tgz#1a35632a693cf50113bcc5ffe6b51969df79c4ec"
-  integrity sha512-UaYMSPsYZ7s/ECGoj4KoHC2jwQd5iQ7K+FFGnCAILdQrv7hPmvM2Ydg45ThT/sH46DqktCRV2SqjRuxeBH8nRA==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-global/-/jss-plugin-global-10.9.0.tgz#fc07a0086ac97aca174e37edb480b69277f3931f"
+  integrity sha512-4G8PHNJ0x6nwAFsEzcuVDiBlyMsj2y3VjmFAx/uHk/R/gzJV+yRHICjT4MKGGu1cJq2hfowFWCyrr/Gg37FbgQ==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.8.2"
+    jss "10.9.0"
 
 jss-plugin-nested@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.8.2.tgz#79f3c7f75ea6a36ae72fe52e777035bb24d230c7"
-  integrity sha512-acRvuPJOb930fuYmhkJaa994EADpt8TxI63Iyg96C8FJ9T2xRyU5T6R1IYKRwUiqZo+2Sr7fdGzRTDD4uBZaMA==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-nested/-/jss-plugin-nested-10.9.0.tgz#cc1c7d63ad542c3ccc6e2c66c8328c6b6b00f4b3"
+  integrity sha512-2UJnDrfCZpMYcpPYR16oZB7VAC6b/1QLsRiAutOt7wJaaqwCBvNsosLEu/fUyKNQNGdvg2PPJFDO5AX7dwxtoA==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.8.2"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
 jss-plugin-props-sort@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.8.2.tgz#e25a7471868652c394562b6dc5433dcaea7dff6f"
-  integrity sha512-wqdcjayKRWBZnNpLUrXvsWqh+5J5YToAQ+8HNBNw0kZxVvCDwzhK2Nx6AKs7p+5/MbAh2PLgNW5Ym/ysbVAuqQ==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-props-sort/-/jss-plugin-props-sort-10.9.0.tgz#30e9567ef9479043feb6e5e59db09b4de687c47d"
+  integrity sha512-7A76HI8bzwqrsMOJTWKx/uD5v+U8piLnp5bvru7g/3ZEQOu1+PjHvv7bFdNO3DwNPC9oM0a//KwIJsIcDCjDzw==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.8.2"
+    jss "10.9.0"
 
 jss-plugin-rule-value-function@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.8.2.tgz#55354b55f1b2968a15976729968f767f02d64049"
-  integrity sha512-bW0EKAs+0HXpb6BKJhrn94IDdiWb0CnSluTkh0rGEgyzY/nmD1uV/Wf6KGlesGOZ9gmJzQy+9FFdxIUID1c9Ug==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-rule-value-function/-/jss-plugin-rule-value-function-10.9.0.tgz#379fd2732c0746fe45168011fe25544c1a295d67"
+  integrity sha512-IHJv6YrEf8pRzkY207cPmdbBstBaE+z8pazhPShfz0tZSDtRdQua5jjg6NMz3IbTasVx9FdnmptxPqSWL5tyJg==
   dependencies:
     "@babel/runtime" "^7.3.1"
-    jss "10.8.2"
+    jss "10.9.0"
     tiny-warning "^1.0.2"
 
 jss-plugin-template@^10.9.0:
@@ -12471,13 +12471,13 @@ jss-plugin-template@^10.9.0:
     tiny-warning "^1.0.2"
 
 jss-plugin-vendor-prefixer@^10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.8.2.tgz#ebb4a482642f34091e454901e21176441dd5f475"
-  integrity sha512-DeGv18QsSiYLSVIEB2+l0af6OToUe0JB+trpzUxyqD2QRC/5AzzDrCrYffO5AHZ81QbffYvSN/pkfZaTWpRXlg==
+  version "10.9.0"
+  resolved "https://registry.yarnpkg.com/jss-plugin-vendor-prefixer/-/jss-plugin-vendor-prefixer-10.9.0.tgz#aa9df98abfb3f75f7ed59a3ec50a5452461a206a"
+  integrity sha512-MbvsaXP7iiVdYVSEoi+blrW+AYnTDvHTW6I6zqi7JcwXdc6I9Kbm234nEblayhF38EftoenbM+5218pidmC5gA==
   dependencies:
     "@babel/runtime" "^7.3.1"
     css-vendor "^2.0.8"
-    jss "10.8.2"
+    jss "10.9.0"
 
 jss-rtl@^0.3.0:
   version "0.3.0"
@@ -12485,16 +12485,6 @@ jss-rtl@^0.3.0:
   integrity sha512-rg9jJmP1bAyhNOAp+BDZgOP/lMm4+oQ76qGueupDQ68Wq+G+6SGvCZvhIEg8OHSONRWOwFT6skCI+APGi8DgmA==
   dependencies:
     rtl-css-js "^1.13.1"
-
-jss@10.8.2:
-  version "10.8.2"
-  resolved "https://registry.yarnpkg.com/jss/-/jss-10.8.2.tgz#4b2a30b094b924629a64928236017a52c7c97505"
-  integrity sha512-FkoUNxI329CKQ9OQC8L72MBF9KPf5q8mIupAJ5twU7G7XREW7ahb+7jFfrjZ4iy1qvhx1HwIWUIvkZBDnKkEdQ==
-  dependencies:
-    "@babel/runtime" "^7.3.1"
-    csstype "^3.0.2"
-    is-in-browser "^1.1.3"
-    tiny-warning "^1.0.2"
 
 jss@10.9.0, jss@^10.8.2, jss@^10.9.0:
   version "10.9.0"


### PR DESCRIPTION
Closes #2991 

The file `@mui/monorepo/docs/pages/_document` still depends on it so we can't remove `@mui/styles` from `docs/package.json` yet.