### PR TITLE
[docs] Fix flag layout shift

### DIFF
--- a/packages/grid/x-data-grid-generator/src/renderer/renderCountry.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderCountry.tsx
@@ -19,13 +19,15 @@ const Country = React.memo(function Country(props: CountryProps) {
         display: 'flex',
         alignItems: 'center',
         '&  > img': {
-          mr: '4px',
+          mr: 0.5,
+          flexShrink: 0,
           width: '20px',
         },
       }}
     >
       <img
         loading="lazy"
+        width="20"
         src={`https://flagcdn.com/w20/${value.code.toLowerCase()}.png`}
         srcSet={`https://flagcdn.com/w40/${value.code.toLowerCase()}.png 2x`}
         alt=""

--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditCountry.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditCountry.tsx
@@ -48,7 +48,7 @@ function EditCountry(props: GridRenderEditCellParams) {
           component="li"
           sx={{
             '& > img': {
-              mr: 2,
+              mr: 1.5,
               flexShrink: 0,
             },
           }}

--- a/packages/grid/x-data-grid-generator/src/renderer/renderEditCurrency.tsx
+++ b/packages/grid/x-data-grid-generator/src/renderer/renderEditCurrency.tsx
@@ -47,7 +47,7 @@ function EditCurrency(props: GridRenderEditCellParams) {
           component="li"
           sx={{
             '& > img': {
-              mr: 2,
+              mr: 1.5,
               flexShrink: 0,
             },
           }}


### PR DESCRIPTION
Open https://master--material-ui-x.netlify.app/components/data-grid/demo/. The width of the flag change between no loaded and loaded img:

<img width="614" alt="Screenshot 2022-01-29 at 01 31 01" src="https://user-images.githubusercontent.com/3165635/151639070-c015b553-8d44-4f79-bf31-3c059a0deb88.png">
 
This creates a layout shift which is distracting. To be clear, this is a low value fix, but I noticed it, knew the solution as I faced it with the Autocomplete's demo already so went for it: small improvements like this compound.

Preview: https://deploy-preview-3773--material-ui-x.netlify.app/components/data-grid/demo/