### PR TITLE
[docs] Extend full width

### DIFF
--- a/docs/src/modules/components/ApiDocs.js
+++ b/docs/src/modules/components/ApiDocs.js
@@ -35,7 +35,7 @@ function ApiDocs(props) {
   const { api } = props;
 
   return (
-    <Box sx={{ w: 1 }}>
+    <Box sx={{ width: 1 }}>
       {api.properties.map((property, index) => (
         <Accordion key={index}>
           <AccordionSummary


### PR DESCRIPTION
I used the wrong CSS prop in #3769.

In https://master--material-ui-x.netlify.app/components/data-grid/selection/#apiref

![image](https://user-images.githubusercontent.com/42154031/152193463-3c2b24db-39aa-43da-9c18-2a1ff448ef8c.png)
