### PR TITLE
[test] Increase timeout for Firefox

### DIFF
--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -26,7 +26,7 @@ const browserStack = {
   accessKey: process.env.BROWSERSTACK_ACCESS_KEY,
   build,
   // https://github.com/browserstack/api#timeout300
-  timeout: 6 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
+  timeout: 10 * 60, // Maximum time before a worker is terminated. Default 5 minutes.
 };
 
 process.env.CHROME_BIN = playwright.chromium.executablePath();


### PR DESCRIPTION
The last green build was 5 days ago. Before and after this, Firefox has timed out in the majority of the cases. I want to test if increasing the timeout solves the issue. This is the same value used by the core: https://github.com/mui-org/material-ui/pull/28476

<img width="300" src="https://user-images.githubusercontent.com/42154031/152023500-54047a82-efe6-4ca3-b61f-2bce1c559b0e.png" alt="image" style="max-width: 100%;">