### PR TITLE
[core] Remove none code related instructions from git

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -50,11 +50,7 @@ Once deployed, it will be accessible at https://material-ui-x.netlify.app/ for t
 
 ### Announce
 
-1. **GitHub**. Make a new release on GitHub (for people subscribing to releases). Mark it as "pre-release" if the version is not stable. https://github.com/mui-org/material-ui-x/releases
-2. **Twitter**. Make a release tweet from the main MUI account with the highlights from the release on GitHub and use this banner.
-   Add a link to the GitHub release. Don't forget to change the version before exporting it: https://www.figma.com/file/vOx7rzFQZ9e54W81NReDdU/Utilities?node-id=2%3A7.
-   You can check an example tweet here: https://twitter.com/MaterialUI/status/1472880775955718150
-   If the release contains a big feature a additional tweet can be added in a thread to highlight that feature specifically. For inspiration check an example from MUI Core: https://twitter.com/MaterialUI/status/1467946870811078661
+Follow the instructions in https://mui-org.notion.site/Releases-7490ef9581b4447ebdbf86b13164272d.
 
 ## Manual changelog generation
 


### PR DESCRIPTION
I have updated https://www.notion.so/mui-org/Releases-7490ef9581b4447ebdbf86b13164272d to be more in sync with what we do, and also to improve a bit the process. In any case, it's not code-related so I'm moving the content out of git.

Same as in https://github.com/mui-org/material-ui/pull/30843 and a continuation of #2997.